### PR TITLE
Upgrade flux-operator to 0.9.0

### DIFF
--- a/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.6.0
+appVersion: v0.9.0
 description: 'A Helm chart for deploying the Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -18,13 +18,11 @@ keywords:
 - gitops
 kubeVersion: '>=1.22.0-0'
 maintainers:
-- email: stefan.prodan@control-plane.io
-  name: Stefan Prodan
-- name: Soule Ba
-  url: soule.ba@control-plane.io
+- email: flux-enterprise@control-plane.io
+  name: ControlPlane Flux Team
 name: flux-operator
 sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.6.0
+version: 0.9.0

--- a/packages/system/fluxcd-operator/charts/flux-operator/README.md
+++ b/packages/system/fluxcd-operator/charts/flux-operator/README.md
@@ -1,9 +1,9 @@
 # flux-operator
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.0](https://img.shields.io/badge/AppVersion-v0.6.0-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.9.0](https://img.shields.io/badge/AppVersion-v0.9.0-informational?style=flat-square)
 
-The [Flux Operator](https://github.com/controlplaneio-fluxcd) provides a declarative API
-for the installation and upgrade of CNCF [Flux](https://fluxcd.io) and the
+The [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator) provides a
+declarative API for the installation and upgrade of CNCF [Flux](https://fluxcd.io) and the
 ControlPlane [enterprise distribution](https://control-plane.io/enterprise-for-flux-cd/).
 
 The operator automates the patching for hotfixes and CVEs affecting the Flux controllers container images
@@ -49,6 +49,7 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 | resources | object | `{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"64Mi"}}` | Container resources requests and limits settings. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context settings. The default is compliant with the pod security restricted profile. |
 | serviceAccount | object | `{"automount":true,"create":true,"name":""}` | Pod service account settings. The name of the service account defaults to the release name. |
+| serviceMonitor | object | `{"create":false,"interval":"60s","labels":{},"scrapeTimeout":"30s"}` | Prometheus Operator scraping settings. |
 | tolerations | list | `[]` | Pod tolerations settings. |
 
 ## Source Code

--- a/packages/system/fluxcd-operator/charts/flux-operator/templates/crds.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/templates/crds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
@@ -77,6 +77,12 @@ spec:
                       NetworkPolicy restricts network access to the current namespace.
                       Defaults to true.
                     type: boolean
+                  tenantDefaultServiceAccount:
+                    description: |-
+                      TenantDefaultServiceAccount is the name of the service account
+                      to use as default when the multitenant lockdown is enabled.
+                      Defaults to the 'default' service account from the tenant namespace.
+                    type: string
                   type:
                     default: kubernetes
                     description: |-
@@ -202,6 +208,29 @@ spec:
                       type: object
                     type: array
                 type: object
+              migrateResources:
+                default: true
+                description: |-
+                  MigrateResources instructs the controller to migrate the Flux custom resources
+                  from the previous version to the latest API version specified in the CRD.
+                  Defaults to true.
+                type: boolean
+              sharding:
+                description: Sharding holds the specification of the sharding configuration.
+                properties:
+                  key:
+                    default: sharding.fluxcd.io/key
+                    description: Key is the label key used to shard the resources.
+                    type: string
+                  shards:
+                    description: Shards is the list of shard names.
+                    items:
+                      type: string
+                    minItems: 1
+                    type: array
+                required:
+                - shards
+                type: object
               storage:
                 description: |-
                   Storage holds the specification of the source-controller
@@ -274,7 +303,6 @@ spec:
                 type: boolean
             required:
             - distribution
-            - wait
             type: object
           status:
             description: FluxInstanceStatus defines the observed state of FluxInstance
@@ -307,16 +335,8 @@ spec:
               conditions:
                 description: Conditions contains the readiness conditions of the object.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -357,12 +377,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -429,7 +444,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
@@ -622,16 +637,8 @@ spec:
               conditions:
                 description: Conditions contains the readiness conditions of the object.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -672,12 +679,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/packages/system/fluxcd-operator/charts/flux-operator/templates/deployment.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/templates/deployment.yaml
@@ -18,10 +18,13 @@ spec:
       {{- include "flux-operator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.commonAnnotations }}
       annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
+        {{- with .Values.commonAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "flux-operator.labels" . | nindent 8 }}
         {{- with .Values.commonLabels }}

--- a/packages/system/fluxcd-operator/charts/flux-operator/templates/servicemonitor.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/templates/servicemonitor.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.serviceMonitor.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "flux-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flux-operator.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  selector:
+    matchLabels:
+      {{- include "flux-operator.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - targetPort: 8080
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/packages/system/fluxcd-operator/charts/flux-operator/values.schema.json
+++ b/packages/system/fluxcd-operator/charts/flux-operator/values.schema.json
@@ -293,6 +293,29 @@
             },
             "type": "object"
         },
+        "serviceMonitor": {
+            "default": {
+                "create": false,
+                "interval": "60s",
+                "scrapeTimeout": "30s"
+            },
+            "properties": {
+                "create": {
+                    "type": "boolean"
+                },
+                "interval": {
+                    "type": "string"
+                },
+                "labels": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "scrapeTimeout": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "tolerations": {
             "items": {
                 "type": "object"

--- a/packages/system/fluxcd-operator/charts/flux-operator/values.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/values.yaml
@@ -84,14 +84,21 @@ affinity: # @schema default: {"nodeAffinity":{"requiredDuringSchedulingIgnoredDu
 # -- Pod tolerations settings.
 tolerations: [ ] # @schema item: object ; uniqueItems: true
 
-# -- Marketplace settings.
-marketplace:
-  type: ""
-  license: ""
-  account: ""
-
 # -- If `true`, the container ports (`8080` and `8081`) are exposed on the host network.
 hostNetwork: false # @schema default: false
 
 # -- Container extra environment variables.
 extraEnvs: [ ] # @schema item: object ; uniqueItems: true
+
+# -- Prometheus Operator scraping settings.
+serviceMonitor: # @schema default: {"create":false,"interval":"60s","scrapeTimeout":"30s"}
+  create: false
+  interval: 60s
+  scrapeTimeout: 30s
+  labels: { }
+
+# -- Marketplace settings.
+marketplace:
+  type: ""
+  license: ""
+  account: ""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated to version 0.9.0 of the Flux Operator Helm chart.
	- Introduced a new `ServiceMonitor` resource for Prometheus metrics scraping.
	- Added configuration options for the `serviceMonitor`, including scrape interval and timeout settings.

- **Bug Fixes**
	- Corrected the GitHub repository URL in the README.

- **Documentation**
	- Updated README to reflect new version and added details for the `serviceMonitor` settings.

- **Chores**
	- Updated maintainer information in the chart configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->