### PR TITLE
release 0.10.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ build:
 	make -C packages/system/cilium image
 	make -C packages/system/kubeovn image
 	make -C packages/system/dashboard image
+	make -C packages/system/kamaji image
 	make -C packages/core/installer image
 	make manifests
 

--- a/manifests/cozystack-installer.yaml
+++ b/manifests/cozystack-installer.yaml
@@ -68,7 +68,7 @@ spec:
       serviceAccountName: cozystack
       containers:
       - name: cozystack
-        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.10.1"
+        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.10.2"
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: localhost
@@ -87,7 +87,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
       - name: darkhttpd
-        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.10.1"
+        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.10.2"
         command:
         - /usr/bin/darkhttpd
         - /cozystack/assets

--- a/manifests/cozystack-installer.yaml
+++ b/manifests/cozystack-installer.yaml
@@ -68,7 +68,7 @@ spec:
       serviceAccountName: cozystack
       containers:
       - name: cozystack
-        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.10.2"
+        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.10.3"
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: localhost
@@ -87,7 +87,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
       - name: darkhttpd
-        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.10.2"
+        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.10.3"
         command:
         - /usr/bin/darkhttpd
         - /cozystack/assets

--- a/packages/apps/http-cache/images/nginx-cache.json
+++ b/packages/apps/http-cache/images/nginx-cache.json
@@ -32,17 +32,17 @@
       }
     }
   },
-  "buildx.build.ref": "cozystack/cozystack0/7j4plhjjn8onm0o8q0omik63x",
-  "containerimage.config.digest": "sha256:f30f57d817c596f7a7d0ecfe734b7b41994eca9d36d43307206314ee37bdb286",
+  "buildx.build.ref": "cozystack/cozystack0/spml9ia4vkl6wxfboxgso9jnd",
+  "containerimage.config.digest": "sha256:4bfe7bdc746d0f7db6d8fccb4ef68c8b1dc2306c27e2716f589dee951bf86a03",
   "containerimage.descriptor": {
     "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-    "digest": "sha256:f7d86b1a72a12b60434a12a604e9ddd3779d9fa605205c7968fe9495e764c94c",
+    "digest": "sha256:6b5dbb5319ddcf9f545ba0f7b8b3f2117e85bc96e684b5e3adf23e0fef5dde8d",
     "size": 1094,
     "platform": {
       "architecture": "amd64",
       "os": "linux"
     }
   },
-  "containerimage.digest": "sha256:f7d86b1a72a12b60434a12a604e9ddd3779d9fa605205c7968fe9495e764c94c",
-  "image.name": "ghcr.io/aenix-io/cozystack/nginx-cache:v0.1.0,ghcr.io/aenix-io/cozystack/nginx-cache:v0.1.0-v0.10.1"
+  "containerimage.digest": "sha256:6b5dbb5319ddcf9f545ba0f7b8b3f2117e85bc96e684b5e3adf23e0fef5dde8d",
+  "image.name": "ghcr.io/aenix-io/cozystack/nginx-cache:v0.1.0,ghcr.io/aenix-io/cozystack/nginx-cache:v0.1.0-v0.10.3"
 }

--- a/packages/apps/kubernetes/Chart.yaml
+++ b/packages/apps/kubernetes/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.8.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/kubernetes/Chart.yaml
+++ b/packages/apps/kubernetes/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/kubernetes/images/ubuntu-container-disk.json
+++ b/packages/apps/kubernetes/images/ubuntu-container-disk.json
@@ -32,7 +32,7 @@
       }
     }
   },
-  "buildx.build.ref": "cozystack/cozystack0/xkanpm0dojuj7v0lo951qocfb",
+  "buildx.build.ref": "cozystack/cozystack0/zie1df5xk0xb5lj1fmedk76qx",
   "containerimage.config.digest": "sha256:c144c5f12a47af7880ee5f056b14177c07b585b8ab1e68b7e7900e1c923083cf",
   "containerimage.descriptor": {
     "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
@@ -44,5 +44,5 @@
     }
   },
   "containerimage.digest": "sha256:81caf89efe252ae2ca1990d08a3a314552d70ff36bcd4022b173c7150fbec805",
-  "image.name": "ghcr.io/aenix-io/cozystack/ubuntu-container-disk:v1.30.1,ghcr.io/aenix-io/cozystack/ubuntu-container-disk:v1.30.1-v0.10.1"
+  "image.name": "ghcr.io/aenix-io/cozystack/ubuntu-container-disk:v1.30.1,ghcr.io/aenix-io/cozystack/ubuntu-container-disk:v1.30.1-v0.10.3"
 }

--- a/packages/apps/kubernetes/templates/ingress.yaml
+++ b/packages/apps/kubernetes/templates/ingress.yaml
@@ -10,9 +10,8 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: AUTO_HTTP
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($scheme = http) {
-        set $proxy_upstream_name "tenant-root-kubernetes-infra-ingress-nginx-80";
+        set $proxy_upstream_name "{{ .Release.Namespace }}-{{ .Release.Name }}-ingress-nginx-80";
         set $proxy_host $proxy_upstream_name;
-        set $service_port 80;
       }
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"

--- a/packages/apps/kubernetes/templates/ingress.yaml
+++ b/packages/apps/kubernetes/templates/ingress.yaml
@@ -7,16 +7,15 @@ kind: Ingress
 metadata:
   name: {{ .Release.Name }}-ingress-nginx
   annotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    nginx.ingress.kubernetes.io/backend-protocol: "AUTO_HTTP"
+    nginx.ingress.kubernetes.io/backend-protocol: AUTO_HTTP
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      set $proxy_upstream_name "{{ .Release.Namespace }}-{{ .Release.Name }}-ingress-nginx-80";
-      if ($scheme = https) {
-        set $proxy_upstream_name "{{ .Release.Namespace }}-{{ .Release.Name }}-ingress-nginx-443";
-        set $service_port 443;
+      if ($scheme = http) {
+        set $proxy_upstream_name "tenant-root-kubernetes-infra-ingress-nginx-80";
+        set $proxy_host $proxy_upstream_name;
+        set $service_port 80;
       }
-      set $proxy_host $proxy_upstream_name;
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: "{{ $ingress }}"
   rules:
@@ -30,14 +29,14 @@ spec:
           service:
             name: {{ $.Release.Name }}-ingress-nginx
             port:
-              number: 80
+              number: 443
       - path: /
         pathType: ImplementationSpecific
         backend:
           service:
             name: {{ $.Release.Name }}-ingress-nginx
             port:
-              number: 443
+              number: 80
   {{- end }}
 ---
 apiVersion: v1

--- a/packages/apps/tenant/Chart.yaml
+++ b/packages/apps/tenant/Chart.yaml
@@ -4,4 +4,4 @@ description: Separated tenant namespace
 icon: /logos/tenant.svg
 
 type: application
-version: 1.3.0
+version: 1.3.1

--- a/packages/apps/tenant/templates/namespace.yaml
+++ b/packages/apps/tenant/templates/namespace.yaml
@@ -21,6 +21,15 @@ metadata:
     namespace.cozystack.io/{{ $x }}: "{{ index $existingNS.metadata.annotations (printf "namespace.cozystack.io/%s" $x) | required (printf "namespace %s has no namespace.cozystack.io/%s annotation" $.Release.Namespace $x) }}"
     {{- end }}
     {{- end }}
+  labels:
+    {{- if hasPrefix "tenant-" .Release.Namespace }}
+    {{- $parts := splitList "-" .Release.Namespace }}
+    {{- range $i, $v := $parts }}
+    {{- if ne $i 0 }}
+    tenant.cozystack.io/{{ join "-" (slice $parts 0 (add $i 1)) }}: ""
+    {{- end }}
+    {{- end }}
+    {{- end }}
   ownerReferences:
   - apiVersion: v1
     blockOwnerDeletion: true

--- a/packages/apps/tenant/templates/networkpolicy.yaml
+++ b/packages/apps/tenant/templates/networkpolicy.yaml
@@ -28,17 +28,6 @@ spec:
   - toEntities:
       - world
 ---
-apiVersion: cilium.io/v2
-kind: CiliumNetworkPolicy
-metadata:
-  name: allow-from-system
-  namespace: {{ include "tenant.name" . }}
-spec:
-  endpointSelector: {}
-  ingress:
-  - fromEntities:
-    - cluster
----
 {{- if ne (include "tenant.name" .) "tenant-root" }}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -49,35 +38,63 @@ spec:
   endpointSelector: {}
   ingress:
   - fromEndpoints:
-    - matchLabels:
-        "kubernetes.io/metadata.name": "tenant-root"
     {{- if hasPrefix "tenant-" .Release.Namespace }}
     {{- $parts := splitList "-" .Release.Namespace }}
     {{- range $i, $v := $parts }}
     {{- if ne $i 0 }}
     - matchLabels:
-        "kubernetes.io/metadata.name": {{ join "-" (slice $parts 0 (add $i 1)) }}
+        "k8s:io.kubernetes.pod.namespace": {{ join "-" (slice $parts 0 (add $i 1)) }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-to-upper-tenants
+  namespace: {{ include "tenant.name" . }}
+spec:
+  endpointSelector: {}
+  egress:
+  - toEndpoints:
+    {{- if hasPrefix "tenant-" .Release.Namespace }}
+    {{- $parts := splitList "-" .Release.Namespace }}
+    {{- range $i, $v := $parts }}
+    {{- if ne $i 0 }}
+    - matchLabels:
+        "k8s:io.kubernetes.pod.namespace": {{ join "-" (slice $parts 0 (add $i 1)) }}
     {{- end }}
     {{- end }}
     {{- end }}
 {{- end }}
 ---
-{{- if not .Values.etcd }}
-{{- $existingNS := lookup "v1" "Namespace" "" .Release.Namespace }}
 apiVersion: cilium.io/v2
-kind: CiliumNetworkPolicy
+kind: CiliumClusterwideNetworkPolicy
 metadata:
-  name: allow-to-etcd
-  namespace: {{ include "tenant.name" . }}
+  name: "allow-to-down-labels-{{ include "tenant.name" . }}"
 spec:
   endpointSelector:
     matchLabels:
-      policy.cozystack.io/allow-to-etcd: "true"
+      k8s:io.kubernetes.pod.namespace: "{{ include "tenant.name" . }}"
   egress:
   - toEndpoints:
     - matchLabels:
-        io.kubernetes.pod.namespace: "{{ index $existingNS.metadata.annotations "namespace.cozystack.io/etcd" }}"
-        cozystack.io/service: etcd
+        "k8s:io.cilium.k8s.namespace.labels.tenant.cozystack.io/{{ include "tenant.name" . }}": ""
+---
+{{- if .Values.etcd }}
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "allow-to-etcd-{{ include "tenant.name" . }}"
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s:io.kubernetes.pod.namespace: "{{ include "tenant.name" . }}"
+      cozystack.io/service: etcd
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        k8s:io.cilium.k8s.namespace.labels.namespace.cozystack.io/etcd: "{{ include "tenant.name" . }}"
 {{- end }}
 ---
 apiVersion: cilium.io/v2
@@ -107,7 +124,7 @@ spec:
   egress:
   - toEndpoints:
     - matchLabels:
-        io.kubernetes.pod.namespace: kube-system
+        k8s:io.kubernetes.pod.namespace: kube-system
         k8s-app: kube-dns
 ---
 apiVersion: cilium.io/v2
@@ -120,7 +137,7 @@ spec:
   egress:
   - toEndpoints:
       - matchLabels:
-          io.kubernetes.pod.namespace: cozy-dashboard
+          k8s:io.kubernetes.pod.namespace: cozy-dashboard
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -15,7 +15,8 @@ kubernetes 0.4.0 6cae6ce8
 kubernetes 0.5.0 6bd2d455
 kubernetes 0.6.0 4cbc8a2c
 kubernetes 0.7.0 ceefae03
-kubernetes 0.8.0 HEAD
+kubernetes 0.8.0 ac11056e
+kubernetes 0.8.1 HEAD
 mysql 0.1.0 f642698
 mysql 0.2.0 8b975ff0
 mysql 0.3.0 HEAD

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -39,7 +39,8 @@ tenant 0.1.5 e3ab858
 tenant 1.0.0 7cd7de7
 tenant 1.1.0 4da8ac3b
 tenant 1.2.0 15478a88
-tenant 1.3.0 HEAD
+tenant 1.3.0 ceefae03
+tenant 1.3.1 HEAD
 virtual-machine 0.1.4 f2015d6
 virtual-machine 0.1.5 7cd7de7
 virtual-machine 0.2.0 HEAD

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -16,7 +16,8 @@ kubernetes 0.5.0 6bd2d455
 kubernetes 0.6.0 4cbc8a2c
 kubernetes 0.7.0 ceefae03
 kubernetes 0.8.0 ac11056e
-kubernetes 0.8.1 HEAD
+kubernetes 0.8.1 e54608d8
+kubernetes 0.8.2 HEAD
 mysql 0.1.0 f642698
 mysql 0.2.0 8b975ff0
 mysql 0.3.0 HEAD

--- a/packages/core/installer/images/cozystack.json
+++ b/packages/core/installer/images/cozystack.json
@@ -1,10 +1,10 @@
 {
-  "buildx.build.ref": "cozystack/cozystack0/yrz86wtha0lfzho1mnejnjqe0",
+  "buildx.build.ref": "cozystack/cozystack0/90r2t47wnn545649ni2ch601y",
   "containerimage.descriptor": {
     "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
-    "digest": "sha256:dae1740df06a014e4014726792dac7a3c8b7eaa07e32857592e5462c92446659",
+    "digest": "sha256:a9744f1928c13c2f3ca2ab87ebe0d0d4531e35827668f4b449fbf8e5074f6218",
     "size": 685
   },
-  "containerimage.digest": "sha256:dae1740df06a014e4014726792dac7a3c8b7eaa07e32857592e5462c92446659",
-  "image.name": "ghcr.io/aenix-io/cozystack/cozystack:v0.10.2"
+  "containerimage.digest": "sha256:a9744f1928c13c2f3ca2ab87ebe0d0d4531e35827668f4b449fbf8e5074f6218",
+  "image.name": "ghcr.io/aenix-io/cozystack/cozystack:v0.10.3"
 }

--- a/packages/core/installer/images/cozystack.json
+++ b/packages/core/installer/images/cozystack.json
@@ -1,10 +1,10 @@
 {
-  "buildx.build.ref": "cozystack/cozystack0/zk58yqp4vkrfgx3gdjumn9k70",
+  "buildx.build.ref": "cozystack/cozystack0/yrz86wtha0lfzho1mnejnjqe0",
   "containerimage.descriptor": {
     "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
-    "digest": "sha256:b92988122fa68adc85751384170a46895b5761cc5bf27e80b0b53b12b89b6d6c",
+    "digest": "sha256:dae1740df06a014e4014726792dac7a3c8b7eaa07e32857592e5462c92446659",
     "size": 685
   },
-  "containerimage.digest": "sha256:b92988122fa68adc85751384170a46895b5761cc5bf27e80b0b53b12b89b6d6c",
-  "image.name": "ghcr.io/aenix-io/cozystack/cozystack:latest"
+  "containerimage.digest": "sha256:dae1740df06a014e4014726792dac7a3c8b7eaa07e32857592e5462c92446659",
+  "image.name": "ghcr.io/aenix-io/cozystack/cozystack:v0.10.2"
 }

--- a/packages/core/installer/images/cozystack.tag
+++ b/packages/core/installer/images/cozystack.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/cozystack:v0.10.2
+ghcr.io/aenix-io/cozystack/cozystack:v0.10.3

--- a/packages/core/installer/images/cozystack.tag
+++ b/packages/core/installer/images/cozystack.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/cozystack:latest
+ghcr.io/aenix-io/cozystack/cozystack:v0.10.2

--- a/packages/core/installer/images/matchbox.json
+++ b/packages/core/installer/images/matchbox.json
@@ -29,17 +29,17 @@
       }
     }
   },
-  "buildx.build.ref": "cozystack/cozystack0/bm9aw2403e2nzak1q98n4mzc1",
-  "containerimage.config.digest": "sha256:28731f7008e27eede20e5d5a464bd101ed949472b794e4239a0ff2721a02df69",
+  "buildx.build.ref": "cozystack/cozystack0/4ksaiyxq8uqy5iuedn1qyljdc",
+  "containerimage.config.digest": "sha256:4c52be2a28c48ad39af2664140b6b0476438b17e7a82685930a43f72405e1b2e",
   "containerimage.descriptor": {
     "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-    "digest": "sha256:20e05ccb6e5d34b707ec01046824bb9b5b367c87980a5842393654a14a4b14ad",
+    "digest": "sha256:200a449e1559cc5f2a207444ac16d40f3c2b03f5a04c90e32f5cb83ba072f55c",
     "size": 1488,
     "platform": {
       "architecture": "amd64",
       "os": "linux"
     }
   },
-  "containerimage.digest": "sha256:20e05ccb6e5d34b707ec01046824bb9b5b367c87980a5842393654a14a4b14ad",
-  "image.name": "ghcr.io/aenix-io/cozystack/matchbox:v0.10.2,ghcr.io/aenix-io/cozystack/matchbox:v1.7.1-v0.10.2"
+  "containerimage.digest": "sha256:200a449e1559cc5f2a207444ac16d40f3c2b03f5a04c90e32f5cb83ba072f55c",
+  "image.name": "ghcr.io/aenix-io/cozystack/matchbox:v0.10.3,ghcr.io/aenix-io/cozystack/matchbox:v1.7.1-v0.10.3"
 }

--- a/packages/core/installer/images/matchbox.json
+++ b/packages/core/installer/images/matchbox.json
@@ -29,17 +29,17 @@
       }
     }
   },
-  "buildx.build.ref": "cozystack/cozystack0/qu2ygr61roizh7ga2l4kkmdx6",
-  "containerimage.config.digest": "sha256:94aa5abc006ac672ccdd91b8d9361fd14de6e0b286299f4e44dd09002becc3b7",
+  "buildx.build.ref": "cozystack/cozystack0/bm9aw2403e2nzak1q98n4mzc1",
+  "containerimage.config.digest": "sha256:28731f7008e27eede20e5d5a464bd101ed949472b794e4239a0ff2721a02df69",
   "containerimage.descriptor": {
     "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-    "digest": "sha256:b1e6084402619dde9dcdc8251cd581cbfc3940c885e938547b7b7306376a411e",
+    "digest": "sha256:20e05ccb6e5d34b707ec01046824bb9b5b367c87980a5842393654a14a4b14ad",
     "size": 1488,
     "platform": {
       "architecture": "amd64",
       "os": "linux"
     }
   },
-  "containerimage.digest": "sha256:b1e6084402619dde9dcdc8251cd581cbfc3940c885e938547b7b7306376a411e",
-  "image.name": "ghcr.io/aenix-io/cozystack/matchbox:v0.10.1,ghcr.io/aenix-io/cozystack/matchbox:v1.7.1-v0.10.1"
+  "containerimage.digest": "sha256:20e05ccb6e5d34b707ec01046824bb9b5b367c87980a5842393654a14a4b14ad",
+  "image.name": "ghcr.io/aenix-io/cozystack/matchbox:v0.10.2,ghcr.io/aenix-io/cozystack/matchbox:v1.7.1-v0.10.2"
 }

--- a/packages/core/platform/bundles/distro-full.yaml
+++ b/packages/core/platform/bundles/distro-full.yaml
@@ -93,13 +93,13 @@ releases:
   releaseName: kafka-operator
   chart: cozy-kafka-operator
   namespace: cozy-kafka-operator
-  dependsOn: [cilium,kubeovn]
+  dependsOn: [cilium]
 
 - name: clickhouse-operator
   releaseName: clickhouse-operator
   chart: cozy-clickhouse-operator
   namespace: cozy-clickhouse-operator
-  dependsOn: [cilium,kubeovn]
+  dependsOn: [cilium]
 
 - name: rabbitmq-operator
   releaseName: rabbitmq-operator

--- a/packages/system/cilium/images/cilium.json
+++ b/packages/system/cilium/images/cilium.json
@@ -11,7 +11,7 @@
       {
         "uri": "pkg:docker/golang@1.22-bookworm?platform=linux%2Famd64",
         "digest": {
-          "sha256": "af9b40f2b1851be993763b85288f8434af87b5678af04355b1e33ff530b5765f"
+          "sha256": "39b7e6ebaca464d51989858871f792f2e186dce8ce0cbdba7e88e4444b244407"
         }
       },
       {
@@ -45,17 +45,17 @@
       }
     }
   },
-  "buildx.build.ref": "cozystack/cozystack0/3a5uyqqyj3lnwkgdniwjp341a",
-  "containerimage.config.digest": "sha256:db99b8b1e565f406af5b240b1ef76b5cc3ba1b510c6e035e1497c5089d65ee12",
+  "buildx.build.ref": "cozystack/cozystack0/s6wdt6414bz57mu5kdltf56s1",
+  "containerimage.config.digest": "sha256:e4a2ffa097cfead78a8e7623cf186d5f594e72e139e4dda5a06bcd1c58c6838e",
   "containerimage.descriptor": {
     "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-    "digest": "sha256:0e9fa8f6f5194b84227ea7e7b93ef77244b5550ec62671e04d398818dccfb282",
+    "digest": "sha256:8110f6b17ec98d87d9aebf3f4b99409f020840a958166e28c74b2d4e1bfb5a51",
     "size": 2083,
     "platform": {
       "architecture": "amd64",
       "os": "linux"
     }
   },
-  "containerimage.digest": "sha256:0e9fa8f6f5194b84227ea7e7b93ef77244b5550ec62671e04d398818dccfb282",
-  "image.name": "ghcr.io/aenix-io/cozystack/cilium:1.15.5,ghcr.io/aenix-io/cozystack/cilium:1.15.5-v0.10.1"
+  "containerimage.digest": "sha256:8110f6b17ec98d87d9aebf3f4b99409f020840a958166e28c74b2d4e1bfb5a51",
+  "image.name": "ghcr.io/aenix-io/cozystack/cilium:1.15.5,ghcr.io/aenix-io/cozystack/cilium:1.15.5-v0.10.3"
 }

--- a/packages/system/cilium/templates/clusterwide-networkpolicies.yaml
+++ b/packages/system/cilium/templates/clusterwide-networkpolicies.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-from-system
+spec:
+  endpointSelector: {}
+  ingress:
+  - fromEndpoints:
+      - matchLabels:
+          "k8s:io.cilium.k8s.namespace.labels.cozystack.io/system": "true"

--- a/packages/system/dashboard/images/dashboard.json
+++ b/packages/system/dashboard/images/dashboard.json
@@ -35,17 +35,17 @@
       }
     }
   },
-  "buildx.build.ref": "cozystack/cozystack0/puq8k1x2nsc986l15a2vanb8s",
-  "containerimage.config.digest": "sha256:2c68c6ce6620a8c8afd84fed1c2265738d661a47ded0be21b2517b0309ed7307",
+  "buildx.build.ref": "cozystack/cozystack0/k90p7qja1tca86jt2ozzg98a9",
+  "containerimage.config.digest": "sha256:27fc7abbe19e41a85443ae022a42f7166ef4334efba85a3e4059f92740f24620",
   "containerimage.descriptor": {
     "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-    "digest": "sha256:fdabfe2caa3fe2d92ca4a07b60a55c91163d7db25aa12cc4c6034c32ac1dcb17",
+    "digest": "sha256:8f206c2ae2bbaed8e76db45704c4f76945176d448a310ed77d1abbe1b89f8b7b",
     "size": 703,
     "platform": {
       "architecture": "amd64",
       "os": "linux"
     }
   },
-  "containerimage.digest": "sha256:fdabfe2caa3fe2d92ca4a07b60a55c91163d7db25aa12cc4c6034c32ac1dcb17",
-  "image.name": "ghcr.io/aenix-io/cozystack/dashboard:v0.10.1"
+  "containerimage.digest": "sha256:8f206c2ae2bbaed8e76db45704c4f76945176d448a310ed77d1abbe1b89f8b7b",
+  "image.name": "ghcr.io/aenix-io/cozystack/dashboard:v0.10.3"
 }

--- a/packages/system/dashboard/images/dashboard.tag
+++ b/packages/system/dashboard/images/dashboard.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/dashboard:v0.10.1
+ghcr.io/aenix-io/cozystack/dashboard:v0.10.3

--- a/packages/system/dashboard/images/kubeapps-apis.json
+++ b/packages/system/dashboard/images/kubeapps-apis.json
@@ -11,7 +11,7 @@
       {
         "uri": "pkg:docker/bitnami/minideb@bookworm?platform=linux%2Famd64",
         "digest": {
-          "sha256": "b13cb4b41be91e22858e9b050a51137b636a34694a92ff17c27cb010e5f93f04"
+          "sha256": "a43a80e7ccfee2af468eb2cb7fb9ab3a38a9c6a11d98556b7218674fa1a599a9"
         }
       },
       {
@@ -41,17 +41,17 @@
       }
     }
   },
-  "buildx.build.ref": "cozystack/cozystack0/nk99hhpt81cl5xu6eecdk86qs",
-  "containerimage.config.digest": "sha256:662ea8b8642d1c6662e5eef79ea8329863f5178a80457e1faf983506efe7a611",
+  "buildx.build.ref": "cozystack/cozystack0/umvwwe8i6d3s3gnn71z41y2c6",
+  "containerimage.config.digest": "sha256:a39c384b5a183e506c331f2fc1a4ab1b27f620bbc596407965fa9e7190a04ae4",
   "containerimage.descriptor": {
     "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-    "digest": "sha256:eaedcb64abd1c245bd2959c66df430d0fcbbb5968334501f484231707de7ed7d",
-    "size": 1890,
+    "digest": "sha256:3151eb381f7b8fe6a9b9a0ee5c3d99cfda7d708b2b89931b4288d22169da67af",
+    "size": 1891,
     "platform": {
       "architecture": "amd64",
       "os": "linux"
     }
   },
-  "containerimage.digest": "sha256:eaedcb64abd1c245bd2959c66df430d0fcbbb5968334501f484231707de7ed7d",
-  "image.name": "ghcr.io/aenix-io/cozystack/kubeapps-apis:v0.10.1"
+  "containerimage.digest": "sha256:3151eb381f7b8fe6a9b9a0ee5c3d99cfda7d708b2b89931b4288d22169da67af",
+  "image.name": "ghcr.io/aenix-io/cozystack/kubeapps-apis:v0.10.3"
 }

--- a/packages/system/dashboard/images/kubeapps-apis.tag
+++ b/packages/system/dashboard/images/kubeapps-apis.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/kubeapps-apis:v0.10.1
+ghcr.io/aenix-io/cozystack/kubeapps-apis:v0.10.3

--- a/packages/system/kamaji/Makefile
+++ b/packages/system/kamaji/Makefile
@@ -1,6 +1,7 @@
 export NAME=kamaji
 export NAMESPACE=cozy-$(NAME)
 
+include ../../../scripts/common-envs.mk
 include ../../../scripts/package-system.mk
 
 update:
@@ -8,3 +9,19 @@ update:
 	helm repo add clastix https://clastix.github.io/charts
 	helm repo update clastix
 	helm pull clastix/kamaji --untar --untardir charts
+
+image:
+	docker buildx build images/kamaji \
+		--provenance false \
+		--tag $(REGISTRY)/kamaji:$(call settag,$(TAG)) \
+		--cache-from type=registry,ref=$(REGISTRY)/kamaji:latest \
+		--cache-to type=inline \
+		--metadata-file images/kamaji.json \
+		--push=$(PUSH) \
+		--label "org.opencontainers.image.source=https://github.com/aenix-io/cozystack"
+		--load=$(LOAD)
+	REPOSITORY="$(REGISTRY)/kamaji" \
+		yq -i '.kamaji.image.repository = strenv(REPOSITORY)' values.yaml
+	TAG=$(TAG)@$$(yq e '."containerimage.digest"' images/kamaji.json -o json -r) \
+		yq -i '.kamaji.image.tag = strenv(TAG)' values.yaml
+	rm -f images/kamaji.json

--- a/packages/system/kamaji/images/kamaji/Dockerfile
+++ b/packages/system/kamaji/images/kamaji/Dockerfile
@@ -1,0 +1,25 @@
+# Build the manager binary
+FROM golang:1.22 as builder
+
+ARG VERSION=v1.0.0
+ARG TARGETOS TARGETARCH
+
+WORKDIR /workspace
+
+RUN curl -sSL https://github.com/clastix/kamaji/archive/refs/tags/v1.0.0.tar.gz | tar -xzvf- --strip=1
+
+COPY patches /patches
+RUN git apply /patches/enable-gc.diff
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build \
+    -ldflags "-X github.com/clastix/kamaji/internal.GitRepo=$GIT_REPO -X github.com/clastix/kamaji/internal.GitTag=$GIT_LAST_TAG -X github.com/clastix/kamaji/internal.GitCommit=$GIT_HEAD_COMMIT -X github.com/clastix/kamaji/internal.GitDirty=$GIT_MODIFIED -X github.com/clastix/kamaji/internal.BuildTime=$BUILD_DATE" \
+    -a -o kamaji main.go
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/kamaji .
+USER 65532:65532
+
+ENTRYPOINT ["/kamaji"]

--- a/packages/system/kamaji/images/kamaji/patches/enable-gc.diff
+++ b/packages/system/kamaji/images/kamaji/patches/enable-gc.diff
@@ -1,0 +1,30 @@
+diff --git a/internal/kubeadm/uploadconfig.go b/internal/kubeadm/uploadconfig.go
+index 0dc9e71..e516390 100644
+--- a/internal/kubeadm/uploadconfig.go
++++ b/internal/kubeadm/uploadconfig.go
+@@ -98,21 +98,15 @@ func getKubeletConfigmapContent(kubeletConfiguration KubeletConfiguration) ([]by
+ 				CacheUnauthorizedTTL: zeroDuration,
+ 			},
+ 		},
+-		CgroupDriver:              kubeletConfiguration.TenantControlPlaneCgroupDriver,
+-		ClusterDNS:                kubeletConfiguration.TenantControlPlaneDNSServiceIPs,
+-		ClusterDomain:             kubeletConfiguration.TenantControlPlaneDomain,
+-		CPUManagerReconcilePeriod: zeroDuration,
+-		EvictionHard: map[string]string{
+-			"imagefs.available": "0%",
+-			"nodefs.available":  "0%",
+-			"nodefs.inodesFree": "0%",
+-		},
++		CgroupDriver:                     kubeletConfiguration.TenantControlPlaneCgroupDriver,
++		ClusterDNS:                       kubeletConfiguration.TenantControlPlaneDNSServiceIPs,
++		ClusterDomain:                    kubeletConfiguration.TenantControlPlaneDomain,
++		CPUManagerReconcilePeriod:        zeroDuration,
+ 		EvictionPressureTransitionPeriod: zeroDuration,
+ 		FileCheckFrequency:               zeroDuration,
+ 		HealthzBindAddress:               "127.0.0.1",
+ 		HealthzPort:                      pointer.To(int32(10248)),
+ 		HTTPCheckFrequency:               zeroDuration,
+-		ImageGCHighThresholdPercent:      pointer.To(int32(100)),
+ 		NodeStatusUpdateFrequency:        zeroDuration,
+ 		NodeStatusReportFrequency:        zeroDuration,
+ 		RotateCertificates:               true,

--- a/packages/system/kamaji/values.yaml
+++ b/packages/system/kamaji/values.yaml
@@ -3,5 +3,5 @@ kamaji:
     deploy: false
   image:
     pullPolicy: IfNotPresent
-    tag: latest@sha256:f7e4036ed809176dafc671953a5c95a652dc7d637a67470142e625103f91ca3d
+    tag: v0.10.3@sha256:f7e4036ed809176dafc671953a5c95a652dc7d637a67470142e625103f91ca3d
     repository: ghcr.io/aenix-io/cozystack/kamaji

--- a/packages/system/kamaji/values.yaml
+++ b/packages/system/kamaji/values.yaml
@@ -1,3 +1,7 @@
 kamaji:
   etcd:
     deploy: false
+  image:
+    pullPolicy: IfNotPresent
+    tag: latest@sha256:f7e4036ed809176dafc671953a5c95a652dc7d637a67470142e625103f91ca3d
+    repository: ghcr.io/aenix-io/cozystack/kamaji

--- a/packages/system/kubeovn/images/kubeovn.json
+++ b/packages/system/kubeovn/images/kubeovn.json
@@ -3,15 +3,15 @@
     "buildType": "https://mobyproject.org/buildkit@v1",
     "materials": [
       {
-        "uri": "pkg:docker/kubeovn/kube-ovn-base@v1.13.0?platform=linux%2Famd64",
+        "uri": "pkg:docker/kubeovn/kube-ovn-base@v1.12.19?platform=linux%2Famd64",
         "digest": {
-          "sha256": "789041d6e02edaa9a28f9385e2175d47cecd564d163e7a0fb89d225de8ada2a2"
+          "sha256": "9f9e2199be2a0a10d058c3f45bda08d3a3ea9a8817170219a8f898c90ffbdf9e"
         }
       },
       {
         "uri": "pkg:docker/golang@1.22-bookworm?platform=linux%2Famd64",
         "digest": {
-          "sha256": "800e361142daeb47b5e5bce2ede55be8d67159be75748cb31cbb48798ebec39d"
+          "sha256": "af9b40f2b1851be993763b85288f8434af87b5678af04355b1e33ff530b5765f"
         }
       }
     ],
@@ -35,17 +35,17 @@
       }
     }
   },
-  "buildx.build.ref": "mybuild/mybuild0/sgrxqzg8w1l4zxyi2tpcluk8p",
-  "containerimage.config.digest": "sha256:7bdcdea14eb90de0b87b53e79e1b1fbe35ead5be316a7b4f83859454cb5506af",
+  "buildx.build.ref": "cozystack/cozystack0/e64wck0ep3sxlx32mud1oyyrz",
+  "containerimage.config.digest": "sha256:98931ff70d35bc0a275ab76f860708bb19a98a4e947ff56851e436dc197cab9c",
   "containerimage.descriptor": {
     "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-    "digest": "sha256:89cac6416d9a8bae534d1f5276b0d0a399e873d6b919bb6a3ad780ecf71c8b81",
-    "size": 4621,
+    "digest": "sha256:2ab726a9a9b73ad98c8852099f8b1eb458a556804981cc3653edee7c74e7b8d0",
+    "size": 5015,
     "platform": {
       "architecture": "amd64",
       "os": "linux"
     }
   },
-  "containerimage.digest": "sha256:89cac6416d9a8bae534d1f5276b0d0a399e873d6b919bb6a3ad780ecf71c8b81",
-  "image.name": "ghcr.io/aenix-io/cozystack/kubeovn:v1.13.0,ghcr.io/aenix-io/cozystack/kubeovn:v1.13.0-v0.10.0"
+  "containerimage.digest": "sha256:2ab726a9a9b73ad98c8852099f8b1eb458a556804981cc3653edee7c74e7b8d0",
+  "image.name": "ghcr.io/aenix-io/cozystack/kubeovn:latest,ghcr.io/aenix-io/cozystack/kubeovn:latest"
 }

--- a/packages/system/kubeovn/images/kubeovn.json
+++ b/packages/system/kubeovn/images/kubeovn.json
@@ -11,7 +11,7 @@
       {
         "uri": "pkg:docker/golang@1.22-bookworm?platform=linux%2Famd64",
         "digest": {
-          "sha256": "af9b40f2b1851be993763b85288f8434af87b5678af04355b1e33ff530b5765f"
+          "sha256": "39b7e6ebaca464d51989858871f792f2e186dce8ce0cbdba7e88e4444b244407"
         }
       }
     ],
@@ -35,17 +35,17 @@
       }
     }
   },
-  "buildx.build.ref": "cozystack/cozystack0/e64wck0ep3sxlx32mud1oyyrz",
-  "containerimage.config.digest": "sha256:98931ff70d35bc0a275ab76f860708bb19a98a4e947ff56851e436dc197cab9c",
+  "buildx.build.ref": "cozystack/cozystack0/3kqxn3juk572lfi4come65181",
+  "containerimage.config.digest": "sha256:05764289191ef541c37c86ef63dec99e24a159fba3a657c8427627b021802a1f",
   "containerimage.descriptor": {
     "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-    "digest": "sha256:2ab726a9a9b73ad98c8852099f8b1eb458a556804981cc3653edee7c74e7b8d0",
+    "digest": "sha256:c658f94e663d41c2f88b41e2693009a55dfeaa39a7cbc1e88f33b9f4a6bda8d5",
     "size": 5015,
     "platform": {
       "architecture": "amd64",
       "os": "linux"
     }
   },
-  "containerimage.digest": "sha256:2ab726a9a9b73ad98c8852099f8b1eb458a556804981cc3653edee7c74e7b8d0",
-  "image.name": "ghcr.io/aenix-io/cozystack/kubeovn:latest,ghcr.io/aenix-io/cozystack/kubeovn:latest"
+  "containerimage.digest": "sha256:c658f94e663d41c2f88b41e2693009a55dfeaa39a7cbc1e88f33b9f4a6bda8d5",
+  "image.name": "ghcr.io/aenix-io/cozystack/kubeovn:v1.13.0,ghcr.io/aenix-io/cozystack/kubeovn:v1.13.0-v0.10.3"
 }

--- a/packages/system/kubeovn/images/kubeovn.tag
+++ b/packages/system/kubeovn/images/kubeovn.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/kubeovn:latest
+ghcr.io/aenix-io/cozystack/kubeovn:v1.13.0

--- a/packages/system/kubeovn/images/kubeovn.tag
+++ b/packages/system/kubeovn/images/kubeovn.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/kubeovn:v1.13.0
+ghcr.io/aenix-io/cozystack/kubeovn:latest

--- a/packages/system/kubeovn/images/kubeovn/Dockerfile
+++ b/packages/system/kubeovn/images/kubeovn/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=v1.13.0
+ARG VERSION=v1.12.19
 ARG BASE_TAG=$VERSION
 
 FROM golang:1.22-bookworm as builder


### PR DESCRIPTION
- remove kubeovn ependency from distro-full bundle (#240)
- Fix ingress forward both 80 and 443 ports to tenant clusters (#243)
- Prepare release v0.10.2
- fix: kubeovn building (#253)
- Fix hardcoded values in ingress resource (#269)
- fix kamaji garbage collection (#263)
- Prepare release v0.10.3
- fix network-policies
