### PR TITLE
cdi: specify scratchSpaceStorageClass=local

### DIFF
--- a/packages/system/kubevirt-cdi/templates/cdi-cr.yaml
+++ b/packages/system/kubevirt-cdi/templates/cdi-cr.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cdi
 spec:
   config:
+    scratchSpaceStorageClass: "local"
     featureGates:
     - HonorWaitForFirstConsumer
     - ExpandDisks


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration parameter `scratchSpaceStorageClass` set to `"local"` in the CDI resource, enhancing customization options for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->