### PR TITLE
cilium: enable SCTP feature

### DIFF
--- a/packages/system/cilium/values.yaml
+++ b/packages/system/cilium/values.yaml
@@ -1,6 +1,8 @@
 cilium:
   hubble:
     enabled: false
+  sctp:
+    enabled: true
   externalIPs:
     enabled: true
   autoDirectNodeRoutes: false
@@ -19,6 +21,7 @@ cilium:
   k8sServicePort: 7445
   cni:
     chainingMode: generic-veth
+    chainingTarget: kube-ovn
     customConf: true
     configMap: cni-configuration
   routingMode: native


### PR DESCRIPTION
This PR enables SCTP support in Cilium.

It is required to use with kube-ovn configuration as it is fixes `externalTrafficPolicy: Local` issues:

- https://github.com/kubeovn/kube-ovn/issues/4457