### PR TITLE
Update mysql helm chart

### DIFF
--- a/packages/apps/mysql/templates/mariadb.yaml
+++ b/packages/apps/mysql/templates/mariadb.yaml
@@ -35,8 +35,9 @@ spec:
     #  automaticFailover: true
 
   metrics:
+    enabled: true
     exporter:
-      image: prom/mysqld-exporter:v0.14.0
+      image: prom/mysqld-exporter:v0.15.1
       resources:
         requests:
           cpu: 50m

--- a/packages/core/installer/images/cozystack.json
+++ b/packages/core/installer/images/cozystack.json
@@ -1,4 +1,4 @@
 {
-  "containerimage.config.digest": "sha256:86175d33758c7f8c33396a3bea929c82c4181676e4ab269cfdb57a806d71528f",
-  "containerimage.digest": "sha256:5fca385a497e8b50d06b5b01dde7dc46289e70c0e8a9eb0604939815c1275e39"
+  "containerimage.config.digest": "sha256:326a169fb5d4277a5c3b0359e0c885b31d1360b58475bbc316be1971c710cd8d",
+  "containerimage.digest": "sha256:a608bdb75b3e06f6365f5f0b3fea82ac93c564d11f316f17e3d46e8a497a321d"
 }


### PR DESCRIPTION
Fix regression introduced by https://github.com/aenix-io/cozystack/pull/51

Metrics should now be explicitly enabled