### PR TITLE
hardcoded cilium and kube-ovn install on many bundles  in installer.sh

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -23,11 +23,10 @@ flux_is_ok() {
 }
 
 install_basic_charts() {
-  case "$BUNDLE" in
-    *-full)
-      make -C packages/system/cilium apply resume
-      ;;
-  esac
+  if [ "$BUNDLE" = "paas-full" ] || [ "$BUNDLE" = "distro-full" ] || [ "$BUNDLE" = "paas-proxmox-full" ]; then
+    make -C packages/system/cilium apply resume
+  fi
+  
   if [ "$BUNDLE" = "paas-full" ] || [ "$BUNDLE" = "paas-proxmox-full" ]; then
     make -C packages/system/kubeovn apply resume
   fi

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -23,14 +23,16 @@ flux_is_ok() {
 }
 
 install_basic_charts() {
-  if [ "$BUNDLE" = "paas-full" ] || [ "$BUNDLE" = "distro-full" ]; then
-  make -C packages/system/cilium apply resume
-  fi
-  if [ "$BUNDLE" = "paas-full" ]; then
+  case "$BUNDLE" in
+    *-full)
+      make -C packages/system/cilium apply resume
+      ;;
+  esac
+  if [ "$BUNDLE" = "paas-full" ] || [ "$BUNDLE" = "paas-proxmox-full" ]; then
     make -C packages/system/kubeovn apply resume
   fi
 }
-
+  
 cd "$(dirname "$0")/.."
 
 # Run migrations


### PR DESCRIPTION
in order to include cilium during setup, need to do it for all bundles with suffix "*-full".  For kube-ovn there will be such a hardcode.