### PR TITLE
The declarative way to flush redis for our dashboard

### DIFF
--- a/packages/core/platform/templates/helmreleases.yaml
+++ b/packages/core/platform/templates/helmreleases.yaml
@@ -646,6 +646,17 @@ spec:
     namespace: cozy-cilium
   - name: kubeovn
     namespace: cozy-kubeovn
+  {{- if .Capabilities.APIVersions.Has "source.toolkit.fluxcd.io/v1beta2" }}
+  {{- $repoApps := lookup "source.toolkit.fluxcd.io/v1beta2" "HelmRepository" "cozy-public" "cozystack-apps" }}
+  {{- $repoExtra := lookup "source.toolkit.fluxcd.io/v1beta2" "HelmRepository" "cozy-public" "cozystack-extra" }}
+  values:
+    kubeapps:
+      redis:
+        master:
+          podAnnotations:
+            cozystack.io/repository-hash-apps: {{ (($repoApps.status).artifact).revision | quote }}
+            cozystack.io/repository-hash-extra: {{ (($repoExtra.status).artifact).revision | quote }}
+  {{- end }}
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease

--- a/packages/core/platform/templates/helmreleases.yaml
+++ b/packages/core/platform/templates/helmreleases.yaml
@@ -647,15 +647,18 @@ spec:
   - name: kubeovn
     namespace: cozy-kubeovn
   {{- if .Capabilities.APIVersions.Has "source.toolkit.fluxcd.io/v1beta2" }}
-  {{- $repoApps := lookup "source.toolkit.fluxcd.io/v1beta2" "HelmRepository" "cozy-public" "cozystack-apps" }}
-  {{- $repoExtra := lookup "source.toolkit.fluxcd.io/v1beta2" "HelmRepository" "cozy-public" "cozystack-extra" }}
+  {{- with (lookup "source.toolkit.fluxcd.io/v1beta2" "HelmRepository" "cozy-public" "").items }}
   values:
     kubeapps:
       redis:
         master:
           podAnnotations:
-            cozystack.io/repository-hash-apps: {{ (($repoApps.status).artifact).revision | quote }}
-            cozystack.io/repository-hash-extra: {{ (($repoExtra.status).artifact).revision | quote }}
+            {{- range $index, $repo := . }}
+            {{- with (($repo.status).artifact).revision }}
+            repository.cozystack.io/{{ $repo.metadata.name }}: {{ quote . }}
+            {{- end }}
+            {{- end }}
+  {{- end }}
   {{- end }}
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -35,11 +35,6 @@ kubectl annotate helmrepositories.source.toolkit.fluxcd.io -A -l cozystack.io/re
 # Install platform chart
 make -C packages/core/platform apply
 
-# Flush kubeapps cache
-if kubectl wait --for=condition=ready -n cozy-dashboard pod/dashboard-redis-master-0 --timeout=1s; then
-  kubectl exec -ti -n cozy-dashboard dashboard-redis-master-0 -- sh -c 'redis-cli -a "$REDIS_PASSWORD" flushdb'
-fi
-
 # Reconcile platform chart
 trap 'exit' INT TERM
 while true; do


### PR DESCRIPTION
This PR moves imperative logic of flushing redis from installer.sh to be declarative in platform chart.
Thus now redis will be restarted every time when the flux saves a new artifact for helmrelease in cozy-public namespace:

```yaml
  values:
    kubeapps:
      redis:
        master:
          podAnnotations:
            repository.cozystack.io/cozystack-apps: "sha256:29222315d063ffede0e09e3d6a24549b3f818fd025646d52e938f4477098a1d1"
            repository.cozystack.io/cozystack-extra: "sha256:77381c0662e86398c8fcf53dfb82535cb328cfea38d1351cb220016e5ebe9ba1"
```

This logic is not critical, and used only to show actual infromation about the charts in our dashboard.

This is temporary solution but still a better than already existing now. Hopefully we'll refactor it in a while.

fixes https://github.com/aenix-io/cozystack/issues/19