### PR TITLE
fix: remove plus in kamaji-etcd image tag

### DIFF
--- a/packages/system/kamaji-etcd/Makefile
+++ b/packages/system/kamaji-etcd/Makefile
@@ -6,3 +6,4 @@ update:
 	sed -i 's/hook-failed/before-hook-creation,hook-failed/' `grep -rl hook-failed charts`
 	patch -p4 < patches/fix-svc.diff
 	patch -p4 < patches/fullnameOverride.diff
+	patch -p4 < patches/remove-plus.patch

--- a/packages/system/kamaji-etcd/charts/kamaji-etcd/templates/_helpers.tpl
+++ b/packages/system/kamaji-etcd/charts/kamaji-etcd/templates/_helpers.tpl
@@ -119,11 +119,7 @@ Name of the etcd root-client secret.
 Retrieve the current Kubernetes version to launch a kubectl container with the minimum version skew possible.
 */}}
 {{- define "etcd.jobsTagKubeVersion" -}}
-{{- if contains "-eks-" .Capabilities.KubeVersion.GitVersion }}
 {{- print "v" .Capabilities.KubeVersion.Major "." (.Capabilities.KubeVersion.Minor | replace "+" "") -}}
-{{- else }}
-{{- print "v" .Capabilities.KubeVersion.Major "." .Capabilities.KubeVersion.Minor -}}
-{{- end }}
 {{- end }}
 
 {{/*

--- a/packages/system/kamaji-etcd/patches/remove-plus.patch
+++ b/packages/system/kamaji-etcd/patches/remove-plus.patch
@@ -1,0 +1,16 @@
+diff --git a/packages/system/kamaji-etcd/charts/kamaji-etcd/templates/_helpers.tpl b/packages/system/kamaji-etcd/charts/kamaji-etcd/templates/_helpers.tpl
+index 403e187..e68a967 100644
+--- a/packages/system/kamaji-etcd/charts/kamaji-etcd/templates/_helpers.tpl
++++ b/packages/system/kamaji-etcd/charts/kamaji-etcd/templates/_helpers.tpl
+@@ -119,11 +119,7 @@ Name of the etcd root-client secret.
+ Retrieve the current Kubernetes version to launch a kubectl container with the minimum version skew possible.
+ */}}
+ {{- define "etcd.jobsTagKubeVersion" -}}
+-{{- if contains "-eks-" .Capabilities.KubeVersion.GitVersion }}
+ {{- print "v" .Capabilities.KubeVersion.Major "." (.Capabilities.KubeVersion.Minor | replace "+" "") -}}
+-{{- else }}
+-{{- print "v" .Capabilities.KubeVersion.Major "." .Capabilities.KubeVersion.Minor -}}
+-{{- end }}
+ {{- end }}
+ 
+ {{/*


### PR DESCRIPTION
Upstream issue https://github.com/clastix/kamaji-etcd/pull/56

it makes sense to remove `+` from minor not only for aws.

We're using Talos Linux and also faced with this problem:

```
Server Version: v1.29.0-rc.1
```

Helm recogizes as `v1.29+` and appends it into image tag