### PR TITLE
temporary disable readinessProbe

### DIFF
--- a/packages/system/monitoring/values.yaml
+++ b/packages/system/monitoring/values.yaml
@@ -23,6 +23,11 @@ metrics-server:
         size: 10Gi
 
 fluent-bit:
+
+  readinessProbe:
+    httpGet:
+      path: /
+
   daemonSetVolumes:
     - name: varlog
       hostPath:


### PR DESCRIPTION
It is blocking monitoring installation when monitoring in tenant-root isn't ready yet