### PR TITLE
Fix: kubernetes and etcd-operator issues

### DIFF
--- a/packages/apps/kubernetes/templates/kccm/manager.yaml
+++ b/packages/apps/kubernetes/templates/kccm/manager.yaml
@@ -50,6 +50,4 @@ spec:
       - secret:
           secretName: {{ .Release.Name }}-admin-kubeconfig
         name: kubeconfig
-      tolerations:
-      - operator: Exists
       serviceAccountName: {{ .Release.Name }}-kccm

--- a/packages/core/installer/images/cozystack.json
+++ b/packages/core/installer/images/cozystack.json
@@ -1,4 +1,4 @@
 {
-  "containerimage.config.digest": "sha256:2474ace34da2ef40ac45fe0b953ffd0932e30680cdf574f353ce3bd6c39dbe9b",
-  "containerimage.digest": "sha256:4dd7fb090e817cd75dcde39e801670f779ec15077be704f1188e8fb986955983"
+  "containerimage.config.digest": "sha256:aefc3ca9f56f69270d7ce6f56a1ce5b531332d5641481eb54c8e74b66b0f3341",
+  "containerimage.digest": "sha256:a2bf43cb7eb812166edfeb1a4fae6a76a4ddba93be2c0ba9040a804ccb53c261"
 }

--- a/packages/core/installer/images/matchbox.json
+++ b/packages/core/installer/images/matchbox.json
@@ -1,4 +1,4 @@
 {
-  "containerimage.config.digest": "sha256:f0739211f7a0614aeb981a1d810a2e6d44f8f4d1c927712db1b3c75168ab8d2a",
-  "containerimage.digest": "sha256:ff20cd22d7bead74ad40110b174905ddea837341ffa8919d4f3df49390a1460e"
+  "containerimage.config.digest": "sha256:68ea72fcc581352fabfd87fa6fd482968cc85ee520cab7a614f1244d7ae36eb0",
+  "containerimage.digest": "sha256:cea915e08a19eb6892f3facf3b3648368cd4a05abefc49bc2616ba3340c27e82"
 }

--- a/packages/extra/etcd/templates/datastore.yaml
+++ b/packages/extra/etcd/templates/datastore.yaml
@@ -3,8 +3,6 @@ apiVersion: kamaji.clastix.io/v1alpha1
 kind: DataStore
 metadata:
   name: {{ .Release.Namespace }}
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
 spec:
   driver: etcd
   endpoints:
@@ -34,3 +32,19 @@ spec:
           keyPath: tls.key
           name: etcd-client-tls
           namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-ca-tls
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/resource-policy: keep
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-client-tls
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/resource-policy: keep

--- a/packages/extra/etcd/templates/etcd-cluster.yaml
+++ b/packages/extra/etcd/templates/etcd-cluster.yaml
@@ -12,6 +12,15 @@ spec:
       serverSecret: etcd-server-tls
       clientTrustedCASecret: etcd-ca-tls
       clientSecret: etcd-client-tls
+  podTemplate:
+    spec:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: etcd
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer

--- a/packages/system/dashboard/images/kubeapps-apis.json
+++ b/packages/system/dashboard/images/kubeapps-apis.json
@@ -1,4 +1,4 @@
 {
-  "containerimage.config.digest": "sha256:3db372aae1be0c6819658148a6464d70de36b067e876c2dd03ca4a20f6d735fa",
-  "containerimage.digest": "sha256:c3711659a0d74f496c13313c40f14a0ff59af8078c27de61ca49fa02b75cbd7b"
+  "containerimage.config.digest": "sha256:273a8e7055816068b2975d8ac10f0f7d114cafef74057680ffc60414d4d8cf4c",
+  "containerimage.digest": "sha256:5e111f09ee9c34281e2ef02cb0d41700943f8c036014110765bb002831148547"
 }


### PR DESCRIPTION
fixes: https://github.com/aenix-io/cozystack/issues/118

- Fix datastore creation depends on created secrets
- Add basic topologySpreadConstraints
- Fix kubernetes chart post-rendering (ref https://github.com/fluxcd/helm-controller/issues/283#issuecomment-2095818525)
