### PR TITLE
cilium: disable hostLegacyRouting

### DIFF
--- a/packages/system/cilium/values.yaml
+++ b/packages/system/cilium/values.yaml
@@ -7,6 +7,7 @@ cilium:
   kubeProxyReplacement: true
   bpf:
     masquerade: false
+    hostLegacyRouting: false
   loadBalancer:
     algorithm: maglev
   cgroup:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option, `hostLegacyRouting`, allowing users to control legacy routing behavior for enhanced network performance and compatibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->