### PR TITLE
kubernetes: specify correct dns address

### DIFF
--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -39,7 +39,9 @@ metadata:
 spec:
   dataStoreName: "{{ $etcd }}"
   addons:
-    coreDNS: {}
+    coreDNS:
+      dnsServiceIPs:
+      - 10.95.0.10
     konnectivity: {}
   kubelet:
     cgroupfs: systemd


### PR DESCRIPTION
Kamaji specifies coredns address `10.96.0.10` by default, since we're using 10.95.0.0/16 service networking we have to specify correct dns address `10.95.0.10`

reported by @kingdonb

upstream issue https://github.com/clastix/kamaji/issues/468