### PR TITLE
Rename system releases to have -system suffix

### DIFF
--- a/packages/extra/ingress/Chart.yaml
+++ b/packages/extra/ingress/Chart.yaml
@@ -3,4 +3,4 @@ name: ingress
 description: NGINX Ingress Controller
 icon: https://docs.nginx.com/nginx-ingress-controller/images/icons/NGINX-Ingress-Controller-product-icon.svg
 type: application
-version: 1.2.0
+version: 1.3.0

--- a/packages/extra/ingress/templates/nginx-ingress.yaml
+++ b/packages/extra/ingress/templates/nginx-ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: ingress-nginx
+  name: ingress-nginx-system
 spec:
   chart:
     spec:

--- a/packages/extra/monitoring/Chart.yaml
+++ b/packages/extra/monitoring/Chart.yaml
@@ -3,4 +3,4 @@ name: monitoring
 description: Monitoring and observability stack
 icon: https://www.svgrepo.com/download/184787/analytics-laptop.svg
 type: application
-version: 1.1.0
+version: 1.2.0

--- a/packages/extra/monitoring/templates/oncall/oncall-release.yaml
+++ b/packages/extra/monitoring/templates/oncall/oncall-release.yaml
@@ -4,7 +4,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: grafana-oncall
+  name: grafana-oncall-system
   labels:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/packages/extra/versions_map
+++ b/packages/extra/versions_map
@@ -4,6 +4,8 @@ etcd 2.0.1 6fc1cc7d
 etcd 2.1.0 HEAD
 ingress 1.0.0 f642698
 ingress 1.1.0 838bee5d
-ingress 1.2.0 HEAD
+ingress 1.2.0 07d666c0
+ingress 1.3.0 HEAD
 monitoring 1.0.0 f642698
-monitoring 1.1.0 HEAD
+monitoring 1.1.0 15478a88
+monitoring 1.2.0 HEAD


### PR DESCRIPTION
Some software is managed without operator. We store Helm charts for them in system packages and have operator-like logic for installation via FluxCD releases.

This PR changes the name of such releases to have cozy- prefix to have the same standard naming of such charts and do not conflict with user names.

**why is it needed**

Eg. `nats` is not inteneded to be installed via operator, they are prefer the helm-like approach. The same hapening with ingress-nginx controller and grafana-oncall

I purpose to name all of such charts (installed by flux for the user) with `cozy` prefix.
Thus user currently might install user-faced `nats` helm chart with user-specific parameters, later they will be propogated to `cozy-nats` chart managed by FluxCD.