### PR TITLE
fixed the COZYSTACK_INSTALLER_YAML checking

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ '$COZYSTACK_INSTALLER_YAML' = '' ]; then
+if [ -z "$COZYSTACK_INSTALLER_YAML" ]; then
   echo 'COZYSTACK_INSTALLER_YAML variable is not set!' >&2
   echo 'please set it with following command:' >&2
   echo >&2

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ "$COZYSTACK_INSTALLER_YAML" = "" ]; then
+if [ '$COZYSTACK_INSTALLER_YAML' = '' ]; then
   echo 'COZYSTACK_INSTALLER_YAML variable is not set!' >&2
   echo 'please set it with following command:' >&2
   echo >&2


### PR DESCRIPTION
this change fix the checking for COZYSTACK_INSTALLER_YAML environment variable 
the issue was the check was comparing it to a  variable expansion rather then a literal variable.

Signed-off-by: Baga6312 <magroubertn@gmai.com>