### PR TITLE
kamaji: unhardcode cluster.local domain

### DIFF
--- a/packages/system/kamaji/values.yaml
+++ b/packages/system/kamaji/values.yaml
@@ -1,3 +1,8 @@
 kamaji:
   etcd:
     deploy: false
+
+  # Fix https://github.com/clastix/kamaji/pull/467
+  image:
+    repository: ghcr.io/kvaps/test
+    tag: kamaji-v0.6.0-fix


### PR DESCRIPTION
This PR make kamaji working on clusters with different than `cluster.local` domain

upsteram issue: https://github.com/clastix/kamaji/pull/467