### PR TITLE
fix: scraping ingress-nginx metrics

### DIFF
--- a/packages/extra/ingress/Chart.yaml
+++ b/packages/extra/ingress/Chart.yaml
@@ -3,4 +3,4 @@ name: ingress
 description: NGINX Ingress Controller
 icon: https://docs.nginx.com/nginx-ingress-controller/images/icons/NGINX-Ingress-Controller-product-icon.svg
 type: application
-version: 1.1.0
+version: 1.2.0

--- a/packages/extra/ingress/templates/nginx-scrape.yaml
+++ b/packages/extra/ingress/templates/nginx-scrape.yaml
@@ -3,12 +3,11 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMPodScrape
 metadata:
   name: nginx-ingress-controller
-  namespace: cozy-monitoring
 spec:
   jobLabel: jobLabel
   namespaceSelector:
     matchNames:
-    - cozy-ingress-nginx
+    - {{ .Release.Namespace }}
   podMetricsEndpoints:
   - port: metrics
     honorLabels: true
@@ -29,12 +28,11 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMPodScrape
 metadata:
   name: nginx-ingress-controller-detailed
-  namespace: cozy-monitoring
 spec:
   jobLabel: jobLabel
   namespaceSelector:
     matchNames:
-    - cozy-ingress-nginx
+    - {{ .Release.Namespace }}
   podMetricsEndpoints:
   - port: metrics2
     honorLabels: true

--- a/packages/extra/versions_map
+++ b/packages/extra/versions_map
@@ -3,6 +3,7 @@ etcd 2.0.0 a6d0f7cf
 etcd 2.0.1 6fc1cc7d
 etcd 2.1.0 HEAD
 ingress 1.0.0 f642698
-ingress 1.1.0 HEAD
+ingress 1.1.0 838bee5d
+ingress 1.2.0 HEAD
 monitoring 1.0.0 f642698
 monitoring 1.1.0 HEAD


### PR DESCRIPTION
Now grafana dashboards for ingress-nginx controller completely works!
![pic](https://github.com/user-attachments/assets/c2414cc7-9e0c-441e-9668-bf78ea3ef0c6)
![pic](https://github.com/user-attachments/assets/8ebe2488-0c53-4fc8-9e26-fc37e0047ebe)
![pic](https://github.com/user-attachments/assets/675a47b8-0304-4c58-9379-75e23c2db90f)
