### PR TITLE
kube-ovn: disable cozystack image tag

### DIFF
--- a/packages/system/kubeovn/Makefile
+++ b/packages/system/kubeovn/Makefile
@@ -17,7 +17,6 @@ update:
 image:
 	docker buildx build images/kubeovn \
 		--provenance false \
-		--tag $(REGISTRY)/kubeovn:$(call settag,$(TAG)) \
 		--tag $(REGISTRY)/kubeovn:$(call settag,$(KUBEOVN_TAG)) \
 		--tag $(REGISTRY)/kubeovn:$(call settag,$(KUBEOVN_TAG)-$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/kubeovn:latest \


### PR DESCRIPTION
This PR disabled image tag version for kube-ovn
