### PR TITLE
Disable serviceLinks

### DIFF
--- a/packages/apps/kafka/templates/kafka.yaml
+++ b/packages/apps/kafka/templates/kafka.yaml
@@ -76,3 +76,5 @@ spec:
         metadata:
          labels:
            policy.cozystack.io/allow-to-apiserver: "true"
+      spec:
+        enableServiceLinks: false

--- a/packages/apps/kubernetes/templates/cluster-autoscaler/deployment.yaml
+++ b/packages/apps/kubernetes/templates/cluster-autoscaler/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         app: {{ .Release.Name }}-cluster-autoscaler
         policy.cozystack.io/allow-to-apiserver: "true"
     spec:
+      enableServiceLinks: false
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists

--- a/packages/apps/kubernetes/templates/csi/deploy.yaml
+++ b/packages/apps/kubernetes/templates/csi/deploy.yaml
@@ -15,6 +15,7 @@ spec:
         app: {{ .Release.Name }}-kcsi-driver
         policy.cozystack.io/allow-to-apiserver: "true"
     spec:
+      enableServiceLinks: false
       serviceAccountName: {{ .Release.Name }}-kcsi
       priorityClassName: system-cluster-critical
       tolerations:

--- a/packages/apps/kubernetes/templates/kccm/manager.yaml
+++ b/packages/apps/kubernetes/templates/kccm/manager.yaml
@@ -15,6 +15,7 @@ spec:
         k8s-app: {{ .Release.Name }}-kccm
         policy.cozystack.io/allow-to-apiserver: "true"
     spec:
+      enableServiceLinks: false
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists

--- a/packages/apps/rabbitmq/templates/rabbitmq.yaml
+++ b/packages/apps/rabbitmq/templates/rabbitmq.yaml
@@ -16,6 +16,8 @@ spec:
     statefulSet:
       spec:
         template:
+          spec:
+            enableServiceLinks: false
           metadata:
             labels:
               policy.cozystack.io/allow-to-apiserver: "true"


### PR DESCRIPTION
Fixes https://github.com/kubevirt/csi-driver/issues/120#issuecomment-2402467106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option to disable service links for various Kubernetes deployments, enhancing service resolution control for the following:
		- Kafka
		- Cluster Autoscaler
		- CSI Controller
		- Cloud Controller Manager
		- RabbitMQ

<!-- end of auto-generated comment: release notes by coderabbit.ai -->