### PR TITLE
Fix nginx config error parsing configmap

### DIFF
--- a/packages/system/ingress-nginx/values.yaml
+++ b/packages/system/ingress-nginx/values.yaml
@@ -32,8 +32,8 @@ ingress-nginx:
       #real-ip-header: "proxy_protocol"
       #enable-real-ip: "true"
       # keep-alive
-      proxy-connect-timeout: "10s"
-      proxy-read-timeout: "10s"
+      proxy-connect-timeout: "10"
+      proxy-read-timeout: "10"
       keep-alive-requests: "1000000"
       upstream-keepalive-requests: "100000"
       upstream-keepalive-time: '1m'


### PR DESCRIPTION
The error manifests as:

W0705 16:07:35.694677       7 configmap.go:431] unexpected error merging defaults: 2 error(s) decoding:

* cannot parse 'proxy-connect-timeout' as int: strconv.ParseInt: parsing "10s": invalid syntax
* cannot parse 'proxy-read-timeout' as int: strconv.ParseInt: parsing "10s": invalid syntax

I came across this trying to understand why my nginx ingress addon config isn't working, (this didn't help, but at least the warning is gone now.)

I'll continue to try to debug, but I think this can merge any time