### PR TITLE
postgres: automatically set schema permissions

### DIFF
--- a/packages/apps/postgres/Chart.yaml
+++ b/packages/apps/postgres/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/postgres/templates/init-script.yaml
+++ b/packages/apps/postgres/templates/init-script.yaml
@@ -53,47 +53,80 @@ stringData:
 
     echo "== grant privileges on databases to roles"
     {{- range $database, $d := .Values.databases }}
-
-    # admin
     psql -v ON_ERROR_STOP=1 --echo-all -d "{{ $database }}" <<\EOT
-    DO $$DECLARE r record;
+    ALTER DATABASE {{ $database }} OWNER TO {{ $database }}_admin;
+    GRANT CONNECT ON DATABASE {{ $database }} TO {{ $database }}_readonly;
+
+    DO $$
     DECLARE
-        v_schema varchar := 'public';
-        v_new_owner varchar := '{{ $database }}_admin';
+        schema_record record;
     BEGIN
-        FOR r IN
-            select 'ALTER TABLE "' || table_schema || '"."' || table_name || '" OWNER TO ' || v_new_owner || ';' as a from information_schema.tables where table_schema = v_schema
-            union all
-            select 'ALTER TABLE "' || sequence_schema || '"."' || sequence_name || '" OWNER TO ' || v_new_owner || ';' as a from information_schema.sequences where sequence_schema = v_schema
-            union all
-            select 'ALTER TABLE "' || table_schema || '"."' || table_name || '" OWNER TO ' || v_new_owner || ';' as a from information_schema.views where table_schema = v_schema
-            union all
-            select 'ALTER FUNCTION "'||nsp.nspname||'"."'||p.proname||'"('||pg_get_function_identity_arguments(p.oid)||') OWNER TO ' || v_new_owner || ';' as a from pg_proc p join pg_namespace nsp ON p.pronamespace = nsp.oid where nsp.nspname = v_schema
-        LOOP
-            EXECUTE r.a;
+        -- Loop over all schemas
+        FOR schema_record IN SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN ('pg_catalog', 'information_schema') LOOP
+            -- Changing Schema Ownership
+            EXECUTE format('ALTER SCHEMA %I OWNER TO %I', schema_record.schema_name, '{{ $database }}_admin');
+    
+            -- Add rights for the admin role
+            EXECUTE format('GRANT ALL ON SCHEMA %I TO %I', schema_record.schema_name, '{{ $database }}_admin');
+            EXECUTE format('GRANT ALL ON ALL TABLES IN SCHEMA %I TO %I', schema_record.schema_name, '{{ $database }}_admin');
+            EXECUTE format('GRANT ALL ON ALL SEQUENCES IN SCHEMA %I TO %I', schema_record.schema_name, '{{ $database }}_admin');
+            EXECUTE format('GRANT ALL ON ALL FUNCTIONS IN SCHEMA %I TO %I', schema_record.schema_name, '{{ $database }}_admin');
+            EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON TABLES TO %I', schema_record.schema_name, '{{ $database }}_admin');
+            EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON SEQUENCES TO %I', schema_record.schema_name, '{{ $database }}_admin');
+            EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON FUNCTIONS TO %I', schema_record.schema_name, '{{ $database }}_admin');
+    
+            -- Add rights for the readonly role
+            EXECUTE format('GRANT USAGE ON SCHEMA %I TO %I', schema_record.schema_name, '{{ $database }}_readonly');
+            EXECUTE format('GRANT SELECT ON ALL TABLES IN SCHEMA %I TO %I', schema_record.schema_name, '{{ $database }}_readonly');
+            EXECUTE format('GRANT USAGE ON ALL SEQUENCES IN SCHEMA %I TO %I', schema_record.schema_name, '{{ $database }}_readonly');
+            EXECUTE format('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA %I TO %I', schema_record.schema_name, '{{ $database }}_readonly');
+            EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT SELECT ON TABLES TO %I', schema_record.schema_name, '{{ $database }}_readonly');
+            EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT USAGE ON SEQUENCES TO %I', schema_record.schema_name, '{{ $database }}_readonly');
+            EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT EXECUTE ON FUNCTIONS TO %I', schema_record.schema_name, '{{ $database }}_readonly');
         END LOOP;
     END$$;
-    ALTER DATABASE {{ $database }} OWNER TO {{ $database }}_admin;
-    ALTER SCHEMA public OWNER TO {{ $database }}_admin;
-    GRANT ALL ON SCHEMA public TO {{ $database }}_admin;
-    GRANT ALL ON ALL TABLES IN SCHEMA public TO {{ $database }}_admin;
-    GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO {{ $database }}_admin;
-    GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO {{ $database }}_admin;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO {{ $database }}_admin;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {{ $database }}_admin;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {{ $database }}_admin;
     EOT
 
-    # readonly
+    echo "== setup event trigger for schema creation"
     psql -v ON_ERROR_STOP=1 --echo-all -d "{{ $database }}" <<\EOT
-    GRANT CONNECT ON DATABASE {{ $database }} TO {{ $database }}_readonly;
-    GRANT USAGE ON SCHEMA public TO {{ $database }}_readonly;
-    GRANT SELECT ON ALL TABLES IN SCHEMA public TO {{ $database }}_readonly;
-    GRANT USAGE ON ALL SEQUENCES IN SCHEMA public TO {{ $database }}_readonly;
-    GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO {{ $database }}_readonly;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO {{ $database }}_readonly;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE ON SEQUENCES TO {{ $database }}_readonly;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT EXECUTE ON FUNCTIONS TO {{ $database }}_readonly;
+    CREATE OR REPLACE FUNCTION auto_grant_schema_privileges()
+    RETURNS event_trigger LANGUAGE plpgsql AS $$
+    DECLARE
+      obj record;
+    BEGIN
+      FOR obj IN SELECT * FROM pg_event_trigger_ddl_commands() WHERE command_tag = 'CREATE SCHEMA' LOOP
+        EXECUTE format('ALTER SCHEMA %I OWNER TO %I', obj.object_identity, '{{ $database }}_admin');
+        EXECUTE format('GRANT ALL ON SCHEMA %I TO %I', obj.object_identity, '{{ $database }}_admin');
+        EXECUTE format('GRANT USAGE ON SCHEMA %I TO %I', obj.object_identity, '{{ $database }}_readonly');
+        EXECUTE format('GRANT SELECT ON ALL TABLES IN SCHEMA %I TO %I', obj.object_identity, '{{ $database }}_readonly');
+        EXECUTE format('GRANT USAGE ON ALL SEQUENCES IN SCHEMA %I TO %I', obj.object_identity, '{{ $database }}_readonly');
+        EXECUTE format('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA %I TO %I', obj.object_identity, '{{ $database }}_readonly');
+
+        -- Set owner for schema
+        EXECUTE format('ALTER SCHEMA %I OWNER TO %I', obj.object_identity, '{{ $database }}_admin');
+
+        -- Set privileges for admin role
+        EXECUTE format('GRANT ALL ON SCHEMA %I TO %I', obj.object_identity, '{{ $database }}_admin');
+        EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON TABLES TO %I', obj.object_identity, '{{ $database }}_admin');
+        EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON SEQUENCES TO %I', obj.object_identity, '{{ $database }}_admin');
+        EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON FUNCTIONS TO %I', obj.object_identity, '{{ $database }}_admin');
+
+        -- Set privileges for readonly role
+        EXECUTE format('GRANT USAGE ON SCHEMA %I TO %I', obj.object_identity, '{{ $database }}_readonly');
+        EXECUTE format('GRANT SELECT ON ALL TABLES IN SCHEMA %I TO %I', obj.object_identity, '{{ $database }}_readonly');
+        EXECUTE format('GRANT USAGE ON ALL SEQUENCES IN SCHEMA %I TO %I', obj.object_identity, '{{ $database }}_readonly');
+        EXECUTE format('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA %I TO %I', obj.object_identity, '{{ $database }}_readonly');
+        EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT SELECT ON TABLES TO %I', obj.object_identity, '{{ $database }}_readonly');
+        EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT USAGE ON SEQUENCES TO %I', obj.object_identity, '{{ $database }}_readonly');
+        EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT EXECUTE ON FUNCTIONS TO %I', obj.object_identity, '{{ $database }}_readonly');
+      END LOOP;
+    END;
+    $$;
+
+    DROP EVENT TRIGGER IF EXISTS trigger_auto_grant;
+    CREATE EVENT TRIGGER trigger_auto_grant ON ddl_command_end
+    WHEN TAG IN ('CREATE SCHEMA')
+    EXECUTE PROCEDURE auto_grant_schema_privileges();
     EOT
     {{- end }}
 

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -18,7 +18,8 @@ mysql 0.3.0 HEAD
 postgres 0.1.0 f642698
 postgres 0.2.0 7cd7de73
 postgres 0.2.1 4a97e297
-postgres 0.3.0 HEAD
+postgres 0.3.0 995dea6f
+postgres 0.4.0 HEAD
 rabbitmq 0.1.0 f642698
 rabbitmq 0.2.0 HEAD
 redis 0.1.1 f642698


### PR DESCRIPTION
This PR refactors postgress configuration script:
- Added event trigger on creating new schemas for automatically set owner
- Refactored logic for fixing permissions for all objects in all schemas