### PR TITLE
Add MachineHealthChecks for Kubernetes VMs

### DIFF
--- a/packages/apps/kubernetes/Chart.yaml
+++ b/packages/apps/kubernetes/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.1
+version: 0.12.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -210,6 +210,26 @@ spec:
         name: {{ $.Release.Name }}-{{ $groupName }}-{{ $kubevirtmachinetemplateHash }}
         namespace: default
       version: v1.30.1
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: {{ $.Release.Name }}-{{ $groupName }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  clusterName: {{ $.Release.Name }}
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: {{ $.Release.Name }}
+      cluster.x-k8s.io/deployment-name: {{ $.Release.Name }}-{{ $groupName }}
+  unhealthyConditions:
+  - type: Ready
+    status: Unknown
+    timeout: 30s
+  - type: Ready
+    status: "False"
+    timeout: 30s
 {{- end }}
 ---
 {{- /*

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -33,7 +33,8 @@ kubernetes 0.8.2 5ca8823
 kubernetes 0.9.0 9b6dd19
 kubernetes 0.10.0 ac5c38b
 kubernetes 0.11.0 4eaca42
-kubernetes 0.11.1 HEAD
+kubernetes 0.11.1 4f430a90
+kubernetes 0.12.0 HEAD
 mysql 0.1.0 f642698
 mysql 0.2.0 8b975ff0
 mysql 0.3.0 5ca8823


### PR DESCRIPTION
Add `MachineHealthCheck` resource to continiusly checking Machine state.
If Machine is not ready it will be recreated in 60 seconds after unavailabilty. (30 sec kubelet to stop posing the status + 30 sec MachineHealthCheck timeout)

Fixes https://github.com/aenix-io/cozystack/issues/365

Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `MachineHealthCheck` resource to monitor the health of machine deployments in Kubernetes.
  
- **Version Updates**
	- Updated the Kubernetes chart version from `0.11.1` to `0.12.0`.
	- Various packages' versions have been updated to reflect the latest revisions, ensuring accuracy in versioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->