### PR TITLE
Upgrade Flux to 2.4.x

### DIFF
--- a/packages/system/fluxcd/values.yaml
+++ b/packages/system/fluxcd/values.yaml
@@ -4,7 +4,7 @@ flux-instance:
       networkPolicy: true
       domain: cozy.local # -- default value is overriden in patches
     distribution:
-      version: 2.3.x
+      version: 2.4.x
       registry: ghcr.io/fluxcd
     components:
       - source-controller


### PR DESCRIPTION
Now that Cozystack 0.16 is out with flux-operator 0.9.0, users that need it can easily upgrade to Flux 2.4.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded FluxCD version from 2.3.x to 2.4.x.
	- Enhanced configuration for several controllers with new command-line arguments for improved performance and functionality.

- **Bug Fixes**
	- Updated resource limits for containers to ensure optimal resource allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->