### PR TITLE
add fluxcd labels post processor

### DIFF
--- a/packages/system/capi-operator/Makefile
+++ b/packages/system/capi-operator/Makefile
@@ -1,5 +1,5 @@
-NAME=capi-operator
-NAMESPACE=cozy-cluster-api
+export NAME=capi-operator
+export NAMESPACE=cozy-cluster-api
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/capi-providers/Makefile
+++ b/packages/system/capi-providers/Makefile
@@ -1,4 +1,4 @@
-NAME=capi-providers
-NAMESPACE=cozy-cluster-api
+export NAME=capi-providers
+export NAMESPACE=cozy-cluster-api
 
 include ../../../scripts/package-system.mk

--- a/packages/system/cert-manager-issuers/Makefile
+++ b/packages/system/cert-manager-issuers/Makefile
@@ -1,4 +1,4 @@
-NAME=cert-manager-issuers
-NAMESPACE=cozy-cert-manager
+export NAME=cert-manager-issuers
+export NAMESPACE=cozy-cert-manager
 
 include ../../../scripts/package-system.mk

--- a/packages/system/cert-manager/Makefile
+++ b/packages/system/cert-manager/Makefile
@@ -1,5 +1,5 @@
-NAME=cert-manager
-NAMESPACE=cozy-$(NAME)
+export NAME=cert-manager
+export NAMESPACE=cozy-$(NAME)
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/cilium/Makefile
+++ b/packages/system/cilium/Makefile
@@ -1,7 +1,7 @@
 CILIUM_TAG=$(shell awk '$$1 == "version:" {print $$2}' charts/cilium/Chart.yaml)
 
-NAME=cilium
-NAMESPACE=cozy-$(NAME)
+export NAME=cilium
+export NAMESPACE=cozy-$(NAME)
 
 include ../../../scripts/common-envs.mk
 include ../../../scripts/package-system.mk

--- a/packages/system/clickhouse-operator/Makefile
+++ b/packages/system/clickhouse-operator/Makefile
@@ -1,5 +1,5 @@
-NAME=clickhouse-operator
-NAMESPACE=cozy-clickhouse-operator
+export NAME=clickhouse-operator
+export NAMESPACE=cozy-clickhouse-operator
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/dashboard/Makefile
+++ b/packages/system/dashboard/Makefile
@@ -1,5 +1,5 @@
-NAME=dashboard
-NAMESPACE=cozy-$(NAME)
+export NAME=dashboard
+export NAMESPACE=cozy-$(NAME)
 
 include ../../../scripts/common-envs.mk
 include ../../../scripts/package-system.mk

--- a/packages/system/etcd-operator/Makefile
+++ b/packages/system/etcd-operator/Makefile
@@ -1,5 +1,5 @@
-NAME=etcd-operator
-NAMESPACE=cozy-${NAME}
+export NAME=etcd-operator
+export NAMESPACE=cozy-${NAME}
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/grafana-operator/Makefile
+++ b/packages/system/grafana-operator/Makefile
@@ -1,5 +1,5 @@
-NAME=grafana-operator
-NAMESPACE=cozy-grafana-operator
+export NAME=grafana-operator
+export NAMESPACE=cozy-grafana-operator
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/ingress-nginx/Makefile
+++ b/packages/system/ingress-nginx/Makefile
@@ -1,5 +1,5 @@
-NAME=ingress-nginx
-NAMESPACE=cozy-$(NAME)
+export NAME=ingress-nginx
+export NAMESPACE=cozy-$(NAME)
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/kafka-operator/Makefile
+++ b/packages/system/kafka-operator/Makefile
@@ -1,5 +1,5 @@
-NAME=kafka-operator
-NAMESPACE=cozy-$(NAME)
+export NAME=kafka-operator
+export NAMESPACE=cozy-$(NAME)
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/kamaji/Makefile
+++ b/packages/system/kamaji/Makefile
@@ -1,5 +1,5 @@
-NAME=kamaji
-NAMESPACE=cozy-$(NAME)
+export NAME=kamaji
+export NAMESPACE=cozy-$(NAME)
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/kubeovn/Makefile
+++ b/packages/system/kubeovn/Makefile
@@ -1,7 +1,7 @@
 KUBEOVN_TAG = v1.13.0
 
-NAME=kubeovn
-NAMESPACE=cozy-$(NAME)
+export NAME=kubeovn
+export NAMESPACE=cozy-$(NAME)
 
 include ../../../scripts/common-envs.mk
 include ../../../scripts/package-system.mk

--- a/packages/system/kubevirt-cdi-operator/Makefile
+++ b/packages/system/kubevirt-cdi-operator/Makefile
@@ -1,5 +1,5 @@
-NAME=kubevirt-cdi-operator
-NAMESPACE=cozy-kubevirt-cdi
+export NAME=kubevirt-cdi-operator
+export NAMESPACE=cozy-kubevirt-cdi
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/kubevirt-cdi/Makefile
+++ b/packages/system/kubevirt-cdi/Makefile
@@ -1,5 +1,5 @@
-NAME=kubevirt-cdi
-NAMESPACE=cozy-$(NAME)
+export NAME=kubevirt-cdi
+export NAMESPACE=cozy-$(NAME)
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/kubevirt-operator/Makefile
+++ b/packages/system/kubevirt-operator/Makefile
@@ -1,5 +1,5 @@
-NAME=kubevirt-operator
-NAMESPACE=cozy-kubevirt
+export NAME=kubevirt-operator
+export NAMESPACE=cozy-kubevirt
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/kubevirt/Makefile
+++ b/packages/system/kubevirt/Makefile
@@ -1,5 +1,5 @@
-NAME=kubevirt
-NAMESPACE=cozy-$(NAME)
+export NAME=kubevirt
+export NAMESPACE=cozy-$(NAME)
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/linstor/Makefile
+++ b/packages/system/linstor/Makefile
@@ -1,4 +1,4 @@
-NAME=linstor
-NAMESPACE=cozy-$(NAME)
+export NAME=linstor
+export NAMESPACE=cozy-$(NAME)
 
 include ../../../scripts/package-system.mk

--- a/packages/system/mariadb-operator/Makefile
+++ b/packages/system/mariadb-operator/Makefile
@@ -1,5 +1,5 @@
-NAME=mariadb-operator
-NAMESPACE=cozy-$(NAME)
+export NAME=mariadb-operator
+export NAMESPACE=cozy-$(NAME)
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/metallb/Makefile
+++ b/packages/system/metallb/Makefile
@@ -1,5 +1,5 @@
-NAME=metallb
-NAMESPACE=cozy-$(NAME)
+export NAME=metallb
+export NAMESPACE=cozy-$(NAME)
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/monitoring/Makefile
+++ b/packages/system/monitoring/Makefile
@@ -1,5 +1,5 @@
-NAME=monitoring
-NAMESPACE=cozy-$(NAME)
+export NAME=monitoring
+export NAMESPACE=cozy-$(NAME)
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/piraeus-operator/Makefile
+++ b/packages/system/piraeus-operator/Makefile
@@ -1,5 +1,5 @@
-NAME=piraeus-operator
-NAMESPACE=cozy-linstor
+export NAME=piraeus-operator
+export NAMESPACE=cozy-linstor
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/postgres-operator/Makefile
+++ b/packages/system/postgres-operator/Makefile
@@ -1,5 +1,5 @@
-NAME=postgres-operator
-NAMESPACE=cozy-$(NAME)
+export NAME=postgres-operator
+export NAMESPACE=cozy-$(NAME)
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/rabbitmq-operator/Makefile
+++ b/packages/system/rabbitmq-operator/Makefile
@@ -1,5 +1,5 @@
-NAME=rabbitmq-operator
-NAMESPACE=cozy-$(NAME)
+export NAME=rabbitmq-operator
+export NAMESPACE=cozy-$(NAME)
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/redis-operator/Makefile
+++ b/packages/system/redis-operator/Makefile
@@ -1,5 +1,5 @@
-NAME=redis-operator
-NAMESPACE=cozy-$(NAME)
+export NAME=redis-operator
+export NAMESPACE=cozy-$(NAME)
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/telepresence/Makefile
+++ b/packages/system/telepresence/Makefile
@@ -1,5 +1,5 @@
-NAME=traffic-manager
-NAMESPACE=cozy-telepresence
+export NAME=traffic-manager
+export NAMESPACE=cozy-telepresence
 
 include ../../../scripts/package-system.mk
 

--- a/packages/system/victoria-metrics-operator/Makefile
+++ b/packages/system/victoria-metrics-operator/Makefile
@@ -1,5 +1,5 @@
-NAME=victoria-metrics-operator
-NAMESPACE=cozy-$(NAME)
+export NAME=victoria-metrics-operator
+export NAMESPACE=cozy-$(NAME)
 
 include ../../../scripts/package-system.mk
 

--- a/scripts/fluxcd-kustomize.sh
+++ b/scripts/fluxcd-kustomize.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# This scripts adds common fluxcd labels to all objects
+
+if [ -z "$NAME" ]; then
+  echo 'Variable $NAME is not set!' >&2
+  exit 1
+fi
+
+if [ -z "$NAMESPACE" ]; then
+  echo 'Variable $NAMESPACE is not set!' >&2
+  exit 1
+fi
+
+TMP_DIR=$(mktemp -d)
+cat - > "${TMP_DIR}/helm-generated-output.yaml"
+cat > "${TMP_DIR}/global-labels.yaml" <<EOT
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: global-labels
+labels:
+  helm.toolkit.fluxcd.io/name: ${NAME}
+  helm.toolkit.fluxcd.io/namespace: ${NAMESPACE:-$HELM_NAMESPACE}
+fieldSpecs:
+- path: metadata/labels
+  create: true
+EOT
+cat > "${TMP_DIR}/kustomization.yaml" <<EOT
+resources:
+- helm-generated-output.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+transformers:
+- global-labels.yaml
+EOT
+kubectl kustomize "${TMP_DIR}"
+rm -rf "${TMP_DIR}"

--- a/scripts/package-system.mk
+++ b/scripts/package-system.mk
@@ -5,13 +5,13 @@ help: ## Show this help.
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 show: ## Show output of rendered templates
-	kubectl get hr -n $(NAMESPACE) $(NAME) -o jsonpath='{.spec.values}' | helm template --dry-run=server -n $(NAMESPACE) $(NAME) . -f -
+	kubectl get hr -n $(NAMESPACE) $(NAME) -o jsonpath='{.spec.values}' | helm template --dry-run=server --post-renderer ../../../scripts/fluxcd-kustomize.sh -n $(NAMESPACE) $(NAME) . -f -
 
 apply: suspend ## Apply Helm release to a Kubernetes cluster 
-	kubectl get hr -n $(NAMESPACE) $(NAME) -o jsonpath='{.spec.values}' | helm upgrade -i -n $(NAMESPACE) $(NAME) . -f -
+	kubectl get hr -n $(NAMESPACE) $(NAME) -o jsonpath='{.spec.values}' | helm upgrade -i --post-renderer ../../../scripts/fluxcd-kustomize.sh -n $(NAMESPACE) $(NAME) . -f -
 
 diff: ## Diff Helm release against objects in a Kubernetes cluster
-	kubectl get hr -n $(NAMESPACE) $(NAME) -o jsonpath='{.spec.values}' | helm diff upgrade --allow-unreleased --normalize-manifests -n $(NAMESPACE) $(NAME) . -f -
+	kubectl get hr -n $(NAMESPACE) $(NAME) -o jsonpath='{.spec.values}' | helm diff upgrade --allow-unreleased --post-renderer ../../../scripts/fluxcd-kustomize.sh -n $(NAMESPACE) $(NAME) . -f -
 
 suspend: ## Suspend reconciliation for an existing Helm release
 	kubectl patch hr -n $(NAMESPACE) $(NAME) -p '{"spec": {"suspend": true}}' --type=merge --field-manager=flux-client-side-apply


### PR DESCRIPTION
This PR introduces a new fluxcd-kustomize.sh script that can be used as post-processor for helm for adding a common fluxcd labels.

This is very useful for `make diff`, so it will not include diff between these labels anymore

Also for debugging specific kustomize cases, eg:
- https://github.com/fluxcd/helm-controller/issues/283
- https://github.com/fluxcd/flux2/issues/4368