### PR TITLE
hotfix: handle missing flux-operator release during upgrade

### DIFF
--- a/packages/core/installer/images/cozystack.json
+++ b/packages/core/installer/images/cozystack.json
@@ -1,10 +1,10 @@
 {
-  "buildx.build.ref": "priceless_leavitt/priceless_leavitt0/bkyp0lfy9cwyxbqtk2t3sl0ki",
+  "buildx.build.ref": "priceless_leavitt/priceless_leavitt0/cyr9s3a1cszjq9tt9vrh2czxt",
   "containerimage.descriptor": {
     "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
-    "digest": "sha256:539c8bc610ecee7ea8d1b728020b6131eb5e46aafe40d5a4d85e8cf79fae3c72",
+    "digest": "sha256:48e9f676f4eca5f7036648a56767c31beb0aca8fdc6d6798bd65de74886ed1ef",
     "size": 685
   },
-  "containerimage.digest": "sha256:539c8bc610ecee7ea8d1b728020b6131eb5e46aafe40d5a4d85e8cf79fae3c72",
+  "containerimage.digest": "sha256:48e9f676f4eca5f7036648a56767c31beb0aca8fdc6d6798bd65de74886ed1ef",
   "image.name": "ghcr.io/aenix-io/cozystack/cozystack:v0.8.0"
 }

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -27,14 +27,20 @@ ensure_fluxcd() {
   if flux_is_ok; then
     return
   fi
-  if kubectl get crd helmreleases.helm.toolkit.fluxcd.io helmrepositories.source.toolkit.fluxcd.io; then
-    targets="apply resume"
+  # Install fluxcd-operator
+  if kubectl get helmreleases.helm.toolkit.fluxcd.io  -n cozy-fluxcd fluxcd-operator; then
+    make -C packages/system/fluxcd-operator apply resume
   else
-    targets="apply-locally"
+    make -C packages/system/fluxcd-operator apply-locally
   fi
-  make -C packages/system/fluxcd-operator $targets
   wait_for_crds fluxinstances.fluxcd.controlplane.io
-  make -C packages/system/fluxcd $targets
+
+   # Install fluxcd
+  if kubectl get helmreleases.helm.toolkit.fluxcd.io  -n cozy-fluxcd fluxcd; then
+    make -C packages/system/fluxcd apply resume
+  else
+    make -C packages/system/fluxcd apply-locally
+  fi
   wait_for_crds helmreleases.helm.toolkit.fluxcd.io helmrepositories.source.toolkit.fluxcd.io
 }
 


### PR DESCRIPTION
image to test:

```
ghcr.io/aenix-io/cozystack/cozystack:v0.8.0@sha256:48e9f676f4eca5f7036648a56767c31beb0aca8fdc6d6798bd65de74886ed1ef
```


this PR should fix a problem of upgrading from older cozystack version

```
make: Leaving directory '/cozystack/packages/core/platform'
deployment.apps/source-controller condition met
deployment.apps/helm-controller condition met
Error from server (NotFound): helmreleases.helm.toolkit.fluxcd.io "fluxcd" not found
NAME                                        CREATED AT
helmreleases.helm.toolkit.fluxcd.io         2024-05-29T11:00:16Z
helmrepositories.source.toolkit.fluxcd.io   2024-05-29T11:00:17Z
make: Entering directory '/cozystack/packages/system/fluxcd-operator'
kubectl patch hr -n cozy-fluxcd fluxcd-operator -p '{"spec": {"suspend": true}}' --type=merge --field-manager=flux-client-side-apply
Error from server (NotFound): helmreleases.helm.toolkit.fluxcd.io "fluxcd-operator" not found
make: *** [../../../scripts/package-system.mk:20: suspend] Error 1
make: Leaving directory '/cozystack/packages/system/fluxcd-operator'
time="2024-07-04T12:50:05Z" level=fatal msg="failed to run" err="exit status 2"
```