### PR TITLE
70 minimize flux requests

### DIFF
--- a/packages/core/fluxcd/values.yaml
+++ b/packages/core/fluxcd/values.yaml
@@ -1,5 +1,4 @@
 flux2:
-  clusterDomain: ""
   helmController:
     resources:
       requests:


### PR DESCRIPTION
I suggest to minimize flux cpu requests so the whole stack fits into a smaller node.
Values are taken from running and mostly idle setup of Cozystack.
Defaults are 100m.

Part of #70 