### PR TITLE
fix: grafana ingress class

### DIFF
--- a/packages/extra/monitoring/templates/grafana/grafana.yaml
+++ b/packages/extra/monitoring/templates/grafana/grafana.yaml
@@ -67,7 +67,7 @@ spec:
   ingress:
     metadata:
       annotations:
-        kubernetes.io/ingress.class: "{{ $ingress }}"
+        acme.cert-manager.io/http01-ingress-class: "{{ $ingress }}"
         cert-manager.io/cluster-issuer: letsencrypt-prod
     spec:
       ingressClassName: "{{ $ingress }}"


### PR DESCRIPTION
Grafana uses default ingress class `nginx` specified in ClusterIssuer resource, we need to overwrite it to correct ingress class from namespace annotation