### PR TITLE
fix: dependsOn kubeovn and cilium in *-hosted bundles

### DIFF
--- a/packages/core/platform/bundles/distro-hosted.yaml
+++ b/packages/core/platform/bundles/distro-hosted.yaml
@@ -54,13 +54,13 @@ releases:
   releaseName: kafka-operator
   chart: cozy-kafka-operator
   namespace: cozy-kafka-operator
-  dependsOn: [cilium,kubeovn]
+  dependsOn: []
 
 - name: clickhouse-operator
   releaseName: clickhouse-operator
   chart: cozy-clickhouse-operator
   namespace: cozy-clickhouse-operator
-  dependsOn: [cilium,kubeovn]
+  dependsOn: []
 
 - name: rabbitmq-operator
   releaseName: rabbitmq-operator

--- a/packages/core/platform/bundles/paas-hosted.yaml
+++ b/packages/core/platform/bundles/paas-hosted.yaml
@@ -54,13 +54,13 @@ releases:
   releaseName: kafka-operator
   chart: cozy-kafka-operator
   namespace: cozy-kafka-operator
-  dependsOn: [cilium,kubeovn]
+  dependsOn: []
 
 - name: clickhouse-operator
   releaseName: clickhouse-operator
   chart: cozy-clickhouse-operator
   namespace: cozy-clickhouse-operator
-  dependsOn: [cilium,kubeovn]
+  dependsOn: []
 
 - name: rabbitmq-operator
   releaseName: rabbitmq-operator


### PR DESCRIPTION
This PR removes kubeovn and cilium dependencies in `*-hosted` bundles