### PR TITLE
fix kubevirt infrastructure-provider version

### DIFF
--- a/packages/system/capi-providers/templates/providers.yaml
+++ b/packages/system/capi-providers/templates/providers.yaml
@@ -28,5 +28,5 @@ kind: InfrastructureProvider
 metadata:
   name: kubevirt
 spec:
-  # https://github.com/kubevirt/cloud-provider-kubevirt
-  version: v0.5.1
+  # https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt
+  version: v0.1.8


### PR DESCRIPTION
Fix wrong version for KubeVirt CAPI provider