### PR TITLE
fix clickhouse login

### DIFF
--- a/packages/apps/clickhouse/Chart.yaml
+++ b/packages/apps/clickhouse/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/clickhouse/templates/clickhouse.yaml
+++ b/packages/apps/clickhouse/templates/clickhouse.yaml
@@ -14,6 +14,7 @@ spec:
       {{- range $name, $u := . }}
       {{ $name }}/password_sha256_hex: {{ sha256sum $u.password }}
       {{ $name }}/profile: {{ ternary "readonly" "default" (index $u "readonly" | default false) }}
+      {{ $name }}/networks/ip: ["::/0"]
       {{- end }}
     {{- end }}
     profiles:

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -1,5 +1,6 @@
 clickhouse 0.1.0 ca79f72
-clickhouse 0.2.0 HEAD
+clickhouse 0.2.0 7cd7de73
+clickhouse 0.2.1 HEAD
 http-cache 0.1.0 a956713
 http-cache 0.2.0 HEAD
 kafka 0.1.0 760f86d2


### PR DESCRIPTION
The Altinity Operator, by default, only allows user logins from localhost. This pull request enables logins from other networks.