### PR TITLE
Add initial ARM support

### DIFF
--- a/packages/core/installer/Makefile
+++ b/packages/core/installer/Makefile
@@ -25,6 +25,7 @@ image-cozystack:
 		--provenance false \
 		--tag $(REGISTRY)/cozystack:$(call settag,$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/cozystack:latest \
+		--platform linux/amd64,linux/arm64 \
 		--cache-to type=inline \
 		--metadata-file images/cozystack.json \
 		--push=$(PUSH) \

--- a/packages/core/installer/images/cozystack.json
+++ b/packages/core/installer/images/cozystack.json
@@ -1,4 +1,10 @@
 {
-  "containerimage.config.digest": "sha256:6d54a5b971e80fbaace664054d4e67f24fd1fbb7807ebaffd036d4ea7195df10",
-  "containerimage.digest": "sha256:a6b167235d8556ff7e45f4582c2491a2ad48292a46005dcf767908e2fb78e74e"
+  "buildx.build.ref": "youthful_hertz/youthful_hertz0/aafwjh8j28i98f59smgh3qe86",
+  "containerimage.descriptor": {
+    "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+    "digest": "sha256:e0c0defb9f5b10f5187d4002ccec7d01841e96c7350963f253003c0efeff6cef",
+    "size": 685
+  },
+  "containerimage.digest": "sha256:e0c0defb9f5b10f5187d4002ccec7d01841e96c7350963f253003c0efeff6cef",
+  "image.name": "ghcr.io/aenix-io/cozystack/cozystack:latest"
 }

--- a/packages/core/installer/images/cozystack.tag
+++ b/packages/core/installer/images/cozystack.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/cozystack:v0.7.0
+ghcr.io/aenix-io/cozystack/cozystack:latest

--- a/packages/core/installer/images/cozystack/Dockerfile
+++ b/packages/core/installer/images/cozystack/Dockerfile
@@ -3,12 +3,15 @@ FROM golang:alpine3.19 as k8s-await-election-builder
 ARG K8S_AWAIT_ELECTION_GITREPO=https://github.com/LINBIT/k8s-await-election
 ARG K8S_AWAIT_ELECTION_VERSION=0.4.1
 
+# TARGETARCH is a docker special variable: https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+ARG TARGETARCH
+
 RUN apk add --no-cache git make
 RUN git clone ${K8S_AWAIT_ELECTION_GITREPO} /usr/local/go/k8s-await-election/ \
  && cd /usr/local/go/k8s-await-election \
  && git reset --hard v${K8S_AWAIT_ELECTION_VERSION} \
  && make \
- && mv ./out/k8s-await-election-amd64 /k8s-await-election
+ && mv ./out/k8s-await-election-${TARGETARCH} /k8s-await-election
 
 FROM alpine:3.19 AS builder
 


### PR DESCRIPTION
As part of https://github.com/aenix-io/cozystack/issues/27

Thanks [beby.cloud](https://beby.cloud/en/) for providing infrastucture.

Cozystack has been succefully deployed on three Raspbery PIs in minimal configuration:

CNI and kube-proxy used from Talos Linux, cozystack configuration as follows:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: cozystack
  namespace: cozy-system
data:
  bundle-name: "distro-hosted"
  bundle-disable: "etcd-operator"
```


```
# kubectl get hr -A  
NAMESPACE                        NAME                        AGE   READY   STATUS
cozy-cert-manager                cert-manager                65m   True    Helm upgrade succeeded for release cozy-cert-manager/cert-manager.v2 with chart cozy-cert-manager@0.7.0
cozy-cert-manager                cert-manager-issuers        65m   True    Helm install succeeded for release cozy-cert-manager/cert-manager-issuers.v1 with chart cozy-cert-manager-issuers@0.7.0
cozy-clickhouse-operator         clickhouse-operator         65m   True    Helm install succeeded for release cozy-clickhouse-operator/clickhouse-operator.v1 with chart cozy-clickhouse-operator@0.7.0
cozy-grafana-operator            grafana-operator            65m   True    Helm upgrade succeeded for release cozy-grafana-operator/grafana-operator.v2 with chart cozy-grafana-operator@0.7.0
cozy-kafka-operator              kafka-operator              65m   True    Helm install succeeded for release cozy-kafka-operator/kafka-operator.v1 with chart cozy-kafka-operator@0.7.0
cozy-mariadb-operator            mariadb-operator            65m   True    Helm install succeeded for release cozy-mariadb-operator/mariadb-operator.v1 with chart cozy-mariadb-operator@0.7.0
cozy-monitoring                  monitoring                  65m   True    Helm upgrade succeeded for release cozy-monitoring/monitoring.v3 with chart cozy-monitoring@0.7.0
cozy-postgres-operator           postgres-operator           65m   True    Helm upgrade succeeded for release cozy-postgres-operator/postgres-operator.v2 with chart cozy-postgres-operator@0.7.0
cozy-rabbitmq-operator           rabbitmq-operator           65m   True    Helm install succeeded for release cozy-rabbitmq-operator/rabbitmq-operator.v1 with chart cozy-rabbitmq-operator@0.7.0
cozy-redis-operator              redis-operator              65m   True    Helm upgrade succeeded for release cozy-redis-operator/redis-operator.v2 with chart cozy-redis-operator@0.7.0
cozy-telepresence                telepresence                65m   True    Helm install succeeded for release cozy-telepresence/traffic-manager.v1 with chart cozy-telepresence@0.7.0
cozy-victoria-metrics-operator   victoria-metrics-operator   65m   True    Helm upgrade succeeded for release cozy-victoria-metrics-operator/victoria-metrics-operator.v2 with chart cozy-victoria-metrics-operator@0.7.0
tenant-root                      ingress                     14m   True    Helm install succeeded for release tenant-root/ingress.v1 with chart ingress@1.1.0
tenant-root                      ingress-nginx               14m   True    Helm install succeeded for release tenant-root/ingress-nginx.v1 with chart cozy-ingress-nginx@0.7.0
tenant-root                      monitoring                  14m   True    Helm upgrade succeeded for release tenant-root/monitoring.v8 with chart monitoring@1.0.0
tenant-root                      tenant-root                 65m   True    Helm upgrade succeeded for release tenant-root/tenant-root.v3 with chart tenant@1.1.0
```

storage, metallb and monitoring works out-of-box:

![grafana](https://github.com/aenix-io/cozystack/assets/7556217/ebae7408-b3d6-42f8-986c-2f1a5c93843a)

nginx-ingress has been patched to use official images (temporary)

```diff
diff --git a/packages/system/ingress-nginx/values.yaml b/packages/system/ingress-nginx/values.yaml
index 1390e72..0b63791 100644
--- a/packages/system/ingress-nginx/values.yaml
+++ b/packages/system/ingress-nginx/values.yaml
@@ -2,11 +2,6 @@ ingress-nginx:
   controller:
     extraArgs:
       enable-ssl-passthrough: true
-    image:
-      registry: ghcr.io
-      image: kvaps/ingress-nginx-with-protobuf-exporter/controller
-      tag: v1.8.1
-      digest: "sha256:7933a0729c716a8bf879218451ff43ee9c1a8f4850feffb12f81eb9439aefc23"
     allowSnippetAnnotations: true
     replicaCount: 2
     admissionWebhooks:
@@ -14,12 +9,6 @@ ingress-nginx:
         enabled: true
     metrics:
       enabled: true
-    extraContainers:
-    - name: protobuf-exporter
-      image: ghcr.io/kvaps/ingress-nginx-with-protobuf-exporter/protobuf-exporter:v1.8.1@sha256:9b6f3f2688592a0f25038bc15e107642d7374359cbd87442920df1c45f27fe4d
-      args:
-      - --server.telemetry-address=0.0.0.0:9090
-      - --server.exporter-address=0.0.0.0:9091
     service:
       #type: NodePort # ClusterIP
       externalTrafficPolicy: "Local"
@@ -44,4 +33,4 @@ ingress-nginx:

   defaultBackend:
     ##
-    enabled: true
+    enabled: false
```

Needs to enable multiarch building for all the reset images


We probably need to add the automation for making buildx context before the building has started

```
docker buildx create --use
```