### PR TITLE
Update seaweedfs.yaml

### DIFF
--- a/packages/extra/seaweedfs/templates/seaweedfs.yaml
+++ b/packages/extra/seaweedfs/templates/seaweedfs.yaml
@@ -50,7 +50,7 @@ spec:
             cert-manager.io/cluster-issuer: letsencrypt-prod
           tls:
             - hosts:
-              - {{ .Values.host | default (printf "seaweedfs.%s" $host) }}
+              - {{ .Values.host | default (printf "s3.%s" $host) }}
               secretName: {{ .Release.Name }}-s3-ingress-tls
 
       cosi:


### PR DESCRIPTION
Changed tls host to be the same as ingress host

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the default host value in the SeaweedFS configuration to support S3-compatible endpoints.
- **Bug Fixes**
	- Corrected the hostname configuration to reflect the new service access method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->