### PR TITLE
add postgresql.parameters.max_connections

### DIFF
--- a/packages/apps/postgres/Chart.yaml
+++ b/packages/apps/postgres/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.2
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/postgres/README.md
+++ b/packages/apps/postgres/README.md
@@ -35,14 +35,15 @@ more details:
 
 ### Common parameters
 
-| Name                     | Description                                                                                                             | Value   |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------- | ------- |
-| `external`               | Enable external access from outside the cluster                                                                         | `false` |
-| `size`                   | Persistent Volume size                                                                                                  | `10Gi`  |
-| `replicas`               | Number of Postgres replicas                                                                                             | `2`     |
-| `storageClass`           | StorageClass used to store the data                                                                                     | `""`    |
-| `quorum.minSyncReplicas` | Minimum number of synchronous replicas that must acknowledge a transaction before it is considered committed.           | `0`     |
-| `quorum.maxSyncReplicas` | Maximum number of synchronous replicas that can acknowledge a transaction (must be lower than the number of instances). | `0`     |
+| Name                                    | Description                                                                                                              | Value   |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------- |
+| `external`                              | Enable external access from outside the cluster                                                                          | `false` |
+| `size`                                  | Persistent Volume size                                                                                                   | `10Gi`  |
+| `replicas`                              | Number of Postgres replicas                                                                                              | `2`     |
+| `storageClass`                          | StorageClass used to store the data                                                                                      | `""`    |
+| `postgresql.parameters.max_connections` | Determines the maximum number of concurrent connections to the database server. The default is typically 100 connections | `100`   |
+| `quorum.minSyncReplicas`                | Minimum number of synchronous replicas that must acknowledge a transaction before it is considered committed.            | `0`     |
+| `quorum.maxSyncReplicas`                | Maximum number of synchronous replicas that can acknowledge a transaction (must be lower than the number of instances).  | `0`     |
 
 ### Configuration parameters
 

--- a/packages/apps/postgres/templates/db.yaml
+++ b/packages/apps/postgres/templates/db.yaml
@@ -10,6 +10,7 @@ spec:
   postgresql:
     parameters:
       max_wal_senders: "30"
+      max_connections: “{{ .Values.postgresql.parameters.max_connections }}”
 
   minSyncReplicas: {{ .Values.quorum.minSyncReplicas }}
   maxSyncReplicas: {{ .Values.quorum.maxSyncReplicas }}

--- a/packages/apps/postgres/values.schema.json
+++ b/packages/apps/postgres/values.schema.json
@@ -22,6 +22,21 @@
             "description": "StorageClass used to store the data",
             "default": ""
         },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "max_connections": {
+                            "type": "string",
+                            "description": "Determines the maximum number of concurrent connections to the database server. The default is typically 100 connections",
+                            "default": "100"
+                        }
+                    }
+                }
+            }
+        },
         "quorum": {
             "type": "object",
             "properties": {

--- a/packages/apps/postgres/values.yaml
+++ b/packages/apps/postgres/values.yaml
@@ -10,6 +10,12 @@ size: 10Gi
 replicas: 2
 storageClass: ""
 
+## Server Configuration
+## @param postgresql.parameters.max_connections Determines the maximum number of concurrent connections to the database server. The default is typically 100 connections
+postgresql:
+  parameters:
+    max_connections: "100"
+
 ## Configuration for the quorum-based synchronous replication
 ## @param quorum.minSyncReplicas Minimum number of synchronous replicas that must acknowledge a transaction before it is considered committed.
 ## @param quorum.maxSyncReplicas Maximum number of synchronous replicas that can acknowledge a transaction (must be lower than the number of instances).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration parameter `max_connections` for PostgreSQL, allowing users to specify the maximum number of concurrent connections.
	- Added a "Server Configuration" section in the settings for easier management of PostgreSQL parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->