### PR TITLE
bugfix/strimzi-kafka-operator-fix-cluster-dns

### DIFF
--- a/packages/system/kafka-operator/values.yaml
+++ b/packages/system/kafka-operator/values.yaml
@@ -1,2 +1,3 @@
 strimzi-kafka-operator:
   watchAnyNamespace: true
+  kubernetesServiceDnsDomain: cozy.local


### PR DESCRIPTION
kafka zookeeper error after installation:
```
2024-09-15 02:44:33,289 ERROR Failed to verify hostname: kafka-service-zookeeper-2.kafka-service-zookeeper-nodes.tenant-stage.svc.cozy.local (org.apache.zookeeper.common.ZKTrustManager) [ListenerHandler-/0.0.0.0:3888]
javax.net.ssl.SSLPeerUnverifiedException: Certificate for <kafka-service-zookeeper-2.kafka-service-zookeeper-nodes.tenant-stage.svc.cozy.local> doesn't match any of the subject alternative names: [kafka-service-zookeeper-client, *.kafka-service-zookeeper-nodes.tenant-stage.svc.cluster.local, *.kafka-service-zookeeper-nodes.tenant-stage.svc, kafka-service-zookeeper-2.kafka-service-zookeeper-nodes.tenant-stage.svc, kafka-service-zookeeper-client.tenant-stage.svc.cluster.local, kafka-service-zookeeper-client.tenant-stage.svc, kafka-service-zookeeper-2, kafka-service-zookeeper-2.kafka-service-zookeeper-nodes.tenant-stage.svc.cluster.local, *.kafka-service-zookeeper-client.tenant-stage.svc, kafka-service-zookeeper-client.tenant-stage, *.kafka-service-zookeeper-client.tenant-stage.svc.cluster.local]
```
certs sans by default:
```
klin@asus:~/cozy$ openssl x509 -in zookeeper.crt -text -noout | grep -A1 "Subject Alternative Name"
            X509v3 Subject Alternative Name:
                DNS:kafka-service-zookeeper-0.kafka-service-zookeeper-nodes.tenant-stage.svc.cluster.local, DNS:*.kafka-service-zookeeper-nodes.tenant-stage.svc.cluster.local, DNS:kafka-service-zookeeper-client, DNS:kafka-service-zookeeper-0, DNS:kafka-service-zookeeper-client.tenant-stage.svc.cluster.local, DNS:kafka-service-zookeeper-client.tenant-stage.svc, DNS:kafka-service-zookeeper-client.tenant-stage, DNS:*.kafka-service-zookeeper-nodes.tenant-stage.svc, DNS:*.kafka-service-zookeeper-client.tenant-stage.svc, DNS:kafka-service-zookeeper-0.kafka-service-zookeeper-nodes.tenant-stage.svc, DNS:*.kafka-service-zookeeper-client.tenant-stage.svc.cluster.local
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for specifying a custom DNS domain for Kubernetes services within the Kafka operator, enhancing service discovery and networking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->