### PR TITLE
Unsuspend system helmreleases on cozystack restart

### DIFF
--- a/packages/core/platform/templates/helmreleases.yaml
+++ b/packages/core/platform/templates/helmreleases.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: {{ $x.namespace }}
   labels:
     cozystack.io/repository: system
+    cozystack.io/system-app: "true"
 spec:
   interval: 5m
   releaseName: {{ $x.releaseName | default $x.name }}

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -79,6 +79,11 @@ fi
 # Reconcile Helm repositories
 kubectl annotate helmrepositories.source.toolkit.fluxcd.io -A -l cozystack.io/repository reconcile.fluxcd.io/requestedAt=$(date +"%Y-%m-%dT%H:%M:%SZ") --overwrite
 
+# Unsuspend all system charts
+kubectl get hr -A -l cozystack.io/system-app=true --no-headers | while read namespace name rest; do
+  kubectl patch hr -n "$namespace" "$name" -p '{"spec": {"suspend": null}}' --type=merge --field-manager=flux-client-side-apply
+done
+
 # Reconcile platform chart
 trap 'exit' INT TERM
 while true; do


### PR DESCRIPTION
Developers ofthen forget to unsuspend helm releases after the local development (I do!)
This change make ensure that all system helm charts are getting reconciled by flux after cozystack container restart