### PR TITLE
etcd: enable autocompact and defrag

### DIFF
--- a/packages/extra/etcd/Chart.yaml
+++ b/packages/extra/etcd/Chart.yaml
@@ -3,4 +3,4 @@ name: etcd
 description: Storage for Kubernetes clusters
 icon: https://www.svgrepo.com/show/353714/etcd.svg
 type: application
-version: 2.0.1
+version: 2.1.0

--- a/packages/extra/etcd/templates/etcd-cluster.yaml
+++ b/packages/extra/etcd/templates/etcd-cluster.yaml
@@ -15,6 +15,9 @@ metadata:
 spec:
   options:
     quota-backend-bytes: {{ include "calculateQuotaBackendBytes" .Values.size | quote }}
+    auto-compaction-mode: "periodic"
+    auto-compaction-retention: "5m"
+    snapshot-count: "10000"
   replicas: {{ .Values.replicas }}
   storage:
     volumeClaimTemplate:

--- a/packages/extra/etcd/templates/etcd-defrag.yaml
+++ b/packages/extra/etcd/templates/etcd-defrag.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-defrag
+spec:
+  schedule: "0 * * * *"
+  successfulJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: etcd-defrag
+            image: ghcr.io/ahrtr/etcd-defrag:v0.13.0
+            args:
+            - --endpoints={{ range $i, $e := until (int .Values.replicas) }}{{ if $i }},{{ end }}https://{{ $.Release.Name }}-{{ $i }}.{{ $.Release.Name }}-headless.{{ $.Release.Namespace }}.svc:2379{{ end }}
+            - --cacert=/etc/etcd/pki/client/cert/ca.crt
+            - --cert=/etc/etcd/pki/client/cert/tls.crt
+            - --key=/etc/etcd/pki/client/cert/tls.key
+            - --cluster
+            - --defrag-rule
+            - "dbQuotaUsage > 0.8 || dbSize - dbSizeInUse > 200*1024*1024"
+            volumeMounts:
+            - mountPath: /etc/etcd/pki/client/cert
+              name: client-certificate
+              readOnly: true
+          volumes:
+          - name: client-certificate
+            secret:
+              secretName: {{ .Release.Name }}-client-tls
+          restartPolicy: OnFailure

--- a/packages/extra/versions_map
+++ b/packages/extra/versions_map
@@ -1,5 +1,6 @@
 etcd 1.0.0 f7eaab0
 etcd 2.0.0 a6d0f7cf
-etcd 2.0.1 HEAD
+etcd 2.0.1 6fc1cc7d
+etcd 2.1.0 HEAD
 ingress 1.0.0 HEAD
 monitoring 1.0.0 HEAD


### PR DESCRIPTION
This PR adds CronJob prameters for autocompact etcd and cronjob for automatic defrag, according to Kubernetes docs

https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/#maintaining-etcd-clusters