### PR TITLE
Use patch with --no-backup-if-mismatch

### DIFF
--- a/packages/core/fluxcd/Makefile
+++ b/packages/core/fluxcd/Makefile
@@ -17,4 +17,4 @@ diff:
 update:
 	rm -rf charts
 	helm pull oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator --untar --untardir charts
-	patch -p1 --no-backup-if-mismatch < patches/kubernetesEnvs.diff
+	patch --no-backup-if-mismatch -p1 < patches/kubernetesEnvs.diff

--- a/packages/system/dashboard/Makefile
+++ b/packages/system/dashboard/Makefile
@@ -19,7 +19,7 @@ update-chart:
 update-dockerfiles:
 	tag=$$(git ls-remote --tags --sort="v:refname" https://github.com/vmware-tanzu/kubeapps  | awk -F'[/^]' 'END{print $$3}') && \
 	wget https://github.com/vmware-tanzu/kubeapps/raw/$${tag}/cmd/kubeapps-apis/Dockerfile -O images/kubeapps-apis/Dockerfile && \
-	patch images/kubeapps-apis/Dockerfile < images/kubeapps-apis/dockerfile.diff && \
+	patch --no-backup-if-mismatch images/kubeapps-apis/Dockerfile < images/kubeapps-apis/dockerfile.diff && \
 	node_image=$$(wget -O- https://github.com/vmware-tanzu/kubeapps/raw/main/dashboard/Dockerfile | awk '/FROM bitnami\/node/ {print $$2}') && \
 	sed -i "s|FROM .* AS build|FROM $${node_image} AS build|" images/dashboard/Dockerfile && \
 	version=$$(echo "$$tag" | sed 's/^v//') && \

--- a/packages/system/ingress-nginx/Makefile
+++ b/packages/system/ingress-nginx/Makefile
@@ -8,7 +8,7 @@ update:
 	helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 	helm repo update ingress-nginx
 	helm pull ingress-nginx/ingress-nginx --untar --untardir charts
-	patch -p 3 < patches/add-metrics2.patch
+	patch --no-backup-if-mismatch -p 3 < patches/add-metrics2.patch
 	rm -f charts/ingress-nginx/templates/controller-deployment.yaml.orig
 	rm -rf charts/ingress-nginx/changelog/
 	#sed -i '/  type:/a \  allocateLoadBalancerNodePorts: false' charts/ingress-nginx/templates/controller-service.yaml

--- a/packages/system/kamaji-etcd/Makefile
+++ b/packages/system/kamaji-etcd/Makefile
@@ -4,6 +4,6 @@ update:
 	helm repo update clastix
 	helm pull clastix/kamaji-etcd --untar --untardir charts
 	sed -i 's/hook-failed/before-hook-creation,hook-failed/' `grep -rl hook-failed charts`
-	patch -p4 < patches/fix-svc.diff
-	patch -p4 < patches/fullnameOverride.diff
-	patch -p4 < patches/remove-plus.patch
+	patch --no-backup-if-mismatch -p4 < patches/fix-svc.diff
+	patch --no-backup-if-mismatch -p4 < patches/fullnameOverride.diff
+	patch --no-backup-if-mismatch -p4 < patches/remove-plus.patch

--- a/packages/system/kubeovn/Makefile
+++ b/packages/system/kubeovn/Makefile
@@ -10,7 +10,7 @@ update:
 	rm -rf charts && mkdir -p charts/kube-ovn
 	curl -sSL https://github.com/kubeovn/kube-ovn/archive/refs/heads/master.tar.gz | \
 	tar xzvf - --strip 1 kube-ovn-master/charts
-	patch -p4 --no-backup-if-mismatch < patches/cozyconfig.diff
+	patch --no-backup-if-mismatch -p4 < patches/cozyconfig.diff
 	ln -s ../../images charts/kube-ovn/images
 	sed -i '/image:/ s/{{.*}}/{{ include "kubeovn.image" . }}/g' `grep -rl image: charts/kube-ovn/templates/`
 


### PR DESCRIPTION
Add option `--no-backup-if-mismatch` to every patch command, so it will not create .orig and .diff files anymore