### PR TITLE
etcd quota backend bytes

### DIFF
--- a/packages/extra/etcd/Chart.yaml
+++ b/packages/extra/etcd/Chart.yaml
@@ -3,4 +3,4 @@ name: etcd
 description: Storage for Kubernetes clusters
 icon: https://www.svgrepo.com/show/353714/etcd.svg
 type: application
-version: 2.0.0
+version: 2.0.1

--- a/packages/extra/etcd/templates/etcd-cluster.yaml
+++ b/packages/extra/etcd/templates/etcd-cluster.yaml
@@ -1,9 +1,20 @@
+{{- define "calculateQuotaBackendBytes" -}}
+{{- $units := dict "Ki" 1024 "Mi" 1048576 "Gi" 1073741824 -}}
+{{- $value := regexFind "[0-9.]+" . -}}
+{{- $unit := regexFind "[a-zA-Z]+" . -}}
+{{- $numericValue := float64 $value -}}
+{{- $bytes := mulf $numericValue (index $units $unit) -}}
+{{- $result := mulf $bytes 0.95 -}}
+{{- printf "%.0f" $result -}}
+{{- end -}}
 ---
 apiVersion: etcd.aenix.io/v1alpha1
 kind: EtcdCluster
 metadata:
   name: etcd
 spec:
+  options:
+    quota-backend-bytes: {{ include "calculateQuotaBackendBytes" .Values.size | quote }}
   replicas: {{ .Values.replicas }}
   storage:
     volumeClaimTemplate:

--- a/packages/extra/versions_map
+++ b/packages/extra/versions_map
@@ -1,4 +1,5 @@
 etcd 1.0.0 f7eaab0
-etcd 2.0.0 HEAD
+etcd 2.0.0 a6d0f7cf
+etcd 2.0.1 HEAD
 ingress 1.0.0 HEAD
 monitoring 1.0.0 HEAD


### PR DESCRIPTION
This should automatically set quota for 95% from requested size for etcd.

Current default is `2Gi`

details:

https://etcd.io/docs/v3.3/dev-guide/limit/#:~:text=The%20default%20storage%20size%20limit,the%20configured%20value%20exceeds%20it.