### PR TITLE
Enable versioning for cozy-* charts

### DIFF
--- a/hack/prepare_release.sh
+++ b/hack/prepare_release.sh
@@ -3,7 +3,7 @@ set -e
 
 if [ -e $1 ]; then
   echo "Please pass version in the first argument"
-  echo "Example: $0 v0.0.2"
+  echo "Example: $0 0.2.0"
   exit 1
 fi
 
@@ -12,8 +12,14 @@ talos_version=$(awk '/^version:/ {print $2}' packages/core/installer/images/talo
 
 set -x
 
-sed -i "/^TAG / s|=.*|= ${version}|" \
+sed -i "/^TAG / s|=.*|= v${version}|" \
   packages/apps/http-cache/Makefile \
   packages/apps/kubernetes/Makefile \
   packages/core/installer/Makefile \
   packages/system/dashboard/Makefile
+
+sed -i "/^VERSION / s|=.*|= ${version}|" \
+  packages/core/Makefile \
+  packages/system/Makefile
+make -C packages/core fix-chartnames
+make -C packages/system fix-chartnames

--- a/packages/core/Makefile
+++ b/packages/core/Makefile
@@ -1,4 +1,6 @@
+VERSION := 0.2.0
+
 gen: fix-chartnames
 	
 fix-chartnames:
-	find . -name Chart.yaml -maxdepth 2 | awk -F/ '{print $$2}' | while read i; do printf "name: cozy-%s\nversion: 1.0.0\n" "$$i" > "$$i/Chart.yaml"; done
+	find . -name Chart.yaml -maxdepth 2 | awk -F/ '{print $$2}' | while read i; do printf "name: cozy-%s\nversion: $(VERSION)\n" "$$i" > "$$i/Chart.yaml"; done

--- a/packages/core/fluxcd/Chart.yaml
+++ b/packages/core/fluxcd/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-fluxcd
-version: 1.0.0
+version: 0.2.0

--- a/packages/core/installer/Chart.yaml
+++ b/packages/core/installer/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-installer
-version: 1.0.0
+version: 0.2.0

--- a/packages/core/platform/Chart.yaml
+++ b/packages/core/platform/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-platform
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/Makefile
+++ b/packages/system/Makefile
@@ -1,4 +1,5 @@
 OUT=../../_out/repos/system
+VERSION := 0.2.0
 
 gen: fix-chartnames
 
@@ -9,4 +10,4 @@ repo: fix-chartnames
 	cd "$(OUT)" && helm repo index .
 
 fix-chartnames:
-	find . -name Chart.yaml -maxdepth 2 | awk -F/ '{print $$2}' | while read i; do printf "name: cozy-%s\nversion: 1.0.0\n" "$$i" > "$$i/Chart.yaml"; done
+	find . -name Chart.yaml -maxdepth 2 | awk -F/ '{print $$2}' | while read i; do printf "name: cozy-%s\nversion: $(VERSION)\n" "$$i" > "$$i/Chart.yaml"; done

--- a/packages/system/capi-operator/Chart.yaml
+++ b/packages/system/capi-operator/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-capi-operator
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/capi-providers/Chart.yaml
+++ b/packages/system/capi-providers/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-capi-providers
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/cert-manager-issuers/Chart.yaml
+++ b/packages/system/cert-manager-issuers/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-cert-manager-issuers
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/cert-manager/Chart.yaml
+++ b/packages/system/cert-manager/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-cert-manager
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/cilium/Chart.yaml
+++ b/packages/system/cilium/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-cilium
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/dashboard/Chart.yaml
+++ b/packages/system/dashboard/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-dashboard
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/grafana-oncall/Chart.yaml
+++ b/packages/system/grafana-oncall/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-grafana-oncall
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/grafana-operator/Chart.yaml
+++ b/packages/system/grafana-operator/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-grafana-operator
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/ingress-nginx/Chart.yaml
+++ b/packages/system/ingress-nginx/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-ingress-nginx
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/kamaji-etcd/Chart.yaml
+++ b/packages/system/kamaji-etcd/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-kamaji-etcd
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/kamaji/Chart.yaml
+++ b/packages/system/kamaji/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-kamaji
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/kubeovn/Chart.yaml
+++ b/packages/system/kubeovn/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-kubeovn
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/kubevirt-cdi-operator/Chart.yaml
+++ b/packages/system/kubevirt-cdi-operator/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-kubevirt-cdi-operator
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/kubevirt-cdi/Chart.yaml
+++ b/packages/system/kubevirt-cdi/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-kubevirt-cdi
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/kubevirt-csi-node/Chart.yaml
+++ b/packages/system/kubevirt-csi-node/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-kubevirt-csi-node
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/kubevirt-operator/Chart.yaml
+++ b/packages/system/kubevirt-operator/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-kubevirt-operator
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/kubevirt/Chart.yaml
+++ b/packages/system/kubevirt/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-kubevirt
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/linstor/Chart.yaml
+++ b/packages/system/linstor/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-linstor
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/mariadb-operator/Chart.yaml
+++ b/packages/system/mariadb-operator/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-mariadb-operator
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/metallb/Chart.yaml
+++ b/packages/system/metallb/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-metallb
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/monitoring/Chart.yaml
+++ b/packages/system/monitoring/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-monitoring
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/piraeus-operator/Chart.yaml
+++ b/packages/system/piraeus-operator/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-piraeus-operator
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/postgres-operator/Chart.yaml
+++ b/packages/system/postgres-operator/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-postgres-operator
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/rabbitmq-operator/Chart.yaml
+++ b/packages/system/rabbitmq-operator/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-rabbitmq-operator
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/redis-operator/Chart.yaml
+++ b/packages/system/redis-operator/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-redis-operator
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/telepresence/Chart.yaml
+++ b/packages/system/telepresence/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-telepresence
-version: 1.0.0
+version: 0.2.0

--- a/packages/system/victoria-metrics-operator/Chart.yaml
+++ b/packages/system/victoria-metrics-operator/Chart.yaml
@@ -1,2 +1,2 @@
 name: cozy-victoria-metrics-operator
-version: 1.0.0
+version: 0.2.0


### PR DESCRIPTION
This allows to track updates between platform versions, example output:

```
NAMESPACE                        NAME                        AGE   READY   STATUS
cozy-cert-manager                cert-manager                59m   True    Helm upgrade succeeded for release cozy-cert-manager/cert-manager.v2 with chart cozy-cert-manager@0.2.0
cozy-cert-manager                cert-manager-issuers        59m   True    Helm upgrade succeeded for release cozy-cert-manager/cert-manager-issuers.v3 with chart cozy-cert-manager-issuers@0.2.0
cozy-cilium                      cilium                      59m   True    Helm upgrade succeeded for release cozy-cilium/cilium.v7 with chart cozy-cilium@0.2.0
cozy-cluster-api                 capi-operator               59m   True    Helm upgrade succeeded for release cozy-cluster-api/capi-operator.v2 with chart cozy-capi-operator@0.2.0
cozy-cluster-api                 capi-providers              59m   True    Helm upgrade succeeded for release cozy-cluster-api/capi-providers.v2 with chart cozy-capi-providers@0.2.0
cozy-dashboard                   dashboard                   59m   True    Helm upgrade succeeded for release cozy-dashboard/dashboard.v3 with chart cozy-dashboard@0.2.0
cozy-grafana-operator            grafana-operator            59m   True    Helm upgrade succeeded for release cozy-grafana-operator/grafana-operator.v2 with chart cozy-grafana-operator@0.2.0
cozy-kamaji                      kamaji                      59m   True    Helm upgrade succeeded for release cozy-kamaji/kamaji.v2 with chart cozy-kamaji@0.2.0
cozy-kubeovn                     kubeovn                     59m   True    Helm upgrade succeeded for release cozy-kubeovn/kubeovn.v6 with chart cozy-kubeovn@0.2.0
cozy-kubevirt-cdi                kubevirt-cdi                59m   True    Helm upgrade succeeded for release cozy-kubevirt-cdi/kubevirt-cdi.v2 with chart cozy-kubevirt-cdi@0.2.0
cozy-kubevirt-cdi                kubevirt-cdi-operator       59m   True    Helm upgrade succeeded for release cozy-kubevirt-cdi/kubevirt-cdi-operator.v2 with chart cozy-kubevirt-cdi-operator@0.2.0
cozy-kubevirt                    kubevirt                    59m   True    Helm upgrade succeeded for release cozy-kubevirt/kubevirt.v3 with chart cozy-kubevirt@0.2.0
cozy-kubevirt                    kubevirt-operator           59m   True    Helm upgrade succeeded for release cozy-kubevirt/kubevirt-operator.v2 with chart cozy-kubevirt-operator@0.2.0
cozy-linstor                     linstor                     59m   True    Helm upgrade succeeded for release cozy-linstor/linstor.v2 with chart cozy-linstor@0.2.0
cozy-linstor                     piraeus-operator            59m   True    Helm upgrade succeeded for release cozy-linstor/piraeus-operator.v2 with chart cozy-piraeus-operator@0.2.0
cozy-mariadb-operator            mariadb-operator            59m   True    Helm upgrade succeeded for release cozy-mariadb-operator/mariadb-operator.v2 with chart cozy-mariadb-operator@0.2.0
cozy-metallb                     metallb                     59m   True    Helm upgrade succeeded for release cozy-metallb/metallb.v2 with chart cozy-metallb@0.2.0
cozy-monitoring                  monitoring                  50m   True    Helm upgrade succeeded for release cozy-monitoring/monitoring.v3 with chart cozy-monitoring@0.2.0
cozy-postgres-operator           postgres-operator           59m   True    Helm upgrade succeeded for release cozy-postgres-operator/postgres-operator.v2 with chart cozy-postgres-operator@0.2.0
cozy-rabbitmq-operator           rabbitmq-operator           59m   True    Helm upgrade succeeded for release cozy-rabbitmq-operator/rabbitmq-operator.v2 with chart cozy-rabbitmq-operator@0.2.0
cozy-redis-operator              redis-operator              59m   True    Helm upgrade succeeded for release cozy-redis-operator/redis-operator.v3 with chart cozy-redis-operator@0.2.0
cozy-telepresence                telepresence                59m   True    Helm upgrade succeeded for release cozy-telepresence/traffic-manager.v3 with chart cozy-telepresence@0.2.0
cozy-victoria-metrics-operator   victoria-metrics-operator   59m   True    Helm upgrade succeeded for release cozy-victoria-metrics-operator/victoria-metrics-operator.v2 with chart cozy-victoria-metrics-operator@0.2.0
```