### PR TITLE
Fine-tuning Flux configuration

### DIFF
--- a/packages/apps/kubernetes/templates/helmreleases/cert-manager.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/cert-manager.yaml
@@ -7,7 +7,7 @@ metadata:
     cozystack.io/repository: system
     coztstack.io/target-cluster-name: {{ .Release.Name }}
 spec:
-  interval: 1m
+  interval: 5m
   releaseName: cert-manager
   chart:
     spec:
@@ -24,6 +24,11 @@ spec:
   storageNamespace: cozy-cert-manager
   install:
     createNamespace: true
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
   dependsOn:
   {{- if lookup "helm.toolkit.fluxcd.io/v2" "HelmRelease" .Release.Namespace .Release.Name }}
   - name: {{ .Release.Name }}

--- a/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
@@ -6,7 +6,7 @@ metadata:
     cozystack.io/repository: system
     coztstack.io/target-cluster-name: {{ .Release.Name }}
 spec:
-  interval: 1m
+  interval: 5m
   releaseName: cilium
   chart:
     spec:
@@ -23,6 +23,11 @@ spec:
   storageNamespace: cozy-cilium
   install:
     createNamespace: true
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
   values:
     cilium:
       tunnel: disabled

--- a/packages/apps/kubernetes/templates/helmreleases/csi.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/csi.yaml
@@ -6,7 +6,7 @@ metadata:
     cozystack.io/repository: system
     coztstack.io/target-cluster-name: {{ .Release.Name }}
 spec:
-  interval: 1m
+  interval: 5m
   releaseName: csi
   chart:
     spec:
@@ -23,6 +23,11 @@ spec:
   storageNamespace: cozy-csi
   install:
     createNamespace: true
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
   dependsOn:
   {{- if lookup "helm.toolkit.fluxcd.io/v2" "HelmRelease" .Release.Namespace .Release.Name }}
   - name: {{ .Release.Name }}

--- a/packages/apps/kubernetes/templates/helmreleases/fluxcd.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/fluxcd.yaml
@@ -7,7 +7,7 @@ metadata:
     cozystack.io/repository: system
     coztstack.io/target-cluster-name: {{ .Release.Name }}
 spec:
-  interval: 1m
+  interval: 5m
   releaseName: fluxcd-operator
   chart:
     spec:
@@ -24,6 +24,11 @@ spec:
   storageNamespace: cozy-fluxcd
   install:
     createNamespace: true
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
   values:
     flux-operator:
       fullnameOverride: flux-operator
@@ -45,7 +50,7 @@ metadata:
     cozystack.io/repository: system
     coztstack.io/target-cluster-name: {{ .Release.Name }}
 spec:
-  interval: 1m
+  interval: 5m
   releaseName: fluxcd
   chart:
     spec:
@@ -62,6 +67,11 @@ spec:
   storageNamespace: cozy-fluxcd
   install:
     createNamespace: true
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
   dependsOn:
   {{- if lookup "helm.toolkit.fluxcd.io/v2" "HelmRelease" .Release.Namespace .Release.Name }}
   - name: {{ .Release.Name }}

--- a/packages/apps/kubernetes/templates/helmreleases/ingress-nginx.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/ingress-nginx.yaml
@@ -7,7 +7,7 @@ metadata:
     cozystack.io/repository: system
     coztstack.io/target-cluster-name: {{ .Release.Name }}
 spec:
-  interval: 1m
+  interval: 5m
   releaseName: ingress-nginx
   chart:
     spec:
@@ -24,6 +24,11 @@ spec:
   storageNamespace: cozy-ingress-nginx
   install:
     createNamespace: true
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
   values:
     ingress-nginx:
       fullnameOverride: ingress-nginx

--- a/packages/core/platform/templates/helmreleases.yaml
+++ b/packages/core/platform/templates/helmreleases.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     cozystack.io/repository: system
 spec:
-  interval: 1m
+  interval: 5m
   releaseName: {{ $x.releaseName | default $x.name }}
   install:
     crds: CreateReplace


### PR DESCRIPTION
Fix #195

Don't set the `interval` so short on HelmReleases, with this many HelmReleases that really hamstrings the control plane.

Also, copy the install/upgrade remediation config from system packages to the Kubernetes templates for addon packages (cilium, flux, ingress) - in my testing the ingress-nginx chart fails every time the first time. Maybe that should be filed as a separate issue, I haven't looked into detail, it is some issue related to a secret not being created, I think it said something related to an admission controller.

Looks as though it's a conflict with being installed at the same time as the cert-manager addon.