### PR TITLE
Fix: tenant-root domain always overrided to example.org

### DIFF
--- a/packages/core/platform/Makefile
+++ b/packages/core/platform/Makefile
@@ -1,17 +1,19 @@
 NAMESPACE=cozy-system
 NAME=platform
 
+API_VERSIONS_FLAGS=$(addprefix -a ,$(shell kubectl api-versions))
+
 show:
-	helm template -n $(NAMESPACE) $(NAME) . --dry-run=server
+	helm template -n $(NAMESPACE) $(NAME) . --dry-run=server $(API_VERSIONS_FLAGS)
 
 apply:
-	helm template -n $(NAMESPACE) $(NAME) . --dry-run=server | kubectl apply -f-
+	helm template -n $(NAMESPACE) $(NAME) . --dry-run=server $(API_VERSIONS_FLAGS) | kubectl apply -f-
 
 namespaces-show:
-	helm template -n $(NAMESPACE) $(NAME) . --dry-run=server -s templates/namespaces.yaml
+	helm template -n $(NAMESPACE) $(NAME) . --dry-run=server $(API_VERSIONS_FLAGS) -s templates/namespaces.yaml
 
 namespaces-apply:
-	helm template -n $(NAMESPACE) $(NAME) . --dry-run=server -s templates/namespaces.yaml | kubectl apply -f-
+	helm template -n $(NAMESPACE) $(NAME) . --dry-run=server $(API_VERSIONS_FLAGS) -s templates/namespaces.yaml | kubectl apply -f-
 
 diff:
-	helm template -n $(NAMESPACE) $(NAME) . --dry-run=server -s templates/namespaces.yaml | kubectl diff -f-
+	helm template -n $(NAMESPACE) $(NAME) . --dry-run=server $(API_VERSIONS_FLAGS) -s templates/namespaces.yaml | kubectl diff -f-

--- a/packages/core/platform/templates/apps.yaml
+++ b/packages/core/platform/templates/apps.yaml
@@ -1,7 +1,7 @@
 {{- $host := "example.org" }}
 {{- $tenantRoot := list }}
 {{- if .Capabilities.APIVersions.Has "helm.toolkit.fluxcd.io/v2beta1" }}
-{{- $tenantRoot := lookup "helm.toolkit.fluxcd.io/v2beta1" "HelmRelease" "tenant-root" "tenant-root" }}
+{{- $tenantRoot = lookup "helm.toolkit.fluxcd.io/v2beta1" "HelmRelease" "tenant-root" "tenant-root" }}
 {{- end }}
 {{- if and $tenantRoot $tenantRoot.spec $tenantRoot.spec.values $tenantRoot.spec.values.host }}
 {{- $host = $tenantRoot.spec.values.host }}


### PR DESCRIPTION
`.Capabilities.APIVersions.Has "helm.toolkit.fluxcd.io/v2beta1` does not work for Helm Template, so we must explicity pass apiversions to `helm template` command

see: https://github.com/helm/helm/issues/10760