### PR TITLE
fix: Flux does not tolerate kubectl edits

### DIFF
--- a/scripts/package-system.mk
+++ b/scripts/package-system.mk
@@ -14,7 +14,7 @@ diff: ## Diff Helm release against objects in a Kubernetes cluster
 	kubectl get hr -n $(NAMESPACE) $(NAME) -o jsonpath='{.spec.values}' | helm diff upgrade --allow-unreleased --normalize-manifests -n $(NAMESPACE) $(NAME) . -f -
 
 suspend: ## Suspend reconciliation for an existing Helm release
-	kubectl patch hr -n $(NAMESPACE) $(NAME) -p '{"spec": {"suspend": true}}' --type=merge
+	kubectl patch hr -n $(NAMESPACE) $(NAME) -p '{"spec": {"suspend": true}}' --type=merge --field-manager=flux-client-side-apply
 
 resume: ## Resume reconciliation for an existing Helm release
-	kubectl patch hr -n $(NAMESPACE) $(NAME) -p '{"spec": {"suspend": null}}' --type=merge
+	kubectl patch hr -n $(NAMESPACE) $(NAME) -p '{"spec": {"suspend": null}}' --type=merge --field-manager=flux-client-side-apply


### PR DESCRIPTION
Thanks https://github.com/aenix-io/cozystack/pull/96#discussion_r1576142242 from @stefanprodan, that flux does not tolerate kubectl edits

To avoid this the field managed should be specified. Details:
https://fluxcd.io/flux/faq/#why-are-kubectl-edits-rolled-back-by-flux