### PR TITLE
fix version if work in fort

### DIFF
--- a/scripts/common-envs.mk
+++ b/scripts/common-envs.mk
@@ -8,3 +8,9 @@ TAG = $(shell git describe --tags --exact-match 2>/dev/null || echo latest)
 define settag
 $(if $(filter $(TAG),latest),latest,$(1))
 endef
+
+ifeq ($(VERSION),)
+    $(shell git remote add upstream https://github.com/aenix-io/cozystack.git || true)
+    $(shell git fetch upstream --tags)
+    VERSION = $(patsubst v%,%,$(shell git describe --tags --abbrev=0))
+endif


### PR DESCRIPTION
if i work in fork, i see error:

```
klin@asus:~/gumilev/cozystack/packages/core/installer$ make image-cozystack REGISTRY=kklinch0
make -C ../../.. repos
make[1]: Entering directory '/home/klin/gumilev/cozystack'
rm -rf _out
make -C packages/apps check-version-map
make[2]: Entering directory '/home/klin/gumilev/cozystack/packages/apps'
find . -maxdepth 2 -name Chart.yaml  | awk -F/ '{print $2}' | while read i; do sed -i "s/^name: .*/name: $i/" "$i/Chart.yaml"; done
../../hack/gen_versions_map.sh
git diff --exit-code -- versions_map
make[2]: Leaving directory '/home/klin/gumilev/cozystack/packages/apps'
make -C packages/extra check-version-map
make[2]: Entering directory '/home/klin/gumilev/cozystack/packages/extra'
find . -maxdepth 2 -name Chart.yaml | awk -F/ '{print $2}' | while read i; do sed -i "s/^name: .*/name: $i/" "$i/Chart.yaml"; done
../../hack/gen_versions_map.sh
git diff --exit-code -- versions_map
make[2]: Leaving directory '/home/klin/gumilev/cozystack/packages/extra'
make -C packages/system repo
make[2]: Entering directory '/home/klin/gumilev/cozystack/packages/system'
fatal: No names found, cannot describe anything.
rm -rf "../../_out/repos/system"
mkdir -p "../../_out/repos/system"
helm package -d "../../_out/repos/system" $(find . -mindepth 2 -maxdepth 2 -name Chart.yaml | awk 'sub("/Chart.yaml", "")') --version 
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/klin/.kube/config
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /home/klin/.kube/config
Error: flag needs an argument: --version
make[2]: *** [Makefile:8: repo] Error 1
make[2]: Leaving directory '/home/klin/gumilev/cozystack/packages/system'
make[1]: *** [Makefile:26: repos] Error 2
make[1]: Leaving directory '/home/klin/gumilev/cozystack'
make: *** [Makefile:26: image-cozystack] Error 
```

so as not to cause unnecessary difficulties when trying to find the problem, I suggest this crutch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced script functionality to automatically retrieve the latest version tag when not defined.
  
- **Bug Fixes**
	- Improved handling of the `VERSION` variable to ensure it is populated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->