### PR TITLE
Rework VirtualMachine, introduce cloudinit and sshKeys configuration, fix externalPorts

### DIFF
--- a/packages/apps/virtual-machine/Chart.yaml
+++ b/packages/apps/virtual-machine/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/virtual-machine/README.md
+++ b/packages/apps/virtual-machine/README.md
@@ -24,6 +24,7 @@ The virtual machine is managed and hosted through KubeVirt, allowing you to harn
 | `resources.disk`   | The size of the disk allocated for the virtual machine                                            | `5Gi`                               |
 | `sshPwauth`        | Enable password authentication for SSH. If set to `true`, users can log in using a password       | `true`                              |
 | `disableRoot`      | Disable root login via SSH. If set to `true`, root login will be disabled                         | `true`                              |
+| `user`             | The username to be used for the virtual machine. Default is `username`                            | `username`                          |
 | `password`         | The default password for the virtual machine                                                      | `hackme`                            |
 | `chpasswdExpire`   | Set whether the password should expire                                                            | `false`                             |
 | `sshKeys`          | List of SSH public keys for authentication. Can be a single key or a list of keys                 | `["ssh-rsa ...","ssh-ed25519 ..."]` |

--- a/packages/apps/virtual-machine/README.md
+++ b/packages/apps/virtual-machine/README.md
@@ -9,52 +9,72 @@ The virtual machine is managed and hosted through KubeVirt, allowing you to harn
 - Docs: [KubeVirt User Guide](https://kubevirt.io/user-guide/)
 - GitHub: [KubeVirt Repository](https://github.com/kubevirt/kubevirt)
 
+## Accessing virtual machine
+
+You can access the virtual machine using the virtctl tool:
+- [KubeVirt User Guide - Virtctl Client Tool](https://kubevirt.io/user-guide/user_workloads/virtctl_client_tool/)
+
+To access the serial console:
+
+```
+virtctl console <vm>
+```
+
+To access the VM using VNC:
+
+```
+virtctl vnc <vm>
+```
+
+To SSH into the VM:
+
+```
+virtctl ssh <user>@<vm>
+```
+
 ## Parameters
 
 ### Common parameters
 
-| Name               | Description                                                                                       | Value                               |
-| ------------------ | ------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| `external`         | Enable external access from outside the cluster                                                   | `false`                             |
-| `running`          | Determines if the virtual machine should be running                                               | `true`                              |
-| `image`            | The base image for the virtual machine. Allowed values: `ubuntu`, `cirros`, `alpine` and `fedora` | `ubuntu`                            |
-| `storageClass`     | StorageClass used to store the data                                                               | `replicated`                        |
-| `resources.cpu`    | The number of CPU cores allocated to the virtual machine                                          | `1`                                 |
-| `resources.memory` | The amount of memory allocated to the virtual machine                                             | `1024M`                             |
-| `resources.disk`   | The size of the disk allocated for the virtual machine                                            | `5Gi`                               |
-| `sshPwauth`        | Enable password authentication for SSH. If set to `true`, users can log in using a password       | `true`                              |
-| `disableRoot`      | Disable root login via SSH. If set to `true`, root login will be disabled                         | `true`                              |
-| `user`             | The username to be used for the virtual machine. Default is `username`                            | `username`                          |
-| `password`         | The default password for the virtual machine                                                      | `hackme`                            |
-| `chpasswdExpire`   | Set whether the password should expire                                                            | `false`                             |
-| `sshKeys`          | List of SSH public keys for authentication. Can be a single key or a list of keys                 | `["ssh-rsa ...","ssh-ed25519 ..."]` |
+| Name               | Description                                                                                       | Value            |
+| ------------------ | ------------------------------------------------------------------------------------------------- | ---------------- |
+| `external`         | Enable external access from outside the cluster                                                   | `false`          |
+| `externalPorts`    | Specify ports to forward from outside the cluster                                                 | `[]`             |
+| `running`          | Determines if the virtual machine should be running                                               | `true`           |
+| `image`            | The base image for the virtual machine. Allowed values: `ubuntu`, `cirros`, `alpine` and `fedora` | `ubuntu`         |
+| `storageClass`     | StorageClass used to store the data                                                               | `replicated`     |
+| `resources.cpu`    | The number of CPU cores allocated to the virtual machine                                          | `1`              |
+| `resources.memory` | The amount of memory allocated to the virtual machine                                             | `1024M`          |
+| `resources.disk`   | The size of the disk allocated for the virtual machine                                            | `5Gi`            |
+| `sshKeys`          | List of SSH public keys for authentication. Can be a single key or a list of keys.                | `[]`             |
+| `cloudInit`        | cloud-init user data config. See cloud-init documentation for more details.                       | `#cloud-config
+` |
 
 You can customize the exposed ports by specifying them under `service.ports` in the `values.yaml` file.
 
-## Example `values.yaml`
+## Example virtual machine:
 
 ```yaml
-external: false
+external: true
+externalPorts:
+- 22
+- 80
+- 443
 running: true
-image: ubuntu
+image: fedora
+storageClass: replicated
 resources:
   cpu: 1
   memory: 1024M
-  disk: 5Gi
-sshPwauth: true
-disableRoot: true
-password: hackme
-chpasswdExpire: false
-sshKeys: 
-  - YOUR_SSH_PUB_KEY_HERE
-  - ANOTHER_SSH_PUB_KEY_HERE
+  disk: 10Gi
 
-service:
-  ports:
-    - name: http
-      port: 80
-      targetPort: 80
-    - name: https
-      port: 443
-      targetPort: 443
+sshKeys:
+- ssh-rsa ...
+
+cloudInit: |
+  #cloud-config
+  user: fedora
+  password: fedora
+  chpasswd: { expire: False }
+  ssh_pwauth: True
 ```

--- a/packages/apps/virtual-machine/templates/secret.yaml
+++ b/packages/apps/virtual-machine/templates/secret.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.sshKeys }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "virtual-machine.fullname" $ }}-ssh-keys
+stringData:
+  {{- range $k, $v := .Values.sshKeys }}
+  key{{ $k }}: {{ quote $v }} 
+  {{- end }}
+{{- end }}
+{{- if .Values.cloudInit }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "virtual-machine.fullname" . }}-cloud-init
+stringData:
+  userdata: |
+    {{- .Values.cloudInit | nindent 4 }}
+{{- end }}

--- a/packages/apps/virtual-machine/templates/service.yaml
+++ b/packages/apps/virtual-machine/templates/service.yaml
@@ -18,13 +18,11 @@ spec:
     - name: ssh
       port: 22
       targetPort: 22
-    {{- with .Values.service }}
-    {{- if .ports }}
-    {{- range .ports }}
+    {{- if (.Values.service).ports }}
+    {{- range .Values.service.ports }}
     - name: {{ .name }}
       port: {{ .port }}
       targetPort: {{ .targetPort }}
-    {{- end }}
     {{- end }}
     {{- end }}
 {{- end }}

--- a/packages/apps/virtual-machine/templates/service.yaml
+++ b/packages/apps/virtual-machine/templates/service.yaml
@@ -18,11 +18,13 @@ spec:
     - name: ssh
       port: 22
       targetPort: 22
-    {{- if .Values.service.ports }}
-    {{- range .Values.service.ports }}
+    {{- with .Values.service }}
+    {{- if .ports }}
+    {{- range .ports }}
     - name: {{ .name }}
       port: {{ .port }}
       targetPort: {{ .targetPort }}
+    {{- end }}
     {{- end }}
     {{- end }}
 {{- end }}

--- a/packages/apps/virtual-machine/templates/service.yaml
+++ b/packages/apps/virtual-machine/templates/service.yaml
@@ -8,21 +8,14 @@ metadata:
     {{- include "virtual-machine.labels" . | nindent 4 }}
 spec:
   type: {{ ternary "LoadBalancer" "ClusterIP" .Values.external }}
-  {{- if .Values.external }}
   externalTrafficPolicy: Local
   allocateLoadBalancerNodePorts: false
-  {{- end }}
   selector:
     {{- include "virtual-machine.labels" . | nindent 4 }}
   ports:
-    - name: ssh
-      port: 22
-      targetPort: 22
-    {{- if (.Values.service).ports }}
-    {{- range .Values.service.ports }}
-    - name: {{ .name }}
-      port: {{ .port }}
-      targetPort: {{ .targetPort }}
-    {{- end }}
+    {{- range .Values.externalPorts }}
+    - name: port-{{ . }}
+      port: {{ . }}
+      targetPort: {{ . }}
     {{- end }}
 {{- end }}

--- a/packages/apps/virtual-machine/templates/vm.yaml
+++ b/packages/apps/virtual-machine/templates/vm.yaml
@@ -63,6 +63,7 @@ spec:
             #cloud-config
             ssh_pwauth: {{ if .Values.sshPwauth | default false }}True{{ else }}False{{ end }}
             disable_root: {{ if .Values.disableRoot | default false }}True{{ else }}False{{ end }}
+            user: {{ .Values.user }}
             password: {{ .Values.password }}
             chpasswd: { expire: {{ if .Values.chpasswdExpire | default false }}True{{ else }}False{{ end }} }
             ssh_authorized_keys:

--- a/packages/apps/virtual-machine/templates/vm.yaml
+++ b/packages/apps/virtual-machine/templates/vm.yaml
@@ -45,35 +45,39 @@ spec:
           - disk:
               bus: scsi
             name: systemdisk
+          {{- if or .Values.sshKeys .Values.cloudInit }}
           - disk:
               bus: virtio
             name: cloudinitdisk
+          {{- end }}
+          interfaces:
+          - name: default
+            bridge: {}
         machine:
           type: ""
         resources:
           requests:
             memory: {{ .Values.resources.memory | quote }}
+      {{- with .Values.sshKeys }}
+      accessCredentials:
+      - sshPublicKey:
+          source:
+            secret:
+              secretName: {{ include "virtual-machine.fullname" $ }}-ssh-keys
+          propagationMethod:
+            noCloud: {}
+      {{- end }}
       terminationGracePeriodSeconds: 30
       volumes:
-      - dataVolume:
+      - name: systemdisk
+        dataVolume:
           name: {{ include "virtual-machine.fullname" . }}
-        name: systemdisk
-      - cloudInitNoCloud:
-          userData: |-
-            #cloud-config
-            ssh_pwauth: {{ if .Values.sshPwauth | default false }}True{{ else }}False{{ end }}
-            disable_root: {{ if .Values.disableRoot | default false }}True{{ else }}False{{ end }}
-            user: {{ .Values.user }}
-            password: {{ .Values.password }}
-            chpasswd: { expire: {{ if .Values.chpasswdExpire | default false }}True{{ else }}False{{ end }} }
-            ssh_authorized_keys:
-            {{- if .Values.sshKeys }}
-              {{- $keys := .Values.sshKeys }}
-              {{- if not (kindIs "slice" $keys) }}
-                {{- $keys = list $keys }}
-              {{- end }}
-              {{- range $keys }}
-              - {{ . }}
-              {{- end }}
-            {{- end }}
-        name: cloudinitdisk
+      {{- if or .Values.sshKeys .Values.cloudInit }}
+      - name: cloudinitdisk
+        cloudInitNoCloud:
+          secretRef:
+            name: {{ include "virtual-machine.fullname" . }}-cloud-init
+      {{- end }}
+      networks:
+      - name: default
+        pod: {}

--- a/packages/apps/virtual-machine/values.schema.json
+++ b/packages/apps/virtual-machine/values.schema.json
@@ -7,6 +7,14 @@
       "description": "Enable external access from outside the cluster",
       "default": false
     },
+    "externalPorts": {
+      "type": "array",
+      "description": "Specify ports to forward from outside the cluster",
+      "default": "[]",
+      "items": {
+        "type": "string"
+      }
+    },
     "running": {
       "type": "boolean",
       "description": "Determines if the virtual machine should be running",
@@ -49,41 +57,18 @@
         }
       }
     },
-    "sshPwauth": {
-      "type": "boolean",
-      "description": "Enable password authentication for SSH. If set to `true`, users can log in using a password",
-      "default": true
-    },
-    "disableRoot": {
-      "type": "boolean",
-      "description": "Disable root login via SSH. If set to `true`, root login will be disabled",
-      "default": true
-    },
-    "user": {
-      "type": "string",
-      "description": "The username to be used for the virtual machine. Default is `username`",
-      "default": "username"
-    },
-    "password": {
-      "type": "string",
-      "description": "The default password for the virtual machine",
-      "default": "hackme"
-    },
-    "chpasswdExpire": {
-      "type": "boolean",
-      "description": "Set whether the password should expire",
-      "default": false
-    },
     "sshKeys": {
       "type": "array",
-      "description": "List of SSH public keys for authentication. Can be a single key or a list of keys",
-      "default": [
-        "ssh-rsa ...",
-        "ssh-ed25519 ..."
-      ],
+      "description": "List of SSH public keys for authentication. Can be a single key or a list of keys.",
+      "default": "[]",
       "items": {
         "type": "string"
       }
+    },
+    "cloudInit": {
+      "type": "string",
+      "description": "cloud-init user data config. See cloud-init documentation for more details.",
+      "default": "#cloud-config\n"
     }
   }
 }

--- a/packages/apps/virtual-machine/values.schema.json
+++ b/packages/apps/virtual-machine/values.schema.json
@@ -59,6 +59,11 @@
       "description": "Disable root login via SSH. If set to `true`, root login will be disabled",
       "default": true
     },
+    "user": {
+      "type": "string",
+      "description": "The username to be used for the virtual machine. Default is `username`",
+      "default": "username"
+    },
     "password": {
       "type": "string",
       "description": "The default password for the virtual machine",

--- a/packages/apps/virtual-machine/values.yaml
+++ b/packages/apps/virtual-machine/values.yaml
@@ -9,6 +9,7 @@
 ## @param resources.disk The size of the disk allocated for the virtual machine
 ## @param sshPwauth Enable password authentication for SSH. If set to `true`, users can log in using a password
 ## @param disableRoot Disable root login via SSH. If set to `true`, root login will be disabled
+## @param user The username to be used for the virtual machine. Default is `username`
 ## @param password The default password for the virtual machine
 ## @param chpasswdExpire Set whether the password should expire
 ## @param sshKeys List of SSH public keys for authentication. Can be a single key or a list of keys
@@ -23,6 +24,7 @@ resources:
   disk: 5Gi
 sshPwauth: true
 disableRoot: true
+user: username
 password: hackme
 chpasswdExpire: false
 sshKeys:

--- a/packages/apps/virtual-machine/values.yaml
+++ b/packages/apps/virtual-machine/values.yaml
@@ -1,20 +1,18 @@
 ## @section Common parameters
 
 ## @param external Enable external access from outside the cluster
+## @param externalPorts [array] Specify ports to forward from outside the cluster
 ## @param running Determines if the virtual machine should be running
 ## @param image The base image for the virtual machine. Allowed values: `ubuntu`, `cirros`, `alpine` and `fedora`
 ## @param storageClass StorageClass used to store the data
 ## @param resources.cpu The number of CPU cores allocated to the virtual machine
 ## @param resources.memory The amount of memory allocated to the virtual machine
 ## @param resources.disk The size of the disk allocated for the virtual machine
-## @param sshPwauth Enable password authentication for SSH. If set to `true`, users can log in using a password
-## @param disableRoot Disable root login via SSH. If set to `true`, root login will be disabled
-## @param user The username to be used for the virtual machine. Default is `username`
-## @param password The default password for the virtual machine
-## @param chpasswdExpire Set whether the password should expire
-## @param sshKeys List of SSH public keys for authentication. Can be a single key or a list of keys
 
 external: false
+externalPorts:
+- 22
+
 running: true
 image: ubuntu
 storageClass: replicated
@@ -22,11 +20,24 @@ resources:
   cpu: 1
   memory: 1024M
   disk: 5Gi
-sshPwauth: true
-disableRoot: true
-user: username
-password: hackme
-chpasswdExpire: false
-sshKeys:
-  - ssh-rsa ...
-  - ssh-ed25519 ...
+
+## @param sshKeys [array] List of SSH public keys for authentication. Can be a single key or a list of keys.
+## Example:
+## sshKeys:
+##   - ssh-rsa ...
+##   - ssh-ed25519 ...
+##
+sshKeys: []
+
+## @param cloudInit cloud-init user data config. See cloud-init documentation for more details.
+## - https://cloudinit.readthedocs.io/en/latest/explanation/format.html
+## - https://cloudinit.readthedocs.io/en/latest/reference/examples.html
+## Example:
+## cloudInit: |
+##   #cloud-config
+##   password: ubuntu
+##   chpasswd: { expire: False }
+##
+cloudInit: |
+  #cloud-config
+


### PR DESCRIPTION
Previously, an error occurred when trying to access .Values.service.ports in the template, leading to a nil pointer dereference. This commit corrects the issue by ensuring that service.ports is checked for existence before attempting to access it, preventing the error from occurring.

Changes:
- Updated service.yaml to use `{{- with .Values.service }}...{{- end }}` for conditional rendering of ports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new parameters for enhanced virtual machine configuration: `externalPorts` for external access, and `cloudInit` for user data configuration.
	- Added a new section in the documentation for accessing virtual machines using `virtctl`.
	- Enhanced YAML templates to dynamically create Kubernetes Secrets for SSH keys and cloud-init data.

- **Bug Fixes**
	- Improved default storage allocation for virtual machines, increasing disk size from `5Gi` to `10Gi`.

- **Documentation**
	- Updated README to reflect new features and configuration options, improving user guidance.

- **Chores**
	- Version updated from `0.3.0` to `0.4.0`, indicating a new release with significant changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->