### PR TITLE
Prepare release v0.13.0

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -309,8 +309,9 @@ kubectl wait --timeout=5m --for=condition=available -n tenant-root deploy root-i
 kubectl wait --timeout=5m --for=jsonpath=.status.readyReplicas=3 -n tenant-root sts etcd
 
 # Wait for Victoria metrics
-kubectl wait --timeout=5m --for=condition=available deploy -n tenant-root vmalert-vmalert-longterm vmalert-vmalert-shortterm vminsert-longterm vminsert-shortterm
-kubectl wait --timeout=5m --for=jsonpath=.status.readyReplicas=2 -n tenant-root sts vmalertmanager-alertmanager vmselect-longterm vmselect-shortterm vmstorage-longterm vmstorage-shortterm
+kubectl wait --timeout=5m --for=jsonpath=.status.updateStatus=operational -n tenant-root vmalert/vmalert-longterm vmalert/vmalert-shortterm vmalertmanager/alertmanager
+kubectl wait --timeout=5m --for=jsonpath=.status.status=operational -n tenant-root vlogs/generic
+kubectl wait --timeout=5m --for=jsonpath=.status.clusterStatus=operational -n tenant-root vmcluster/shortterm vmcluster/longterm
 
 # Wait for grafana
 kubectl wait --timeout=5m --for=condition=ready -n tenant-root clusters.postgresql.cnpg.io grafana-db

--- a/manifests/cozystack-installer.yaml
+++ b/manifests/cozystack-installer.yaml
@@ -68,7 +68,7 @@ spec:
       serviceAccountName: cozystack
       containers:
       - name: cozystack
-        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.12.0"
+        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.13.0"
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: localhost
@@ -87,7 +87,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
       - name: darkhttpd
-        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.12.0"
+        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.13.0"
         command:
         - /usr/bin/darkhttpd
         - /cozystack/assets

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -5,7 +5,8 @@ clickhouse 0.2.1 5ca8823
 clickhouse 0.3.0 HEAD
 ferretdb 0.1.0 4ffa8615
 ferretdb 0.1.1 5ca8823
-ferretdb 0.2.0 HEAD
+ferretdb 0.2.0 adaf603
+ferretdb 0.3.0 HEAD
 http-cache 0.1.0 a956713
 http-cache 0.2.0 5ca8823
 http-cache 0.3.0 HEAD
@@ -25,7 +26,8 @@ kubernetes 0.7.0 ceefae03
 kubernetes 0.8.0 ac11056e
 kubernetes 0.8.1 e54608d8
 kubernetes 0.8.2 5ca8823
-kubernetes 0.9.0 HEAD
+kubernetes 0.9.0 9b6dd19
+kubernetes 0.10.0 HEAD
 mysql 0.1.0 f642698
 mysql 0.2.0 8b975ff0
 mysql 0.3.0 5ca8823
@@ -59,7 +61,8 @@ tenant 1.4.0 HEAD
 virtual-machine 0.1.4 f2015d6
 virtual-machine 0.1.5 7cd7de7
 virtual-machine 0.2.0 5ca8823
-virtual-machine 0.3.0 HEAD
+virtual-machine 0.3.0 b908400
+virtual-machine 0.4.0 HEAD
 vpn 0.1.0 f642698
 vpn 0.2.0 7151424
 vpn 0.3.0 HEAD

--- a/packages/core/installer/values.yaml
+++ b/packages/core/installer/values.yaml
@@ -1,2 +1,2 @@
 cozystack:
-  image: ghcr.io/aenix-io/cozystack/cozystack:v0.12.0@sha256:0917812850fd0359d5ba78fd819c0e4ce6d7c12eed9cd46813e7284064b71d30
+  image: ghcr.io/aenix-io/cozystack/cozystack:v0.13.0@sha256:0943f277c63f20cea19bef0207dc47f47157b58309c09af18830aac7906d1416

--- a/packages/core/testing/values.yaml
+++ b/packages/core/testing/values.yaml
@@ -1,2 +1,2 @@
 e2e:
-  image: ghcr.io/aenix-io/cozystack/e2e-sandbox:v0.12.0@sha256:be1693c8ce6a9522499f79b1e42b2e08c7ca80405026a095299e5e990a3ab791
+  image: ghcr.io/aenix-io/cozystack/e2e-sandbox:v0.13.0@sha256:be1693c8ce6a9522499f79b1e42b2e08c7ca80405026a095299e5e990a3ab791

--- a/packages/extra/monitoring/templates/vm/vmalertmanager.yaml
+++ b/packages/extra/monitoring/templates/vm/vmalertmanager.yaml
@@ -27,3 +27,6 @@ metadata:
 spec:
   replicaCount: 2
   configSecret: alertmanager
+  podMetadata:
+    labels:
+      policy.cozystack.io/allow-to-apiserver: "true"

--- a/packages/extra/versions_map
+++ b/packages/extra/versions_map
@@ -11,6 +11,7 @@ monitoring 1.0.0 f642698
 monitoring 1.1.0 15478a88
 monitoring 1.2.0 c9e0d63b
 monitoring 1.2.1 4471b4ba
-monitoring 1.3.0 HEAD
+monitoring 1.3.0 6c5cf5b
+monitoring 1.4.0 HEAD
 seaweedfs 0.1.0 5ca8823
 seaweedfs 0.2.0 HEAD

--- a/packages/system/dashboard/values.yaml
+++ b/packages/system/dashboard/values.yaml
@@ -33,11 +33,11 @@ kubeapps:
     image:
       registry: ghcr.io/aenix-io/cozystack
       repository: dashboard
-      tag: v0.12.0
-      digest: sha256:4818712e9fc9c57cc321512760c3226af564a04e69d4b3ec9229ab91fd39abeb
+      tag: v0.13.0
+      digest: "sha256:4818712e9fc9c57cc321512760c3226af564a04e69d4b3ec9229ab91fd39abeb"
   kubeappsapis:
     image:
       registry: ghcr.io/aenix-io/cozystack
       repository: kubeapps-apis
-      tag: v0.12.0
-      digest: "sha256:5eee4c2207f23a6d5317c08bbedfd71b8b22f733b834cd370f1313fb428a22d0"
+      tag: v0.13.0
+      digest: "sha256:a8cf2b536573f4bc29d4dce323ef3007a65567d6f1fe7803490bd71f422aca88"

--- a/packages/system/kamaji/values.yaml
+++ b/packages/system/kamaji/values.yaml
@@ -3,5 +3,5 @@ kamaji:
     deploy: false
   image:
     pullPolicy: IfNotPresent
-    tag: v0.12.0@sha256:197d7c36f76d4d9c09cc82eb87f9e36f05799a2b9158ae27e4729f2dd636ad0d
+    tag: v0.13.0@sha256:197d7c36f76d4d9c09cc82eb87f9e36f05799a2b9158ae27e4729f2dd636ad0d
     repository: ghcr.io/aenix-io/cozystack/kamaji

--- a/packages/system/kubeovn/values.yaml
+++ b/packages/system/kubeovn/values.yaml
@@ -22,4 +22,4 @@ global:
   images:
     kubeovn:
       repository: kubeovn
-      tag: v1.13.0@sha256:55b3ed5d4b628216378040e445aadc3d1cd817ff4d17eb081d884c6e00fb51e2
+      tag: v1.13.0@sha256:5c27a22f6b0a19c9a546e838a80ef73c32b863278cc209d7393555ad8a4f744a


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced monitoring capabilities for Kubernetes deployments, including checks for `vmalert`, `vlogs`, and `vmcluster`.

- **Updates**
	- Updated container images for `cozystack` and `darkhttpd` to version `v0.13.0`.
	- Version mapping updates for `ferretdb`, `kubernetes`, and `virtual-machine` packages.
	- Updated image tags and digests for Kubeapps components to version `v0.13.0`.
	- Updated image tag for Kamaji to version `v0.13.0`.
	- Added new pod metadata labels to the `vmalertmanager` configuration.

- **Bug Fixes**
	- Improved operational status checks for Kubernetes resources using JSONPath expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->