### PR TITLE
Enable ingress access from within cluster

### DIFF
--- a/packages/apps/tenant/templates/networkpolicy.yaml
+++ b/packages/apps/tenant/templates/networkpolicy.yaml
@@ -83,6 +83,21 @@ spec:
     {{- end }}
   {{- end }}
 ---
+{{- if .Values.ingress }}
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: {{ include "tenant.name" . }}-ingress-ingress
+spec:
+  endpointSelector:
+    matchLabels:
+      "k8s:io.kubernetes.pod.namespace": "{{ include "tenant.name" . }}"
+      cozystack.io/service: ingress
+  ingress:
+  - fromEndpoints:
+    - {}
+{{- end }}
+---
 {{- if .Values.etcd }}
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy


### PR DESCRIPTION
Currently ingress have rule to allow access from outside cluster, but have no rule to access from within cluster.
This PR introduces fix for allow ingress access from any namespace by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new network policy for managing ingress traffic, enhancing security and traffic management capabilities.
	- The policy is dynamically configured based on the tenant's settings, allowing for tailored network access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->