### PR TITLE
Fix nginx error related to passthrough TLS

### DIFF
--- a/packages/system/ingress-nginx/values.yaml
+++ b/packages/system/ingress-nginx/values.yaml
@@ -1,7 +1,7 @@
 ingress-nginx:
   controller:
     extraArgs:
-      enable-ssl-passthrough: true
+      enable-ssl-passthrough: ""
     image:
       registry: ghcr.io
       image: kvaps/ingress-nginx-with-protobuf-exporter/controller


### PR DESCRIPTION
I don't understand why "true" value isn't accepted here, but I have seen this before. The `--enable-ssl-passthrough` parameter is not supposed to accept any value, it's a stand-alone argument.

With this change I get my traffic appropriately passed through to backend ingress on a kubevirt cluster that enabled TLS

Without it (the change is made on the addon ingress, which is very strange, because that one isn't even configured to use a passthrough annotation... the root ingress controller doesn't seem to care) I get this error:

> 400 Bad Request
> The plain HTTP request was sent to HTTPS port
> ---
> nginx