### PR TITLE
fix ingress-nginx to depend on cert-manager

### DIFF
--- a/packages/apps/kubernetes/templates/helmreleases/ingress-nginx.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/ingress-nginx.yaml
@@ -8,7 +8,7 @@ metadata:
     coztstack.io/target-cluster-name: {{ .Release.Name }}
 spec:
   interval: 1m
-  releaseName: cert-mnager
+  releaseName: ingress-nginx
   chart:
     spec:
       chart: cozy-ingress-nginx
@@ -40,5 +40,7 @@ spec:
     namespace: {{ .Release.Namespace }}
   {{- end }}
   - name: {{ .Release.Name }}-cilium
+    namespace: {{ .Release.Namespace }}
+  - name: {{ .Release.Name }}-cert-manager
     namespace: {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
I don't think this change is correct, unless you cannot install ingress-nginx without also getting the cert-manager

I installed both together and found that ingress-nginx went into a failed state, apparently because cert-manager wasn't ready in time for its timeout.

There is also a typo where it looks like the `cert-mnager` HelmRelease was copied to make the ingress-nginx HR and it has still the old misspelled releaseName, fixed here. Maybe wrap the cert-manager dependency in a similar lookup and this would be OK? (What has me stumped and I have to come back to, you can probably solve quickly, how to concatenate the strings in go templates for the lookup for the cert-manager helmrelease...)

I'm not able to test further today, but here are some suggestions 🌡️ 