### PR TITLE
Allow specifying externalIPs for ingress-nginx

### DIFF
--- a/packages/extra/ingress/Chart.yaml
+++ b/packages/extra/ingress/Chart.yaml
@@ -3,4 +3,4 @@ name: ingress
 description: NGINX Ingress Controller
 icon: https://docs.nginx.com/nginx-ingress-controller/images/icons/NGINX-Ingress-Controller-product-icon.svg
 type: application
-version: 1.0.0
+version: 1.1.0

--- a/packages/extra/ingress/README.md
+++ b/packages/extra/ingress/README.md
@@ -4,6 +4,7 @@
 
 ### Common parameters
 
-| Name       | Description                      | Value |
-| ---------- | -------------------------------- | ----- |
-| `replicas` | Number of ingress-nginx replicas | `2`   |
+| Name          | Description                      | Value |
+| ------------- | -------------------------------- | ----- |
+| `replicas`    | Number of ingress-nginx replicas | `2`   |
+| `externalIPs` | List of externalIPs for service. | `[]`  |

--- a/packages/extra/ingress/config.json
+++ b/packages/extra/ingress/config.json
@@ -1,0 +1,23 @@
+{
+  "comments": {
+    "format": "##"
+  },
+  "tags": {
+    "param": "@param",
+    "section": "@section",
+    "descriptionStart": "@descriptionStart",
+    "descriptionEnd": "@descriptionEnd",
+    "skip": "@skip",
+    "extra": "@extra"
+  },
+  "modifiers": {
+    "array": "array",
+    "object": "object",
+    "string": "string",
+    "nullable": "nullable",
+    "default": "default"
+  },
+  "regexp": {
+    "paramsSectionTitle": "Parameters"
+  }
+}

--- a/packages/extra/ingress/templates/nginx-ingress.yaml
+++ b/packages/extra/ingress/templates/nginx-ingress.yaml
@@ -27,3 +27,13 @@ spec:
         admissionWebhooks:
           enabled: false
         {{- end }}
+        service:
+          {{- if .Values.externalIPs }}
+          externalIPs:
+            {{- toYaml .Values.externalIPs | nindent 12 }}
+          type: ClusterIP
+          externalTrafficPolicy: Cluster
+          {{- else }}
+          type: LoadBalancer
+          externalTrafficPolicy: Local
+          {{- end }}

--- a/packages/extra/ingress/values.schema.json
+++ b/packages/extra/ingress/values.schema.json
@@ -6,6 +6,14 @@
             "type": "number",
             "description": "Number of ingress-nginx replicas",
             "default": 2
+        },
+        "externalIPs": {
+            "type": "array",
+            "description": "List of externalIPs for service.",
+            "default": "[]",
+            "items": {
+                "type": "string"
+            }
         }
     }
 }

--- a/packages/extra/ingress/values.yaml
+++ b/packages/extra/ingress/values.yaml
@@ -3,3 +3,14 @@
 ## @param replicas Number of ingress-nginx replicas
 ##
 replicas: 2
+
+## @param externalIPs [array] List of externalIPs for service.
+## Optional. If not specified will use LoadBalancer service by default.
+## 
+## e.g:
+## externalIPs:
+##   - "11.22.33.44"
+##   - "11.22.33.45"
+##   - "11.22.33.46"
+##
+externalIPs: []

--- a/packages/extra/versions_map
+++ b/packages/extra/versions_map
@@ -2,5 +2,6 @@ etcd 1.0.0 f7eaab0
 etcd 2.0.0 a6d0f7cf
 etcd 2.0.1 6fc1cc7d
 etcd 2.1.0 HEAD
-ingress 1.0.0 HEAD
+ingress 1.0.0 f642698
+ingress 1.1.0 HEAD
 monitoring 1.0.0 HEAD


### PR DESCRIPTION
There is a configuration without load-balancer service, when all nodes of the cluster are responsible for routing traffic.

In this case we can provide user an oportunity to specify IP-addresses of the nodes which are used to recieve traffic.

These nodes will be used to route traffic to nginx-ingress pods.

fixes https://github.com/aenix-io/cozystack/issues/158