### PR TITLE
Introduce valuesFiles for various Cilium configurations

### DIFF
--- a/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
@@ -31,20 +31,8 @@ spec:
   values:
     cilium:
       tunnel: disabled
-      autoDirectNodeRoutes: false
-      bpf:
-        masquerade: true
-      cgroup:
-        autoMount:
-          enabled: true
-        hostRoot: /run/cilium/cgroupv2
       k8sServiceHost: {{ .Release.Name }}.{{ .Release.Namespace }}.svc
       k8sServicePort: 6443
-    
-      cni:
-        chainingMode: ~
-        customConf: false
-        configMap: ""
       routingMode: tunnel
       enableIPv4Masquerade: true
       ipv4NativeRoutingCIDR: ""

--- a/packages/core/platform/bundles/distro-full.yaml
+++ b/packages/core/platform/bundles/distro-full.yaml
@@ -20,14 +20,11 @@ releases:
   namespace: cozy-cilium
   privileged: true
   dependsOn: []
+  valuesFiles:
+  - values.yaml
+  - values-talos.yaml
   values:
     cilium:
-      bpf:
-        masquerade: true
-      cni:
-        chainingMode: ~
-        customConf: false
-        configMap: ""
       enableIPv4Masquerade: true
       enableIdentityMark: true
       ipv4NativeRoutingCIDR: "{{ index $cozyConfig.data "ipv4-pod-cidr" }}"

--- a/packages/core/platform/bundles/paas-full.yaml
+++ b/packages/core/platform/bundles/paas-full.yaml
@@ -20,6 +20,10 @@ releases:
   namespace: cozy-cilium
   privileged: true
   dependsOn: []
+  valuesFiles:
+  - values.yaml
+  - values-talos.yaml
+  - values-kubeovn.yaml
 
 - name: kubeovn
   releaseName: kubeovn

--- a/packages/core/platform/templates/helmreleases.yaml
+++ b/packages/core/platform/templates/helmreleases.yaml
@@ -39,6 +39,10 @@ spec:
         kind: HelmRepository
         name: cozystack-system
         namespace: cozy-system
+      {{- with $x.valuesFiles }}
+      valuesFiles:
+      {{- toYaml $x.valuesFiles | nindent 6 }}
+      {{- end }}
   {{- $values := dict }}
   {{- with $x.values }}
   {{- $values = merge . $values }}

--- a/packages/system/cilium/values-kubeovn.yaml
+++ b/packages/system/cilium/values-kubeovn.yaml
@@ -1,0 +1,19 @@
+cilium:
+  sctp:
+    enabled: true
+  autoDirectNodeRoutes: false
+  kubeProxyReplacement: true
+  bpf:
+    masquerade: false
+  cni:
+    chainingMode: generic-veth
+    chainingTarget: kube-ovn
+    customConf: true
+    configMap: cni-configuration
+  routingMode: native
+  enableIPv4Masquerade: false
+  enableIPv6Masquerade: false
+  enableIdentityMark: false
+  enableRuntimeDeviceDetection: true
+  forceDeviceDetection: true
+  devices: ovn0

--- a/packages/system/cilium/values-talos.yaml
+++ b/packages/system/cilium/values-talos.yaml
@@ -1,0 +1,7 @@
+cilium:
+  cgroup:
+    autoMount:
+      enabled: false
+    hostRoot: /sys/fs/cgroup
+  k8sServiceHost: localhost
+  k8sServicePort: 7445

--- a/packages/system/cilium/values.yaml
+++ b/packages/system/cilium/values.yaml
@@ -1,39 +1,12 @@
 cilium:
   hubble:
     enabled: false
-  sctp:
-    enabled: true
   externalIPs:
     enabled: true
-  autoDirectNodeRoutes: false
-  kubeProxyReplacement: true
-  bpf:
-    masquerade: false
   loadBalancer:
     algorithm: maglev
-  cgroup:
-    autoMount:
-      enabled: false
-    hostRoot: /sys/fs/cgroup
   ipam:
     mode: "kubernetes"
-  k8sServiceHost: localhost
-  k8sServicePort: 7445
-  cni:
-    chainingMode: generic-veth
-    chainingTarget: kube-ovn
-    customConf: true
-    configMap: cni-configuration
-  routingMode: native
-  enableIPv4Masquerade: false
-  enableIPv6Masquerade: false
-  enableIdentityMark: false
-  enableRuntimeDeviceDetection: true
-  forceDeviceDetection: true
-  devices: ovn0
-  extraEnv:
-    - name: CILIUM_ENFORCE_DEVICE_DETECTION
-      value: "true"
   image:
     repository: ghcr.io/aenix-io/cozystack/cilium
     tag: 1.16.1

--- a/scripts/package.mk
+++ b/scripts/package.mk
@@ -1,20 +1,21 @@
 .DEFAULT_GOAL=help
 .PHONY=help show diff apply delete update image
+.VALUES_FILES=$(shell kubectl get hr -n $(NAMESPACE) $(NAME) -o go-template='{{ range .spec.chart.spec.valuesFiles}}-f {{ . }} {{ end }}-f -')
 
 help: ## Show this help.
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 show: check ## Show output of rendered templates
 	kubectl get hr -n $(NAMESPACE) $(NAME) -o jsonpath='{.spec.values}' | NAMESPACE=$(NAMESPACE) NAME=$(NAME) \
-		helm template --dry-run=server --post-renderer ../../../scripts/fluxcd-kustomize.sh -n $(NAMESPACE) $(NAME) . -f -
+		helm template --dry-run=server --post-renderer ../../../scripts/fluxcd-kustomize.sh -n $(NAMESPACE) $(NAME) . $(.VALUES_FILES)
 
 apply: check suspend ## Apply Helm release to a Kubernetes cluster
 	kubectl get hr -n $(NAMESPACE) $(NAME) -o jsonpath='{.spec.values}' | NAMESPACE=$(NAMESPACE) NAME=$(NAME) \
-		helm upgrade -i --post-renderer ../../../scripts/fluxcd-kustomize.sh -n $(NAMESPACE) $(NAME) . -f -
+		helm upgrade -i --post-renderer ../../../scripts/fluxcd-kustomize.sh -n $(NAMESPACE) $(NAME) . $(.VALUES_FILES)
 
 diff: check ## Diff Helm release against objects in a Kubernetes cluster
 	kubectl get hr -n $(NAMESPACE) $(NAME) -o jsonpath='{.spec.values}' | NAMESPACE=$(NAMESPACE) NAME=$(NAME) \
-		helm diff upgrade --show-secrets --allow-unreleased --post-renderer ../../../scripts/fluxcd-kustomize.sh -n $(NAMESPACE) $(NAME) . -f -
+		helm diff upgrade --show-secrets --allow-unreleased --post-renderer ../../../scripts/fluxcd-kustomize.sh -n $(NAMESPACE) $(NAME) . $(.VALUES_FILES)
 
 suspend: check ## Suspend reconciliation for an existing Helm release
 	kubectl patch hr -n $(NAMESPACE) $(NAME) -p '{"spec": {"suspend": true}}' --type=merge --field-manager=flux-client-side-apply


### PR DESCRIPTION
This PR introduces different values files for `cozy-cilium` chart, and `valuesFiles` for fluxcd.

This might be useful in cases where same chart reused for multiple configurations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced multiple values files for enhanced configuration management in Cilium deployments.
	- Added new YAML configurations for Cilium, allowing for tailored networking settings in Kubernetes.

- **Bug Fixes**
	- Removed deprecated configuration parameters to simplify deployment and management of Cilium.

- **Documentation**
	- Updated Helm templates to support conditional inclusion of values files, improving flexibility in chart rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->