### PR TITLE
cilium node port

### DIFF
--- a/packages/system/cilium/values.yaml
+++ b/packages/system/cilium/values.yaml
@@ -3,6 +3,8 @@ cilium:
     enabled: false
   externalIPs:
     enabled: true
+  nodePort:
+    enabled: true
   loadBalancer:
     algorithm: maglev
   ipam:


### PR DESCRIPTION
This PR fixes the error for tenant Kubernetes clusters:

```
Failed to start: daemon creation failed: unable to initialize BPF masquerade support: BPF masquerade requires NodePort
```