### PR TITLE
release 0.7.0

### DIFF
--- a/manifests/cozystack-installer.yaml
+++ b/manifests/cozystack-installer.yaml
@@ -68,7 +68,7 @@ spec:
       serviceAccountName: cozystack
       containers:
       - name: cozystack
-        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.6.0"
+        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.7.0"
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: localhost
@@ -87,7 +87,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
       - name: darkhttpd
-        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.6.0"
+        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.7.0"
         command:
         - /usr/bin/darkhttpd
         - /cozystack/assets

--- a/packages/apps/http-cache/images/nginx-cache.json
+++ b/packages/apps/http-cache/images/nginx-cache.json
@@ -1,4 +1,4 @@
 {
-  "containerimage.config.digest": "sha256:aa7a9874c35d7fac8668a623744acbf376b48aed2ef1dc4b3a19054fdcff99cf",
-  "containerimage.digest": "sha256:d825427d433dda95db40264c6559b44c7bbb726e69279e90fe73fe8fc9265abb"
+  "containerimage.config.digest": "sha256:31dedc466b9f92131f3e0f35b47d1f3771b6895d5b9a6cc089786b76b00c3a25",
+  "containerimage.digest": "sha256:86c7a8f2a11cbede492c778ffd67c759f722ab6958cab4a9df66af4035b1d7d9"
 }

--- a/packages/core/installer/images/cozystack.json
+++ b/packages/core/installer/images/cozystack.json
@@ -1,4 +1,4 @@
 {
-  "containerimage.config.digest": "sha256:8726af130b534d259ae28a92d84fb866df045765739a59146974d85554e5f188",
-  "containerimage.digest": "sha256:bc9109b0ed072ecbb143ea74edb9bf8a801b4903e0b849aeaa79488c4a9fb7f2"
+  "containerimage.config.digest": "sha256:6d54a5b971e80fbaace664054d4e67f24fd1fbb7807ebaffd036d4ea7195df10",
+  "containerimage.digest": "sha256:a6b167235d8556ff7e45f4582c2491a2ad48292a46005dcf767908e2fb78e74e"
 }

--- a/packages/core/installer/images/cozystack.tag
+++ b/packages/core/installer/images/cozystack.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/cozystack:v0.6.0
+ghcr.io/aenix-io/cozystack/cozystack:v0.7.0

--- a/packages/core/installer/images/matchbox.json
+++ b/packages/core/installer/images/matchbox.json
@@ -1,4 +1,4 @@
 {
-  "containerimage.config.digest": "sha256:05f6f9ed2e662dde64ace18dbbd69001b39778841bda812d7b6b86e064270e64",
-  "containerimage.digest": "sha256:56ef77367394c4b073c862974726d882036c9b95d27a56a774987fe3244c35f6"
+  "containerimage.config.digest": "sha256:ed483d1187cdfeb92df319a30dde57141ceb1d4bafcc28ba006a1e60abc445ff",
+  "containerimage.digest": "sha256:000a46c2bffc3cf13909dc0ca570cdcea9692d85b1ef2a875afe08ea8136d2c2"
 }

--- a/packages/system/cilium/images/cilium.tag
+++ b/packages/system/cilium/images/cilium.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/cilium:latest
+ghcr.io/aenix-io/cozystack/cilium:v0.7.0

--- a/packages/system/dashboard/images/dashboard.tag
+++ b/packages/system/dashboard/images/dashboard.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/dashboard:v0.6.0
+ghcr.io/aenix-io/cozystack/dashboard:v0.7.0

--- a/packages/system/dashboard/images/kubeapps-apis.json
+++ b/packages/system/dashboard/images/kubeapps-apis.json
@@ -1,4 +1,4 @@
 {
-  "containerimage.config.digest": "sha256:79ac02f0fe54d2007b222efe05596a1bf35b8557e406d018f825a2334bd73249",
-  "containerimage.digest": "sha256:1c1dbee8e5c4be14e5df36a69be75a6a2907445564379e23b7f8fbea1afc7093"
+  "containerimage.config.digest": "sha256:44db4f7c92adb68c79eb3e152c95318e559e5c1ac0ba6e3d467596b1315f37a1",
+  "containerimage.digest": "sha256:b0c355cf5387b376e676a9e395fa0a11790409123a29e637a7080a413fe7f10d"
 }

--- a/packages/system/dashboard/images/kubeapps-apis.tag
+++ b/packages/system/dashboard/images/kubeapps-apis.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/kubeapps-apis:v0.6.0
+ghcr.io/aenix-io/cozystack/kubeapps-apis:v0.7.0

--- a/packages/system/kubeovn/images/kubeovn.json
+++ b/packages/system/kubeovn/images/kubeovn.json
@@ -1,4 +1,4 @@
 {
-  "containerimage.config.digest": "sha256:f83db05cfc7228a02d1308721de535e90e355d1b147b2d36bb98e10a848c3ef6",
-  "containerimage.digest": "sha256:440075488baba3610d7f8be6283f89ab3862ff3a9556c51a0e99ec6d46315192"
+  "containerimage.config.digest": "sha256:b3d76d1764c8c470a32b4d3b19e48592eda547710e8e6508666930e1db1b4cb3",
+  "containerimage.digest": "sha256:e5275d3a367aba3b4a7ec0bf25583cc21241e320da2ffd86f5c9cf4a7f6fac77"
 }

--- a/packages/system/kubeovn/images/kubeovn.tag
+++ b/packages/system/kubeovn/images/kubeovn.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/kubeovn:latest
+ghcr.io/aenix-io/cozystack/kubeovn:v0.7.0

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -3,7 +3,7 @@ set -o pipefail
 set -e
 
 BUNDLE=$(set -x; kubectl get configmap -n cozy-system cozystack -o 'go-template={{index .data "bundle-name"}}')
-VERSION=3
+VERSION=4
 
 run_migrations() {
   if ! kubectl get configmap -n cozy-system cozystack-version; then

--- a/scripts/migrations/3
+++ b/scripts/migrations/3
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Migration 3 --> 4
+
+# Fix kubeovn crds
+kubeovn_crds=$(kubectl get crd -o name | grep '\.kubeovn\.io$')
+if [ -n "$kubeovn_crds" ]; then
+  kubectl annotate $kubeovn_crds meta.helm.sh/release-namespace=cozy-kubeovn meta.helm.sh/release-name=kubeovn
+  kubectl label $kubeovn_crds app.kubernetes.io/managed-by=Helm
+fi
+
+# Write version to cozystack-version config
+kubectl create configmap -n cozy-system cozystack-version --from-literal=version=4 --dry-run=client -o yaml | kubectl apply -f-


### PR DESCRIPTION
- etcd: enable autocompact and defrag (#137)
- switched place -maxdepth im Makefiles (#140)
- postgres: fix users and roles (#138)
- kubernetes: enable bpf masqurade and tunnel routing (#144)
- Unhardcode cluster.local domain (#142)
- kamaji: unhardcode cluster.local domain (#145)
- kubernetes: specify correct dns address (#147)
- change hardcode for talos registry (#148)
- Update Cilium v1.15.5
- Update kube-ovn v1.13.0-ge1310e17 and enable image building (#149)
- cilium: enforce device detection and enable image building
- kube-ovn: disable cozystack image tag