### PR TITLE
fix postgres max_connections

### DIFF
--- a/packages/apps/postgres/values.schema.json
+++ b/packages/apps/postgres/values.schema.json
@@ -29,9 +29,9 @@
                     "type": "object",
                     "properties": {
                         "max_connections": {
-                            "type": "string",
+                            "type": "number",
                             "description": "Determines the maximum number of concurrent connections to the database server. The default is typically 100 connections",
-                            "default": "100"
+                            "default": 100
                         }
                     }
                 }

--- a/packages/apps/postgres/values.yaml
+++ b/packages/apps/postgres/values.yaml
@@ -14,7 +14,7 @@ storageClass: ""
 ## @param postgresql.parameters.max_connections Determines the maximum number of concurrent connections to the database server. The default is typically 100 connections
 postgresql:
   parameters:
-    max_connections: "100"
+    max_connections: 100
 
 ## Configuration for the quorum-based synchronous replication
 ## @param quorum.minSyncReplicas Minimum number of synchronous replicas that must acknowledge a transaction before it is considered committed.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `max_connections` parameter to accept numeric values for improved clarity and correctness in PostgreSQL configurations.

- **Bug Fixes**
	- Corrected the data type for `max_connections` from string to number in both schema and configuration files to ensure proper interpretation by the PostgreSQL server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->