### PR TITLE
fix Kamaji OOM

### DIFF
--- a/packages/system/kamaji/values.yaml
+++ b/packages/system/kamaji/values.yaml
@@ -5,3 +5,11 @@ kamaji:
     pullPolicy: IfNotPresent
     tag: v0.14.1@sha256:5a1c82f19552e4ec852880b943290921ec38f4f70b1256848e335f2b96ce09e3
     repository: ghcr.io/aenix-io/cozystack/kamaji
+
+  resources:
+    limits:
+      cpu: 200m
+      memory: 500Mi
+    requests:
+      cpu: 100m
+      memory: 100Mi


### PR DESCRIPTION
Sometimes Kamaji can be killed due to defult limits let's expand them a little

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced resource management configurations for the `kamaji` service, enhancing control over CPU and memory allocation.
	- Added specifications for resource limits and requests to improve stability and performance in a Kubernetes environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->