### PR TITLE
Upgrade Flux operator to 0.10

### DIFF
--- a/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.9.0
+appVersion: v0.10.0
 description: 'A Helm chart for deploying the Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.9.0
+version: 0.10.0

--- a/packages/system/fluxcd-operator/charts/flux-operator/README.md
+++ b/packages/system/fluxcd-operator/charts/flux-operator/README.md
@@ -1,6 +1,6 @@
 # flux-operator
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.9.0](https://img.shields.io/badge/AppVersion-v0.9.0-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.10.0](https://img.shields.io/badge/AppVersion-v0.10.0-informational?style=flat-square)
 
 The [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator) provides a
 declarative API for the installation and upgrade of CNCF [Flux](https://fluxcd.io) and the
@@ -35,12 +35,14 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 | affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]}]}]}}}` | Pod affinity and anti-affinity settings. |
 | commonAnnotations | object | `{}` | Common annotations to add to all deployed objects including pods. |
 | commonLabels | object | `{}` | Common labels to add to all deployed objects including pods. |
+| extraArgs | list | `[]` | Container extra arguments. |
 | extraEnvs | list | `[]` | Container extra environment variables. |
 | fullnameOverride | string | `""` |  |
 | hostNetwork | bool | `false` | If `true`, the container ports (`8080` and `8081`) are exposed on the host network. |
 | image | object | `{"pullSecrets":[],"repository":"ghcr.io/controlplaneio-fluxcd/flux-operator","tag":""}` | Container image settings. The image tag defaults to the chart appVersion. |
 | installCRDs | bool | `true` | Install and upgrade the custom resource definitions. |
 | livenessProbe | object | `{"httpGet":{"path":"/healthz","port":8081},"initialDelaySeconds":15,"periodSeconds":20}` | Container liveness probe settings. |
+| logLevel | string | `"info"` | Container logging level flag. |
 | marketplace | object | `{"account":"","license":"","type":""}` | Marketplace settings. |
 | nameOverride | string | `""` |  |
 | podSecurityContext | object | `{}` | Pod security context settings. |

--- a/packages/system/fluxcd-operator/charts/flux-operator/templates/deployment.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/templates/deployment.yaml
@@ -48,6 +48,11 @@ spec:
       {{- end }}
       containers:
         - name: manager
+          args:
+            - --log-level={{ .Values.logLevel }}
+            {{- range .Values.extraArgs }}
+            - {{ . }}
+            {{- end }}
           env:
             - name: RUNTIME_NAMESPACE
               valueFrom:

--- a/packages/system/fluxcd-operator/charts/flux-operator/values.schema.json
+++ b/packages/system/fluxcd-operator/charts/flux-operator/values.schema.json
@@ -71,6 +71,13 @@
             "properties": {},
             "type": "object"
         },
+        "extraArgs": {
+            "items": {
+                "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
         "extraEnvs": {
             "items": {
                 "type": "object"
@@ -139,6 +146,14 @@
                 }
             },
             "type": "object"
+        },
+        "logLevel": {
+            "enum": [
+                "debug",
+                "info",
+                "error"
+            ],
+            "type": "string"
         },
         "marketplace": {
             "properties": {

--- a/packages/system/fluxcd-operator/charts/flux-operator/values.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/values.yaml
@@ -90,6 +90,12 @@ hostNetwork: false # @schema default: false
 # -- Container extra environment variables.
 extraEnvs: [ ] # @schema item: object ; uniqueItems: true
 
+# -- Container extra arguments.
+extraArgs: [ ] # @schema item: string ; uniqueItems: true
+
+# -- Container logging level flag.
+logLevel: "info" # @schema enum:[debug,info,error]
+
 # -- Prometheus Operator scraping settings.
 serviceMonitor: # @schema default: {"create":false,"interval":"60s","scrapeTimeout":"30s"}
   create: false

--- a/packages/system/fluxcd/values.yaml
+++ b/packages/system/fluxcd/values.yaml
@@ -4,7 +4,7 @@ flux-instance:
       networkPolicy: true
       domain: cozy.local # -- default value is overriden in patches
     distribution:
-      version: 2.3.x
+      version: 2.4.x
       registry: ghcr.io/fluxcd
     components:
       - source-controller


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated Flux Operator Helm chart to version 0.10.0, introducing new configuration options: `extraArgs` for additional command-line arguments and `logLevel` for logging verbosity.
  
- **Bug Fixes**
	- Corrected formatting in the annotations section of the Helm chart.

- **Documentation**
	- Updated README to reflect new version and configuration options.

- **Chores**
	- Updated FluxCD instance configuration to version 2.4.x with refined deployment specifications for improved functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->