### PR TITLE
Prepare release v0.16.2

### DIFF
--- a/manifests/cozystack-installer.yaml
+++ b/manifests/cozystack-installer.yaml
@@ -68,7 +68,7 @@ spec:
       serviceAccountName: cozystack
       containers:
       - name: cozystack
-        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.16.1"
+        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.16.2"
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: localhost
@@ -87,7 +87,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
       - name: darkhttpd
-        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.16.1"
+        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.16.2"
         command:
         - /usr/bin/darkhttpd
         - /cozystack/assets

--- a/packages/apps/kubernetes/images/cluster-autoscaler.tag
+++ b/packages/apps/kubernetes/images/cluster-autoscaler.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/cluster-autoscaler:0.11.0@sha256:7f617de5a24de790a15d9e97c6287ff2b390922e6e74c7a665cbf498f634514d
+ghcr.io/aenix-io/cozystack/cluster-autoscaler:0.11.1@sha256:7f617de5a24de790a15d9e97c6287ff2b390922e6e74c7a665cbf498f634514d

--- a/packages/apps/kubernetes/images/kubevirt-cloud-provider.tag
+++ b/packages/apps/kubernetes/images/kubevirt-cloud-provider.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/kubevirt-cloud-provider:0.11.0@sha256:91e6843afa704ba7c513842bc3a612f2c0b295ce95aebe60fbb6be09709a1947
+ghcr.io/aenix-io/cozystack/kubevirt-cloud-provider:0.11.1@sha256:b5aa62a53be566b49dea635ce8f6b9280566e260f8493ff3d71f8c7501fb4cbc

--- a/packages/apps/kubernetes/images/kubevirt-csi-driver.tag
+++ b/packages/apps/kubernetes/images/kubevirt-csi-driver.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/kubevirt-csi-driver:0.11.0@sha256:1a9e6592fc035dbaae27f308b934206858c2e0025d4c99cd906b51615cc9766c
+ghcr.io/aenix-io/cozystack/kubevirt-csi-driver:0.11.1@sha256:705e20e638315501aaa8b8156ceb8b260086b21876aa994bec9d6c406955c6d4

--- a/packages/core/installer/values.yaml
+++ b/packages/core/installer/values.yaml
@@ -1,2 +1,2 @@
 cozystack:
-  image: ghcr.io/aenix-io/cozystack/cozystack:v0.16.1@sha256:f27695d23d449f10888295bd2ba6c084c8fa4b81f109d4836ec9db528b943b62
+  image: ghcr.io/aenix-io/cozystack/cozystack:v0.16.2@sha256:0ee9d03a0453f19cc8deabf9ee4b9c6d9cc61e4ba833546a62a2f6b2265868f3

--- a/packages/core/testing/values.yaml
+++ b/packages/core/testing/values.yaml
@@ -1,2 +1,2 @@
 e2e:
-  image: ghcr.io/aenix-io/cozystack/e2e-sandbox:v0.16.1@sha256:25b298d621ec79431d106184d59849bbae634588742583d111628126ad8615c5
+  image: ghcr.io/aenix-io/cozystack/e2e-sandbox:v0.16.2@sha256:25b298d621ec79431d106184d59849bbae634588742583d111628126ad8615c5

--- a/packages/system/dashboard/values.yaml
+++ b/packages/system/dashboard/values.yaml
@@ -33,11 +33,11 @@ kubeapps:
     image:
       registry: ghcr.io/aenix-io/cozystack
       repository: dashboard
-      tag: v0.16.1
+      tag: v0.16.2
       digest: "sha256:4818712e9fc9c57cc321512760c3226af564a04e69d4b3ec9229ab91fd39abeb"
   kubeappsapis:
     image:
       registry: ghcr.io/aenix-io/cozystack
       repository: kubeapps-apis
-      tag: v0.16.1
+      tag: v0.16.2
       digest: "sha256:55bc8e2495933112c7cb4bb9e3b1fcb8df46aa14e27fa007f78388a9757e3238"

--- a/packages/system/kamaji/values.yaml
+++ b/packages/system/kamaji/values.yaml
@@ -3,7 +3,7 @@ kamaji:
     deploy: false
   image:
     pullPolicy: IfNotPresent
-    tag: v0.16.1@sha256:95a9658cbbe1cbfbc42b9ab1df4f2a39342d7a8f1ff10a10b81b8656f3744c39
+    tag: v0.16.2@sha256:95a9658cbbe1cbfbc42b9ab1df4f2a39342d7a8f1ff10a10b81b8656f3744c39
     repository: ghcr.io/aenix-io/cozystack/kamaji
   resources:
     limits:


### PR DESCRIPTION
- cilium: Fix tunnel option (#392)
- fix grpc address lookup in kubevirt-csi-driver (#393)
- Prepare release v0.16.2
