### PR TITLE
kubernetes: enable bpf masqurade and tunnel based routing for tenant clusters

### DIFF
--- a/packages/apps/kubernetes/Chart.yaml
+++ b/packages/apps/kubernetes/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -55,7 +55,7 @@ spec:
       className: "{{ $ingress }}"
   deployment:
   replicas: 2
-  version: 1.29.0
+  version: 1.29.4
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: KubevirtCluster
@@ -176,5 +176,5 @@ spec:
         kind: KubevirtMachineTemplate
         name: {{ $.Release.Name }}-{{ $groupName }}
         namespace: default
-      version: v1.29.0
+      version: v1.29.4
 {{- end }}

--- a/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
@@ -26,7 +26,9 @@ spec:
   values:
     cilium:
       tunnel: disabled
-      autoDirectNodeRoutes: true
+      autoDirectNodeRoutes: false
+      bpf:
+        masquerade: true
       cgroup:
         autoMount:
           enabled: true
@@ -38,9 +40,9 @@ spec:
         chainingMode: ~
         customConf: false
         configMap: ""
-      routingMode: native
+      routingMode: tunnel
       enableIPv4Masquerade: true
-      ipv4NativeRoutingCIDR: "10.244.0.0/16"
+      ipv4NativeRoutingCIDR: ""
   dependsOn:
   - name: {{ .Release.Name }}
     namespace: {{ .Release.Namespace }}

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -6,7 +6,8 @@ kafka 0.1.0 760f86d2
 kafka 0.2.0 HEAD
 kubernetes 0.1.0 f642698
 kubernetes 0.2.0 7cd7de73
-kubernetes 0.3.0 HEAD
+kubernetes 0.3.0 7caccec1
+kubernetes 0.4.0 HEAD
 mysql 0.1.0 f642698
 mysql 0.2.0 8b975ff0
 mysql 0.3.0 HEAD


### PR DESCRIPTION
This PR solves issues with communication across pods in management cluster with KubeVirt and enables BPF masquerading