### PR TITLE
add kk operator and configure

### DIFF
--- a/packages/core/platform/bundles/distro-full.yaml
+++ b/packages/core/platform/bundles/distro-full.yaml
@@ -181,3 +181,10 @@ releases:
   namespace: cozy-keycloak
   optional: true
   dependsOn: [postgres-operator]
+
+- name: keycloak-operator
+  releaseName: keycloak-operator
+  chart: cozy-keycloak-operator
+  namespace: cozy-keycloak
+  optional: true
+  dependsOn: [keycloak]

--- a/packages/core/platform/bundles/distro-hosted.yaml
+++ b/packages/core/platform/bundles/distro-hosted.yaml
@@ -131,3 +131,10 @@ releases:
   namespace: cozy-keycloak
   optional: true
   dependsOn: [postgres-operator]
+
+- name: keycloak-operator
+  releaseName: keycloak-operator
+  chart: cozy-keycloak-operator
+  namespace: cozy-keycloak
+  optional: true
+  dependsOn: [keycloak]

--- a/packages/core/platform/bundles/paas-full.yaml
+++ b/packages/core/platform/bundles/paas-full.yaml
@@ -255,3 +255,9 @@ releases:
   chart: cozy-keycloak
   namespace: cozy-keycloak
   dependsOn: [postgres-operator]
+
+- name: keycloak-operator
+  releaseName: keycloak-operator
+  chart: cozy-keycloak-operator
+  namespace: cozy-keycloak
+  dependsOn: [keycloak]

--- a/packages/core/platform/bundles/paas-hosted.yaml
+++ b/packages/core/platform/bundles/paas-hosted.yaml
@@ -151,3 +151,9 @@ releases:
   chart: cozy-keycloak
   namespace: cozy-keycloak
   dependsOn: [postgres-operator]
+
+- name: keycloak-operator
+  releaseName: keycloak-operator
+  chart: cozy-keycloak-operator
+  namespace: cozy-keycloak
+  dependsOn: [keycloak]

--- a/packages/system/keycloak-operator/Chart.yaml
+++ b/packages/system/keycloak-operator/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: cozy-keycloak-operator
+version: 0.0.0 # Placeholder, the actual version will be automatically set during the build process

--- a/packages/system/keycloak-operator/Makefile
+++ b/packages/system/keycloak-operator/Makefile
@@ -1,0 +1,7 @@
+include ../../../scripts/package.mk
+
+update:
+	rm -rf charts
+	helm repo add epamedp https://epam.github.io/edp-helm-charts/stable
+	helm repo update epamedp
+	helm pull epamedp/keycloak-operator --untar --untardir charts

--- a/packages/system/keycloak-operator/charts/keycloak-operator/.helmignore
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/packages/system/keycloak-operator/charts/keycloak-operator/Chart.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/Chart.yaml
@@ -1,0 +1,311 @@
+annotations:
+  artifacthub.io/changes: |
+    - Add frontend url property for realm
+    - Allow define KeycloakRealmUser password in Kubernetes secret
+    - Update current development version
+    - Publish 1.15.0 version on OperatorHub
+    - Update current development version
+    - Add a description to the Custom Resources fields
+  artifacthub.io/crds: |
+    - kind: Keycloak
+      version: v1.edp.epam.com/v1
+      name: keycloak
+      displayName: keycloak
+      description: Keycloak instance baseline configuration
+    - kind: ClusterKeycloak
+      version: v1.edp.epam.com/v1alpha1
+      name: clusterkeycloak
+      displayName: clusterkeycloak
+      description: Keycloak instance baseline configuration
+    - kind: KeycloakAuthFlow
+      version: v1.edp.epam.com/v1
+      name: keycloakauthflows
+      displayName: keycloakauthflows
+      description: Keycloak AuthFlow Management
+    - kind: KeycloakClient
+      version: v1.edp.epam.com/v1
+      name: keycloakpermissiontemplate
+      displayName: KeycloakClient
+      description: Keycloak client Management
+    - kind: KeycloakClientScope
+      version: v1.edp.epam.com/v1
+      name: keycloakclientscope
+      displayName: KeycloakClientScope
+      description: Keycloak Client Scope Management
+    - kind: KeycloakRealm
+      version: v1.edp.epam.com/v1
+      name: keycloakrealm
+      displayName: KeycloakRealm
+      description: Keycloak Realm Management
+    - kind: KeycloakRealmComponent
+      version: v1.edp.epam.com/v1
+      name: keycloakrealmcomponent
+      displayName: KeycloakRealmComponent
+      description: Keycloak Realm Component Management
+    - kind: KeycloakRealmGroup
+      version: v1.edp.epam.com/v1
+      name: keycloakrealmgroup
+      displayName: KeycloakRealmGroup
+      description: Keycloak Realm Group Management
+    - kind: KeycloakRealmIdentityProvider
+      version: v1.edp.epam.com/v1
+      name: keycloakrealmidentityprovider
+      displayName: KeycloakRealmIdentityProvider
+      description: Keycloak Realm Identity Provider Management
+    - kind: KeycloakRealmRole
+      version: v1.edp.epam.com/v1
+      name: keycloakrealmrole
+      displayName: KeycloakRealmRole
+      description: Keycloak Realm Role Management
+    - kind: KeycloakRealmRoleBatch
+      version: v1.edp.epam.com/v1
+      name: keycloakrealmrolebatch
+      displayName: KeycloakRealmRoleBatch
+      description: Keycloak Realm Role Management in a batch mode
+    - kind: KeycloakRealmUser
+      version: v1.edp.epam.com/v1
+      name: keycloakrealmuser
+      displayName: KeycloakRealmUser
+      description: Keycloak Realm User Management
+  artifacthub.io/crdsExamples: |
+    - apiVersion: v1.edp.epam.com/v1
+      kind: KeycloakClientScope
+      metadata:
+        name: groups
+      spec:
+        name: groups
+        realm: main
+        description: "Group Membership"
+        protocol: openid-connect
+        protocolMappers:
+          - name: groups
+            protocol: openid-connect
+            protocolMapper: "oidc-group-membership-mapper"
+            config:
+              "access.token.claim": "true"
+              "claim.name": "groups"
+              "full.path": "false"
+              "id.token.claim": "true"
+              "userinfo.token.claim": "true"
+    - apiVersion: v1.edp.epam.com/v1
+      kind: KeycloakClient
+      metadata:
+        name: argocd
+      spec:
+        advancedProtocolMappers: true
+        clientId: agocd
+        directAccess: true
+        public: false
+        secret: ''
+        targetRealm: edp-delivery-main
+        webUrl: https://argocd.example.com
+        defaultClientScopes:
+          - argocd_groups
+    - apiVersion: v1.edp.epam.com/v1
+      kind: KeycloakRealmGroup
+      metadata:
+        name: argocd-admins
+      spec:
+        clientRoles: null
+        name: ArgoCDAdmins
+        realm: main
+    - apiVersion: v1.edp.epam.com/v1
+      kind: KeycloakAuthFlow
+      metadata:
+        name: d1-auth-flow
+      spec:
+        realm: d2-id-k8s-realm-name
+        alias: MyBrowser
+        description: browser with idp
+        providerId: basic-flow
+        topLevel: true
+        builtIn: false
+        authenticationExecutions:
+          - authenticator: "auth-cookie"
+            priority: 0
+            requirement: "ALTERNATIVE"
+          - authenticator: "identity-provider-redirector"
+            priority: 1
+            requirement: "REQUIRED"
+            authenticatorConfig:
+              alias: my-alias
+              config:
+                "defaultProvider": "my-alias"
+    - apiVersion: v1.edp.epam.com/v1
+      kind: KeycloakRealmComponent
+      metadata:
+        name: kerberos-test
+      spec:
+        realm: d1-id-k8s-realm-name
+        name: cr-kerb-test
+        providerId: kerberos
+        providerType: "org.keycloak.storage.UserStorageProvider"
+        config:
+          allowPasswordAuthentication: ["true"]
+          cachePolicy: ["EVICT_WEEKLY"]
+          debug: ["true"]
+          editMode: ["READ_ONLY"]
+          enabled: ["true"]
+          evictionDay: ["3"]
+          evictionHour: ["5"]
+          evictionMinute: ["7"]
+          kerberosRealm: ["test-realm"]
+          keyTab: ["test-key-tab"]
+          priority: ["0"]
+          serverPrincipal: ["srv-principal-test"]
+          updateProfileFirstLogin: ["true"]
+    - apiVersion: v1.edp.epam.com/v1
+      kind: KeycloakRealmIdentityProvider
+      metadata:
+        name: instagram-test
+      spec:
+        realm: d2-id-k8s-realm-name
+        alias: instagram
+        authenticateByDefault: false
+        enabled: true
+        firstBrokerLoginFlowAlias: "first broker login"
+        providerId: "instagram"
+        config:
+          clientId: "foo"
+          clientSecret: "bar"
+          hideOnLoginPage: "true"
+          syncMode: "IMPORT"
+          useJwksUrl: "true"
+        mappers:
+          - name: "test3212"
+            identityProviderMapper: "oidc-hardcoded-role-idp-mapper"
+            identityProviderAlias: "instagram"
+            config:
+              role: "role-tr"
+              syncMode: "INHERIT"
+          - name: "test-33221"
+            identityProviderMapper: "hardcoded-attribute-idp-mapper"
+            identityProviderAlias: "instagram"
+            config:
+              attribute: "foo"
+              "attribute.value": "bar"
+              syncMode: "IMPORT"
+    - apiVersion: v1.edp.epam.com/v1
+      kind: KeycloakRealm
+      metadata:
+        name: d2-id-k8s-realm-name
+      spec:
+        id: d1-id-kc-realm-name
+        realmName: d2-id-kc-realm-name
+        keycloakOwner: main
+        passwordPolicy:
+          - type: "forceExpiredPasswordChange"
+            value: "365"
+          - type: "length"
+            value: "8"
+        realmEventConfig:
+          adminEventsDetailsEnabled: false
+          adminEventsEnabled: true
+          enabledEventTypes:
+            - UPDATE_CONSENT_ERROR
+            - CLIENT_LOGIN
+          eventsEnabled: true
+          eventsExpiration: 15000
+          eventsListeners:
+            - jboss-logging
+    - apiVersion: v1.edp.epam.com/v1
+      kind: KeycloakRealmUser
+      metadata:
+        name: d1-user-test1
+      spec:
+        realm: d1-id-k8s-realm-name
+        username: "john.snow13"
+        firstName: "John"
+        lastName: "Snow"
+        email: "john.snow13@example.com"
+        enabled: true
+        emailVerified: true
+        password: "12345678"
+        keepResource: true
+        requiredUserActions:
+          - UPDATE_PASSWORD
+        attributes:
+          foo: "bar"
+          baz: "jazz"
+    - apiVersion: v1.edp.epam.com/v1
+      kind: Keycloak
+      metadata:
+        name: my-keycloak
+      spec:
+        secret: my-keycloak-secret
+        url: https://example.com
+    - apiVersion: v1.edp.epam.com/v1
+      kind: KeycloakRealmRoleBatch
+      metadata:
+        name: myrole
+      spec:
+        realm: main
+        roles:
+          - attributes: null
+            composite: true
+            composites: null
+            description: default developer role
+            isDefault: false
+            name: developer
+          - attributes: null
+            composite: true
+            composites: null
+            description: default administrator role
+            isDefault: false
+            name: administrator
+    - apiVersion: v1.edp.epam.com/v1
+      kind: KeycloakRealmRole
+      metadata:
+        name: realmrole
+      spec:
+        attributes: null
+        composite: true
+        composites: null
+        description: default developer role
+        name: developer
+        realm: main
+    - apiVersion: v1.edp.epam.com/v1alpha1
+      kind: ClusterKeycloak
+      metadata:
+        name: keycloak-sample
+      spec:
+        secret: secret-name-in-operator-ns
+        url: https://keycloak.example.com
+  artifacthub.io/images: |
+    - name: keycloak-operator:1.23.0
+      image: epamedp/keycloak-operator:1.23.0
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: KubeRocketCI Documentation
+      url: https://docs.kuberocketci.io
+    - name: EPAM SolutionHub
+      url: https://solutionshub.epam.com/solution/kuberocketci
+  artifacthub.io/operator: "true"
+  artifacthub.io/operatorCapabilities: Deep Insights
+apiVersion: v2
+appVersion: 1.23.0
+description: A Helm chart for KubeRocketCI Keycloak Operator
+home: https://docs.kuberocketci.io/
+icon: https://docs.kuberocketci.io/img/logo.svg
+keywords:
+- authentication
+- authorization
+- edp
+- idp
+- keycloak
+- oauth
+- oidc
+- operator
+- saml
+- sso
+maintainers:
+- email: SupportEPMD-EDP@epam.com
+  name: epmd-edp
+  url: https://solutionshub.epam.com/solution/kuberocketci
+- name: sergk
+  url: https://github.com/SergK
+name: keycloak-operator
+sources:
+- https://github.com/epam/edp-keycloak-operator
+type: application
+version: 1.23.0

--- a/packages/system/keycloak-operator/charts/keycloak-operator/README.md
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/README.md
@@ -1,0 +1,142 @@
+# keycloak-operator
+
+![Version: 1.23.0](https://img.shields.io/badge/Version-1.23.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.23.0](https://img.shields.io/badge/AppVersion-1.23.0-informational?style=flat-square)
+
+A Helm chart for KubeRocketCI Keycloak Operator
+
+**Homepage:** <https://docs.kuberocketci.io/>
+
+## Overview
+
+Keycloak Operator is a KubeRocketCI operator responsible for configuring existing Keycloak instances. The operator runs both on OpenShift and Kubernetes.
+
+_**NOTE:** Operator is platform-independent, which is why there is a unified instruction for deployment._
+
+## Prerequisites
+
+1. Linux machine or Windows Subsystem for Linux instance with [Helm 3](https://helm.sh/docs/intro/install/) installed;
+2. Cluster admin access to the cluster;
+
+## Installation Using Helm Chart
+
+To install the Keycloak Operator, follow the steps below:
+
+1. To add the Helm EPAMEDP Charts for a local client, run "helm repo add":
+
+     ```bash
+     helm repo add epamedp https://epam.github.io/edp-helm-charts/stable
+     ```
+
+2. Choose the available Helm chart version:
+
+     ```bash
+     helm search repo epamedp/keycloak-operator -l
+     NAME                           CHART VERSION   APP VERSION     DESCRIPTION
+     epamedp/keycloak-operator      1.22.0          1.22.0          A Helm chart for KRCI Keycloak Operator
+     ```
+
+    _**NOTE:** It is highly recommended to use the latest stable version._
+
+3. Full chart parameters available below.
+
+4. Install the operator in the <edp-project> namespace with the helm command; find below the installation command example:
+
+    ```bash
+    helm install keycloak-operator epamedp/keycloak-operator --version <chart_version> --namespace <edp-project> --set name=keycloak-operator
+    ```
+
+5. Check the <edp-project> namespace containing Deployment with your operator in running status.
+
+## Quick Start
+
+1. Create a User in the Keycloak `Master` realm, and assign a `create-realm` role.
+
+2. Insert newly created user credentials into Kubernetes secret:
+
+    ```yaml
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name:  keycloak-access
+    type: Opaque
+    data:
+      username: dXNlcg==   # base64-encoded value of "user"
+      password: cGFzcw==   # base64-encoded value of "pass"
+    ```
+
+3. Create Custom Resource `kind: Keycloak` with Keycloak instance URL and secret created on the previous step:
+
+    ```yaml
+    apiVersion: v1.edp.epam.com/v1
+    kind: Keycloak
+    metadata:
+      name: keycloak-sample
+    spec:
+      secret: keycloak-access             # Secret name
+      url: https://keycloak.example.com   # Keycloak URL
+    ```
+
+    Wait for the `.status` field with  `status.connected: true`
+
+4. Create Keycloak realm and group using Custom Resources:
+
+   ```yaml
+   apiVersion: v1.edp.epam.com/v1
+   kind: KeycloakRealm
+   metadata:
+    name: keycloakrealm-sample
+   spec:
+    realmName: realm-sample
+    keycloakOwner: keycloak-sample   # the name of `kind: Keycloak`
+    ```
+
+    ```yaml
+    apiVersion: v1.edp.epam.com/v1
+    kind: KeycloakRealmGroup
+    metadata:
+      name: argocd-admins
+    spec:
+      name: ArgoCDAdmins
+      realm: keycloakrealm-sample   # the name of `kind: KeycloakRealm`
+    ```
+
+    Inspect [available custom resource](./docs/arch.md) and [CR templates folder](./deploy-templates/_crd_examples/) for more examples
+
+## Local Development
+
+To develop the operator, first set up a local environment, and refer to the [Local Development](https://docs.kuberocketci.io/docs/developer-guide/local-development) page.
+
+Development versions are also available from the [snapshot helm chart repository](https://epam.github.io/edp-helm-charts/snapshot/) page.
+
+### Related Articles
+
+* [Install KubeRocketCI](https://docs.kuberocketci.io/docs/operator-guide/install-kuberocketci)
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| epmd-edp | <SupportEPMD-EDP@epam.com> | <https://solutionshub.epam.com/solution/kuberocketci> |
+| sergk |  | <https://github.com/SergK> |
+
+## Source Code
+
+* <https://github.com/epam/edp-keycloak-operator>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity for pod assignment |
+| annotations | object | `{}` | Annotations to be added to the Deployment |
+| clusterReconciliationEnabled | bool | `false` | If clusterReconciliationEnabled is true, the operator reconciles all Keycloak instances in the cluster;  otherwise, it only reconciles instances in the same namespace by default, and cluster-scoped resources are ignored. |
+| extraVolumeMounts | list | `[]` | Additional volumeMounts to be added to the container |
+| extraVolumes | list | `[]` | Additional volumes to be added to the pod |
+| image.repository | string | `"epamedp/keycloak-operator"` | KubeRocketCI keycloak-operator Docker image name. The released image can be found on [Dockerhub](https://hub.docker.com/r/epamedp/keycloak-operator) |
+| image.tag | string | `nil` | KubeRocketCI keycloak-operator Docker image tag. The released image can be found on [Dockerhub](https://hub.docker.com/r/epamedp/keycloak-operator/tags) |
+| imagePullPolicy | string | `"IfNotPresent"` | If defined, a imagePullPolicy applied to the deployment |
+| imagePullSecrets | list | `[]` | If defined, imagePullSecrets are applied to deployment |
+| name | string | `"keycloak-operator"` | Application name string |
+| nodeSelector | object | `{}` | Node labels for pod assignment |
+| resources | object | `{"limits":{"memory":"192Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | Resource limits and requests for the pod |
+| tolerations | list | `[]` | Node tolerations for server scheduling to nodes with taints |

--- a/packages/system/keycloak-operator/charts/keycloak-operator/README.md.gotmpl
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/README.md.gotmpl
@@ -1,0 +1,122 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+## Overview
+
+Keycloak Operator is a KubeRocketCI operator responsible for configuring existing Keycloak instances. The operator runs both on OpenShift and Kubernetes.
+
+_**NOTE:** Operator is platform-independent, which is why there is a unified instruction for deployment._
+
+## Prerequisites
+
+1. Linux machine or Windows Subsystem for Linux instance with [Helm 3](https://helm.sh/docs/intro/install/) installed;
+2. Cluster admin access to the cluster;
+
+## Installation Using Helm Chart
+
+To install the Keycloak Operator, follow the steps below:
+
+1. To add the Helm EPAMEDP Charts for a local client, run "helm repo add":
+
+     ```bash
+     helm repo add epamedp https://epam.github.io/edp-helm-charts/stable
+     ```
+
+2. Choose the available Helm chart version:
+
+     ```bash
+     helm search repo epamedp/keycloak-operator -l
+     NAME                           CHART VERSION   APP VERSION     DESCRIPTION
+     epamedp/keycloak-operator      1.22.0          1.22.0          A Helm chart for KRCI Keycloak Operator
+     ```
+
+    _**NOTE:** It is highly recommended to use the latest stable version._
+
+3. Full chart parameters available below.
+
+4. Install the operator in the <edp-project> namespace with the helm command; find below the installation command example:
+
+    ```bash
+    helm install keycloak-operator epamedp/keycloak-operator --version <chart_version> --namespace <edp-project> --set name=keycloak-operator
+    ```
+
+5. Check the <edp-project> namespace containing Deployment with your operator in running status.
+
+## Quick Start
+
+1. Create a User in the Keycloak `Master` realm, and assign a `create-realm` role.
+
+2. Insert newly created user credentials into Kubernetes secret:
+
+    ```yaml
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name:  keycloak-access
+    type: Opaque
+    data:
+      username: dXNlcg==   # base64-encoded value of "user"
+      password: cGFzcw==   # base64-encoded value of "pass"
+    ```
+
+3. Create Custom Resource `kind: Keycloak` with Keycloak instance URL and secret created on the previous step:
+
+    ```yaml
+    apiVersion: v1.edp.epam.com/v1
+    kind: Keycloak
+    metadata:
+      name: keycloak-sample
+    spec:
+      secret: keycloak-access             # Secret name
+      url: https://keycloak.example.com   # Keycloak URL
+    ```
+
+    Wait for the `.status` field with  `status.connected: true`
+
+4. Create Keycloak realm and group using Custom Resources:
+
+   ```yaml
+   apiVersion: v1.edp.epam.com/v1
+   kind: KeycloakRealm
+   metadata:
+    name: keycloakrealm-sample
+   spec:
+    realmName: realm-sample
+    keycloakOwner: keycloak-sample   # the name of `kind: Keycloak`
+    ```
+
+    ```yaml
+    apiVersion: v1.edp.epam.com/v1
+    kind: KeycloakRealmGroup
+    metadata:
+      name: argocd-admins
+    spec:
+      name: ArgoCDAdmins
+      realm: keycloakrealm-sample   # the name of `kind: KeycloakRealm`
+    ```
+
+    Inspect [available custom resource](./docs/arch.md) and [CR templates folder](./deploy-templates/_crd_examples/) for more examples
+
+## Local Development
+
+To develop the operator, first set up a local environment, and refer to the [Local Development](https://docs.kuberocketci.io/docs/developer-guide/local-development) page.
+
+Development versions are also available from the [snapshot helm chart repository](https://epam.github.io/edp-helm-charts/snapshot/) page.
+
+### Related Articles
+
+* [Install KubeRocketCI](https://docs.kuberocketci.io/docs/operator-guide/install-kuberocketci)
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/clusterkeycloak.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/clusterkeycloak.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1.edp.epam.com/v1alpha1
+kind: ClusterKeycloak
+metadata:
+  name: keycloak-sample
+spec:
+  secret: keycloak-access
+  url: https://keycloak.example.com

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/clusterkeycloakrealm.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/clusterkeycloakrealm.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1.edp.epam.com/v1alpha1
+kind: ClusterKeycloakRealm
+metadata:
+  name: clusterkeycloakrealm-sample
+spec:
+  clusterKeycloakRef: clusterkeycloak-sample
+  realmName: realm-sample1234
+  authenticationFlows:
+    browserFlow: browserFlow-sample

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloak.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloak.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1.edp.epam.com/v1
+kind: Keycloak
+metadata:
+  name: keycloak-sample
+spec:
+  secret: keycloak-access
+  url: https://keycloak.example.com
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-access
+data:
+  username: YWRtaW4=
+  password: YWRtaW4=

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakauthflow.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakauthflow.yaml
@@ -1,0 +1,83 @@
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakAuthFlow
+metadata:
+  name: keycloakauthflow-sample
+spec:
+  realmRef:
+    name: keycloakrealm-sample
+    kind: KeycloakRealm
+  alias: Demo
+  description: Example of KeycloakAuthFlow
+  providerId: basic-flow
+  topLevel: true
+  builtIn: false
+  authenticationExecutions:
+    - authenticator: "auth-cookie"
+      priority: 0
+      requirement: "ALTERNATIVE"
+    - authenticator: "identity-provider-redirector"
+      priority: 1
+      requirement: "ALTERNATIVE"
+      authenticatorConfig:
+        alias: my-alias
+        config:
+          "defaultProvider": "my-alias"
+---
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakAuthFlow
+metadata:
+  name: keycloakauthflow-forms
+spec:
+  realmRef:
+    name: keycloakrealm-sample
+    kind: KeycloakRealm
+  alias: Forms
+  description: browser auth forms
+  providerId: basic-flow
+  topLevel: false
+  parentName: Demo
+  childType: basic-flow
+  builtIn: false
+---
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakAuthFlow
+metadata:
+  name: keycloakauthflow-x509
+spec:
+  realmRef:
+    name: keycloakrealm-sample
+    kind: KeycloakRealm
+  alias: X509
+  description: Client certificate, and other auth forms.
+  providerId: basic-flow
+  topLevel: false
+  parentName: Forms
+  childType: basic-flow
+  builtIn: false
+  authenticationExecutions:
+    - authenticator: "auth-x509-client-username-form"
+      priority: 0
+      requirement: "ALTERNATIVE"
+---
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakAuthFlow
+metadata:
+  name: keycloakauthflow-otp
+spec:
+  realmRef:
+    name: keycloakrealm-sample
+    kind: KeycloakRealm
+  alias: Conditional OTP
+  description: Flow to determine if the OTP is required for the authentication.
+  providerId: basic-flow
+  topLevel: false
+  parentName: X509
+  childType: basic-flow
+  builtIn: false
+  authenticationExecutions:
+    - authenticator: "conditional-user-configured"
+      priority: 0
+      requirement: "ALTERNATIVE"
+    - authenticator: "auth-otp-form"
+      priority: 0
+      requirement: "ALTERNATIVE"

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakclient.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakclient.yaml
@@ -1,0 +1,117 @@
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakClient
+metadata:
+  name: keycloakclient-sample
+spec:
+  realmRef:
+    name: keycloakrealm-sample
+    kind: KeycloakRealm
+  advancedProtocolMappers: true
+  clientId: agocd
+  directAccess: true
+  public: false
+  secret: $client-secret-name:client-secret-key
+  webUrl: https://argocd.example.com
+  defaultClientScopes:
+    - groups
+  redirectUris:
+    - /url1/*
+    - /url2/*
+
+---
+
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakClient
+metadata:
+  name: keycloakclient-policy-sample
+spec:
+  realmRef:
+    name: keycloakrealm-sample
+    kind: KeycloakRealm
+  clientId: policy-sample
+  secret: $client-secret-policy-sample:client-secret-key
+  webUrl: http://example.com
+  directAccess: true
+  authorizationServicesEnabled: true
+  serviceAccount:
+    enabled: true
+  authorization:
+    policies:
+      - name: role-policy
+        type: role
+        decisionStrategy: AFFIRMATIVE
+        logic: POSITIVE
+        description: "Role policy"
+        rolePolicy:
+          roles:
+            - name: developer
+              required: true
+      - type: aggregate
+        name: aggregate-policy
+        description: "Aggregate policy"
+        aggregatedPolicy:
+          policies:
+            - policy1
+            - policy2
+      - type: client
+        name: client-policy
+        description: "Client policy"
+        clientPolicy:
+          clients:
+            - client1
+            - client2
+      - type: group
+        name: group-policy
+        description: "Group policy"
+        groupPolicy:
+          groups:
+            - name: group1
+              extendChildren: true
+      - type: role
+        name: role-policy
+        description: "Role policy"
+        rolePolicy:
+          roles:
+            - name: developer
+              required: true
+      - type: time
+        name: time-policy
+        description: "Time policy"
+        timePolicy:
+          notBefore: "2021-01-01T00:00:00Z"
+          notOnOrAfter: "2021-12-31T23:59:59Z"
+      - type: user
+        name: user-policy
+        description: "User policy"
+        userPolicy:
+          users:
+            - user1
+            - user2
+    permissions:
+      - name: resource-permission
+        type: resource
+        logic: POSITIVE
+        description: "Resource permission"
+        decisionStrategy: AFFIRMATIVE
+        policies:
+          - role-policy
+        resources:
+          - resource1
+      - name: scope-permission
+        type: scope
+        logic: POSITIVE
+        description: "Scope permission"
+        decisionStrategy: CONSENSUS
+        policies:
+          - role-policy
+        scopes:
+          - scope1
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: client-secret-policy-sample
+data:
+  client-secret-key: cGFzc3dvcmQ=

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakclientscope.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakclientscope.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakClientScope
+metadata:
+  name: keycloakclientscope-sample
+spec:
+  name: groups
+  realmRef:
+    name: keycloakrealm-sample
+    kind: KeycloakRealm
+  description: "Group Membership"
+  protocol: openid-connect
+  protocolMappers:
+    - name: groups
+      protocol: openid-connect
+      protocolMapper: "oidc-group-membership-mapper"
+      config:
+        "access.token.claim": "true"
+        "claim.name": "groups"
+        "full.path": "false"
+        "id.token.claim": "true"
+        "userinfo.token.claim": "true"

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealm.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealm.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakRealm
+metadata:
+  name: keycloakrealm-sample
+spec:
+  id: bfebeff6-ac63-4b46-a1f3-37df5099a9c4
+  realmName: realm-sample
+  keycloakRef:
+    name: keycloak-sample
+    kind: Keycloak
+  passwordPolicy:
+    - type: "forceExpiredPasswordChange"
+      value: "365"
+    - type: "length"
+      value: "8"
+  realmEventConfig:
+    adminEventsDetailsEnabled: false
+    adminEventsEnabled: true
+    enabledEventTypes:
+      - UPDATE_CONSENT_ERROR
+      - CLIENT_LOGIN
+    eventsEnabled: true
+    eventsExpiration: 15000
+    eventsListeners:
+      - jboss-logging
+  tokenSettings:
+    accessTokenLifespan: 300
+    accessCodeLifespan: 300
+    accessToken: 300
+    actionTokenGeneratedByAdminLifespan: 300
+    actionTokenGeneratedByUserLifespan: 300
+    refreshTokenMaxReuse: 300
+    revokeRefreshToken: true
+    defaultSignatureAlgorithm: RS256

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmcomponent.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmcomponent.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakRealmComponent
+metadata:
+  name: component-sample
+spec:
+  realmRef:
+    name: keycloakrealm-sample
+    kind: KeycloakRealm
+  name: component-sample
+  providerId: scope
+  providerType: "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy"
+
+---
+
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakRealmComponent
+metadata:
+  name: component-sample-child
+spec:
+  realmRef:
+    name: keycloakrealm-sample
+    kind: KeycloakRealm
+  name: component-sample-child
+  providerId: scope
+  providerType: "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy"
+  parentRef:
+    name: component-sample
+    kind: KeycloakRealmComponent

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmgroup.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmgroup.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakRealmGroup
+metadata:
+  name: keycloakrealmgroup-sample
+spec:
+  realmRef:
+    name: keycloakrealm-sample
+    kind: KeycloakRealm
+  name: ArgoCDAdmins

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmidentityprovider.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmidentityprovider.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakRealmIdentityProvider
+metadata:
+  name: keycloakrealmidentityprovider-sample
+spec:
+  realmRef:
+    kind: KeycloakRealm
+    name: realm
+  alias: instagram
+  authenticateByDefault: false
+  enabled: true
+  firstBrokerLoginFlowAlias: "first broker login"
+  providerId: "instagram"
+  config:
+    clientId: "foo"
+    clientSecret: "$secretName:secretKey"
+    hideOnLoginPage: "true"
+    syncMode: "IMPORT"
+    useJwksUrl: "true"
+  mappers:
+    - name: "test-33221"
+      identityProviderMapper: "hardcoded-attribute-idp-mapper"
+      identityProviderAlias: "instagram"
+      config:
+        attribute: "foo"
+        "attribute.value": "bar"
+        syncMode: "IMPORT"

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmrole.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmrole.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakRealmRole
+metadata:
+  name: keycloakrealmrole-sample
+spec:
+  description: developer role
+  name: test-role
+  realmRef:
+    name: keycloakrealm-sample
+    kind: KeycloakRealm
+  composite: true
+  composites:
+    - name: offline_access
+  compositesClientRoles:
+    broker:
+      - name: read-token
+    account:
+      - name: manage-account
+      - name: view-profile

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmrolebatch.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmrolebatch.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakRealmRoleBatch
+metadata:
+  name: keycloakrealmrolebatch-sample
+spec:
+  realmRef:
+    name: keycloakrealm-sample
+    kind: KeycloakRealm
+  roles:
+    - description: default qa role
+      isDefault: false
+      name: qa

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmuser.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmuser.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakRealmUser
+metadata:
+  name: keycloakrealmuser-sample
+spec:
+  realmRef:
+    name: keycloakrealm-sample
+    kind: KeycloakRealm
+  username: "john.snow13"
+  firstName: "John"
+  lastName: "Snow"
+  email: "john.snow13@example.com"
+  enabled: true
+  emailVerified: true
+  keepResource: true
+  requiredUserActions:
+    - UPDATE_PASSWORD
+  attributes:
+    foo: "bar"
+    baz: "jazz"

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmuser_password.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmuser_password.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakRealmUser
+metadata:
+  name: keycloakrealmuser-sample
+spec:
+  realmRef:
+    name: keycloakrealm-sample
+    kind: KeycloakRealm
+  username: "john.snow13"
+  firstName: "John"
+  lastName: "Snow"
+  email: "john.snow13@example.com"
+  enabled: true
+  emailVerified: true
+  keepResource: true
+  attributes:
+    foo: "bar"
+    baz: "jazz"
+  passwordSecret:
+    name: existing-k8s-secret
+    key: key-which-contains-password

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_clusterkeycloakrealms.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_clusterkeycloakrealms.yaml
@@ -1,0 +1,258 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: clusterkeycloakrealms.v1.edp.epam.com
+spec:
+  group: v1.edp.epam.com
+  names:
+    kind: ClusterKeycloakRealm
+    listKind: ClusterKeycloakRealmList
+    plural: clusterkeycloakrealms
+    singular: clusterkeycloakrealm
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Keycloak realm is available
+      jsonPath: .status.available
+      name: Available
+      type: boolean
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterKeycloakRealm is the Schema for the clusterkeycloakrealms
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterKeycloakRealmSpec defines the desired state of ClusterKeycloakRealm.
+            properties:
+              authenticationFlows:
+                description: AuthenticationFlow is the configuration for authentication
+                  flows in the realm.
+                nullable: true
+                properties:
+                  browserFlow:
+                    description: BrowserFlow specifies the authentication flow to
+                      use for the realm's browser clients.
+                    example: browser
+                    type: string
+                type: object
+              browserSecurityHeaders:
+                additionalProperties:
+                  type: string
+                description: BrowserSecurityHeaders is a map of security headers to
+                  apply to HTTP responses from the realm's browser clients.
+                nullable: true
+                type: object
+              clusterKeycloakRef:
+                description: ClusterKeycloakRef is a name of the ClusterKeycloak instance
+                  that owns the realm.
+                type: string
+              displayHtmlName:
+                description: DisplayHTMLName name to render in the UI.
+                type: string
+              displayName:
+                description: DisplayName is the display name of the realm.
+                type: string
+              frontendUrl:
+                description: |-
+                  FrontendURL Set the frontend URL for the realm.
+                  Use in combination with the default hostname provider to override the base URL for frontend requests for a specific realm.
+                type: string
+              localization:
+                description: Localization is the configuration for localization in
+                  the realm.
+                nullable: true
+                properties:
+                  internationalizationEnabled:
+                    description: InternationalizationEnabled indicates whether to
+                      enable internationalization.
+                    nullable: true
+                    type: boolean
+                type: object
+              passwordPolicy:
+                description: PasswordPolicies is a list of password policies to apply
+                  to the realm.
+                items:
+                  properties:
+                    type:
+                      description: Type of password policy.
+                      type: string
+                    value:
+                      description: Value of password policy.
+                      type: string
+                  required:
+                  - type
+                  - value
+                  type: object
+                nullable: true
+                type: array
+              realmEventConfig:
+                description: RealmEventConfig is the configuration for events in the
+                  realm.
+                nullable: true
+                properties:
+                  adminEventsDetailsEnabled:
+                    description: AdminEventsDetailsEnabled indicates whether to enable
+                      detailed admin events.
+                    type: boolean
+                  adminEventsEnabled:
+                    description: AdminEventsEnabled indicates whether to enable admin
+                      events.
+                    type: boolean
+                  enabledEventTypes:
+                    description: EnabledEventTypes is a list of event types to enable.
+                    items:
+                      type: string
+                    type: array
+                  eventsEnabled:
+                    description: EventsEnabled indicates whether to enable events.
+                    type: boolean
+                  eventsExpiration:
+                    description: EventsExpiration is the number of seconds after which
+                      events expire.
+                    type: integer
+                  eventsListeners:
+                    description: EventsListeners is a list of event listeners to enable.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              realmName:
+                description: RealmName specifies the name of the realm.
+                type: string
+              themes:
+                description: Themes is a map of themes to apply to the realm.
+                nullable: true
+                properties:
+                  accountTheme:
+                    description: AccountTheme specifies the account theme to use for
+                      the realm.
+                    nullable: true
+                    type: string
+                  adminConsoleTheme:
+                    description: AdminConsoleTheme specifies the admin console theme
+                      to use for the realm.
+                    nullable: true
+                    type: string
+                  emailTheme:
+                    description: EmailTheme specifies the email theme to use for the
+                      realm.
+                    nullable: true
+                    type: string
+                  loginTheme:
+                    description: LoginTheme specifies the login theme to use for the
+                      realm.
+                    nullable: true
+                    type: string
+                type: object
+              tokenSettings:
+                description: TokenSettings is the configuration for tokens in the
+                  realm.
+                nullable: true
+                properties:
+                  accessCodeLifespan:
+                    default: 60
+                    description: |-
+                      AccessCodeLifespan specifies max time(in seconds)a client has to finish the access token protocol.
+                      This should normally be 1 minute.
+                    type: integer
+                  accessToken:
+                    default: 900
+                    description: AccessTokenLifespanForImplicitFlow specifies max
+                      time(in seconds) before an access token is expired for implicit
+                      flow.
+                    type: integer
+                  accessTokenLifespan:
+                    default: 300
+                    description: |-
+                      AccessTokenLifespan specifies max time(in seconds) before an access token is expired.
+                      This value is recommended to be short relative to the SSO timeout.
+                    type: integer
+                  actionTokenGeneratedByAdminLifespan:
+                    default: 43200
+                    description: |-
+                      ActionTokenGeneratedByAdminLifespan specifies max time(in seconds) before an action permit sent to a user by administrator is expired.
+                      This value is recommended to be long to allow administrators to send e-mails for users that are currently offline.
+                      The default timeout can be overridden immediately before issuing the token.
+                    type: integer
+                  actionTokenGeneratedByUserLifespan:
+                    default: 300
+                    description: |-
+                      AccessCodeLifespanUserAction specifies max time(in seconds) before an action permit sent by a user (such as a forgot password e-mail) is expired.
+                      This value is recommended to be short because it's expected that the user would react to self-created action quickly.
+                    type: integer
+                  defaultSignatureAlgorithm:
+                    default: RS256
+                    description: DefaultSignatureAlgorithm specifies the default algorithm
+                      used to sign tokens for the realm
+                    enum:
+                    - ES256
+                    - ES384
+                    - ES512
+                    - EdDSA
+                    - HS256
+                    - HS384
+                    - HS512
+                    - PS256
+                    - PS384
+                    - PS512
+                    - RS256
+                    - RS384
+                    - RS512
+                    example: RS256
+                    type: string
+                  refreshTokenMaxReuse:
+                    default: 0
+                    description: |-
+                      RefreshTokenMaxReuse specifies maximum number of times a refresh token can be reused.
+                      When a different token is used, revocation is immediate.
+                    type: integer
+                  revokeRefreshToken:
+                    default: false
+                    description: |-
+                      RevokeRefreshToken if enabled a refresh token can only be used up to 'refreshTokenMaxReuse' and
+                      is revoked when a different token is used.
+                      Otherwise, refresh tokens are not revoked when used and can be used multiple times.
+                    type: boolean
+                type: object
+            required:
+            - clusterKeycloakRef
+            - realmName
+            type: object
+          status:
+            description: ClusterKeycloakRealmStatus defines the observed state of
+              ClusterKeycloakRealm.
+            properties:
+              available:
+                type: boolean
+              failureCount:
+                format: int64
+                type: integer
+              value:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_clusterkeycloaks.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_clusterkeycloaks.yaml
@@ -1,0 +1,127 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: clusterkeycloaks.v1.edp.epam.com
+spec:
+  group: v1.edp.epam.com
+  names:
+    kind: ClusterKeycloak
+    listKind: ClusterKeycloakList
+    plural: clusterkeycloaks
+    singular: clusterkeycloak
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Is connected to keycloak
+      jsonPath: .status.connected
+      name: Connected
+      type: boolean
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterKeycloak is the Schema for the clusterkeycloaks API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterKeycloakSpec defines the desired state of ClusterKeycloak.
+            properties:
+              adminType:
+                default: user
+                description: |-
+                  AdminType can be user or serviceAccount, if serviceAccount was specified,
+                  then client_credentials grant type should be used for getting admin realm token.
+                enum:
+                - serviceAccount
+                - user
+                type: string
+              caCert:
+                description: |-
+                  CACert defines the root certificate authority
+                  that api clients use when verifying server certificates.
+                  Resources should be in the namespace defined in operator OPERATOR_NAMESPACE env.
+                properties:
+                  configMapKeyRef:
+                    description: Selects a key of a ConfigMap.
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?
+                        type: string
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  secretKeyRef:
+                    description: Selects a key of a secret.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?
+                        type: string
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                type: object
+              insecureSkipVerify:
+                description: |-
+                  InsecureSkipVerify controls whether api client verifies the server's
+                  certificate chain and host name. If InsecureSkipVerify is true, api client
+                  accepts any certificate presented by the server and any host name in that
+                  certificate.
+                type: boolean
+              secret:
+                description: Secret is a secret name which contains admin credentials.
+                type: string
+              url:
+                description: URL of keycloak service.
+                type: string
+            required:
+            - secret
+            - url
+            type: object
+          status:
+            default:
+              connected: false
+            description: ClusterKeycloakStatus defines the observed state of ClusterKeycloak.
+            properties:
+              connected:
+                description: Connected shows if keycloak service is up and running.
+                type: boolean
+            required:
+            - connected
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakauthflows.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakauthflows.yaml
@@ -1,0 +1,152 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: keycloakauthflows.v1.edp.epam.com
+spec:
+  group: v1.edp.epam.com
+  names:
+    kind: KeycloakAuthFlow
+    listKind: KeycloakAuthFlowList
+    plural: keycloakauthflows
+    singular: keycloakauthflow
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Reconcilation status
+      jsonPath: .status.value
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakAuthFlow is the Schema for the keycloak authentication
+          flow API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakAuthFlowSpec defines the desired state of KeycloakAuthFlow.
+            properties:
+              alias:
+                description: Alias is display name for authentication flow.
+                type: string
+              authenticationExecutions:
+                description: AuthenticationExecutions is list of authentication executions
+                  for this auth flow.
+                items:
+                  description: AuthenticationExecution defines keycloak authentication
+                    execution.
+                  properties:
+                    alias:
+                      description: Alias is display name for this execution.
+                      type: string
+                    authenticator:
+                      description: Authenticator is name of authenticator.
+                      type: string
+                    authenticatorConfig:
+                      description: AuthenticatorConfig is configuration for authenticator.
+                      nullable: true
+                      properties:
+                        alias:
+                          description: Alias is display name for authenticator config.
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Config is configuration for authenticator.
+                          type: object
+                      type: object
+                    authenticatorFlow:
+                      description: AuthenticatorFlow is true if this is auth flow.
+                      type: boolean
+                    priority:
+                      description: Priority is priority for this execution. Lower
+                        values have higher priority.
+                      type: integer
+                    requirement:
+                      description: 'Requirement is requirement for this execution.
+                        Available options: REQUIRED, ALTERNATIVE, DISABLED, CONDITIONAL.'
+                      type: string
+                  type: object
+                nullable: true
+                type: array
+              builtIn:
+                description: BuiltIn is true if this is built-in auth flow.
+                type: boolean
+              childRequirement:
+                description: 'ChildRequirement is requirement for child execution.
+                  Available options: REQUIRED, ALTERNATIVE, DISABLED, CONDITIONAL.'
+                type: string
+              childType:
+                description: 'ChildType is type for auth flow if it has a parent,
+                  available options: basic-flow, form-flow'
+                type: string
+              description:
+                description: Description is description for authentication flow.
+                type: string
+              parentName:
+                description: ParentName is name of parent auth flow.
+                type: string
+              providerId:
+                description: ProviderID for root auth flow and provider for child
+                  auth flows.
+                type: string
+              realm:
+                description: |-
+                  Deprecated: use RealmRef instead.
+                  Realm is name of KeycloakRealm custom resource.
+                type: string
+              realmRef:
+                description: RealmRef is reference to Realm custom resource.
+                properties:
+                  kind:
+                    description: Kind specifies the kind of the Keycloak resource.
+                    enum:
+                    - KeycloakRealm
+                    - ClusterKeycloakRealm
+                    type: string
+                  name:
+                    description: Name specifies the name of the Keycloak resource.
+                    type: string
+                type: object
+              topLevel:
+                description: TopLevel is true if this is root auth flow.
+                type: boolean
+            required:
+            - alias
+            - builtIn
+            - providerId
+            - topLevel
+            type: object
+          status:
+            description: KeycloakAuthFlowStatus defines the observed state of KeycloakAuthFlow.
+            properties:
+              failureCount:
+                format: int64
+                type: integer
+              value:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakclients.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakclients.yaml
@@ -1,0 +1,579 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: keycloakclients.v1.edp.epam.com
+spec:
+  group: v1.edp.epam.com
+  names:
+    kind: KeycloakClient
+    listKind: KeycloakClientList
+    plural: keycloakclients
+    singular: keycloakclient
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Reconcilation status
+      jsonPath: .status.value
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakClient is the Schema for the keycloak clients API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakClientSpec defines the desired state of KeycloakClient.
+            properties:
+              advancedProtocolMappers:
+                description: AdvancedProtocolMappers is a flag to enable advanced
+                  protocol mappers.
+                type: boolean
+              attributes:
+                additionalProperties:
+                  type: string
+                default:
+                  post.logout.redirect.uris: +
+                description: Attributes is a map of client attributes.
+                nullable: true
+                type: object
+              authorization:
+                description: Authorization is a client authorization configuration.
+                nullable: true
+                properties:
+                  permissions:
+                    items:
+                      properties:
+                        decisionStrategy:
+                          default: UNANIMOUS
+                          description: DecisionStrategy is a permission decision strategy.
+                          enum:
+                          - UNANIMOUS
+                          - AFFIRMATIVE
+                          - CONSENSUS
+                          type: string
+                        description:
+                          description: Description is a permission description.
+                          type: string
+                        logic:
+                          default: POSITIVE
+                          description: Logic is a permission logic.
+                          enum:
+                          - POSITIVE
+                          - NEGATIVE
+                          type: string
+                        name:
+                          description: Name is a permission name.
+                          type: string
+                        policies:
+                          description: |-
+                            Policies is a list of policies names.
+                            Specifies all the policies that must be applied to the scopes defined by this policy or permission.
+                          example:
+                          - policy1
+                          - policy2
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        resources:
+                          description: |-
+                            Resources is a list of resources names.
+                            Specifies that this permission must be applied to all resource instances of a given type.
+                          example:
+                          - resource1
+                          - resource2
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        scopes:
+                          description: |-
+                            Scopes is a list of authorization scopes names.
+                            Specifies that this permission must be applied to one or more scopes.
+                          example:
+                          - scope1
+                          - scope2
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        type:
+                          description: Type is a permission type.
+                          enum:
+                          - resource
+                          - scope
+                          type: string
+                      required:
+                      - name
+                      - type
+                      type: object
+                    type: array
+                  policies:
+                    items:
+                      description: Policy represents a client authorization policy.
+                      properties:
+                        aggregatedPolicy:
+                          description: AggregatedPolicy is an aggregated policy settings.
+                          properties:
+                            policies:
+                              description: |-
+                                Policies is a list of aggregated policies names.
+                                Specifies all the policies that must be applied to the scopes defined by this policy or permission.
+                              example:
+                                policies:
+                                - policy1
+                                - policy2
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - policies
+                          type: object
+                        clientPolicy:
+                          description: ClientPolicy is a client policy settings.
+                          properties:
+                            clients:
+                              description: Clients is a list of client names. Specifies
+                                which client(s) are allowed by this policy.
+                              example:
+                              - clients1
+                              - clients2
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - clients
+                          type: object
+                        decisionStrategy:
+                          default: UNANIMOUS
+                          description: DecisionStrategy is a policy decision strategy.
+                          enum:
+                          - UNANIMOUS
+                          - AFFIRMATIVE
+                          - CONSENSUS
+                          type: string
+                        description:
+                          description: Description is a policy description.
+                          type: string
+                        groupPolicy:
+                          description: GroupPolicy is a group policy settings.
+                          properties:
+                            groups:
+                              description: Groups is a list of group names. Specifies
+                                which group(s) are allowed by this policy.
+                              example: '{"groups":[{"name":"group1","extendChildren":true},{"name":"group2"}]}'
+                              items:
+                                description: GroupDefinition represents a group in
+                                  a GroupPolicyData.
+                                properties:
+                                  extendChildren:
+                                    description: ExtendChildren is a flag that specifies
+                                      whether to extend children.
+                                    type: boolean
+                                  name:
+                                    description: Name is a group name.
+                                    example: group1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            groupsClaim:
+                              description: |-
+                                GroupsClaim is a group claim.
+                                If defined, the policy will fetch user's groups from the given claim
+                                within an access token or ID token representing the identity asking permissions.
+                                If not defined, user's groups are obtained from your realm configuration.
+                              type: string
+                          type: object
+                        logic:
+                          default: POSITIVE
+                          description: Logic is a policy logic.
+                          enum:
+                          - POSITIVE
+                          - NEGATIVE
+                          type: string
+                        name:
+                          description: Name is a policy name.
+                          type: string
+                        rolePolicy:
+                          description: RolePolicy is a role policy settings.
+                          properties:
+                            roles:
+                              description: Roles is a list of role.
+                              example:
+                                roles:
+                                - name: role1
+                                  required: true
+                                - name: role2
+                              items:
+                                description: RoleDefinition represents a role in a
+                                  RolePolicyData.
+                                properties:
+                                  name:
+                                    description: Name is a role name.
+                                    example: role1
+                                    type: string
+                                  required:
+                                    description: Required is a flag that specifies
+                                      whether the role is required.
+                                    type: boolean
+                                required:
+                                - name
+                                type: object
+                              type: array
+                          required:
+                          - roles
+                          type: object
+                        timePolicy:
+                          description: ScopePolicy is a scope policy settings.
+                          properties:
+                            dayMonth:
+                              description: |-
+                                Day defines the month which the policy MUST be granted.
+                                You can also provide a range by filling the dayMonthEnd field.
+                                In this case, permission is granted only if current month is between or equal to the two values you provided.
+                              example: "1"
+                              type: string
+                            dayMonthEnd:
+                              example: "2"
+                              type: string
+                            hour:
+                              description: |-
+                                Hour defines the hour when the policy MUST be granted.
+                                You can also provide a range by filling the hourEnd.
+                                In this case, permission is granted only if current hour is between or equal to the two values you provided.
+                              example: "1"
+                              type: string
+                            hourEnd:
+                              example: "2"
+                              type: string
+                            minute:
+                              description: |-
+                                Minute defines the minute when the policy MUST be granted.
+                                You can also provide a range by filling the minuteEnd field.
+                                In this case, permission is granted only if current minute is between or equal to the two values you provided.
+                              example: "1"
+                              type: string
+                            minuteEnd:
+                              example: "2"
+                              type: string
+                            month:
+                              description: |-
+                                Month defines the month which the policy MUST be granted.
+                                You can also provide a range by filling the monthEnd.
+                                In this case, permission is granted only if current month is between or equal to the two values you provided.
+                              example: "1"
+                              type: string
+                            monthEnd:
+                              example: "2"
+                              type: string
+                            notBefore:
+                              description: |-
+                                NotBefore defines the time before which the policy MUST NOT be granted.
+                                Only granted if current date/time is after or equal to this value.
+                              example: "2024-03-03 00:00:00"
+                              type: string
+                            notOnOrAfter:
+                              description: |-
+                                NotOnOrAfter defines the time after which the policy MUST NOT be granted.
+                                Only granted if current date/time is before or equal to this value.
+                              example: "2024-04-04 00:00:00"
+                              type: string
+                          required:
+                          - notBefore
+                          - notOnOrAfter
+                          type: object
+                        type:
+                          description: Type is a policy type.
+                          enum:
+                          - aggregate
+                          - client
+                          - group
+                          - role
+                          - time
+                          - user
+                          type: string
+                        userPolicy:
+                          description: UserPolicy is a user policy settings.
+                          properties:
+                            users:
+                              description: Users is a list of usernames. Specifies
+                                which user(s) are allowed by this policy.
+                              example:
+                              - users1
+                              - users2
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - users
+                          type: object
+                      required:
+                      - name
+                      - type
+                      type: object
+                    type: array
+                  scopes:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              authorizationServicesEnabled:
+                description: ServiceAccountsEnabled enable/disable fine-grained authorization
+                  support for a client.
+                type: boolean
+              bearerOnly:
+                description: BearerOnly is a flag to enable bearer-only.
+                type: boolean
+              clientAuthenticatorType:
+                default: client-secret
+                description: ClientAuthenticatorType is a client authenticator type.
+                type: string
+              clientId:
+                description: ClientId is a unique keycloak client ID referenced in
+                  URI and tokens.
+                type: string
+              clientRoles:
+                description: ClientRoles is a list of client roles names assigned
+                  to client.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              consentRequired:
+                description: ConsentRequired is a flag to enable consent.
+                type: boolean
+              defaultClientScopes:
+                description: DefaultClientScopes is a list of default client scopes
+                  assigned to client.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              description:
+                description: Description is a client description.
+                type: string
+              directAccess:
+                description: DirectAccess is a flag to set client as direct access.
+                type: boolean
+              enabled:
+                default: true
+                description: Enabled is a flag to enable client.
+                type: boolean
+              frontChannelLogout:
+                description: FrontChannelLogout is a flag to enable front channel
+                  logout.
+                type: boolean
+              fullScopeAllowed:
+                default: true
+                description: FullScopeAllowed is a flag to enable full scope.
+                type: boolean
+              implicitFlowEnabled:
+                description: ImplicitFlowEnabled is a flag to enable support for OpenID
+                  Connect redirect based authentication without authorization code.
+                type: boolean
+              name:
+                description: Name is a client name.
+                type: string
+              optionalClientScopes:
+                description: OptionalClientScopes is a list of optional client scopes
+                  assigned to client.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              protocol:
+                description: Protocol is a client protocol.
+                nullable: true
+                type: string
+              protocolMappers:
+                description: ProtocolMappers is a list of protocol mappers assigned
+                  to client.
+                items:
+                  properties:
+                    config:
+                      additionalProperties:
+                        type: string
+                      description: Config is a map of protocol mapper configuration.
+                      nullable: true
+                      type: object
+                    name:
+                      description: Name is a protocol mapper name.
+                      type: string
+                    protocol:
+                      description: Protocol is a protocol name.
+                      type: string
+                    protocolMapper:
+                      description: ProtocolMapper is a protocol mapper name.
+                      type: string
+                  type: object
+                nullable: true
+                type: array
+              public:
+                description: Public is a flag to set client as public.
+                type: boolean
+              realmRef:
+                description: RealmRef is reference to Realm custom resource.
+                properties:
+                  kind:
+                    description: Kind specifies the kind of the Keycloak resource.
+                    enum:
+                    - KeycloakRealm
+                    - ClusterKeycloakRealm
+                    type: string
+                  name:
+                    description: Name specifies the name of the Keycloak resource.
+                    type: string
+                type: object
+              realmRoles:
+                description: RealmRoles is a list of realm roles assigned to client.
+                items:
+                  properties:
+                    composite:
+                      description: Composite is a realm composite role name.
+                      type: string
+                    name:
+                      description: Name is a realm role name.
+                      type: string
+                  required:
+                  - composite
+                  type: object
+                nullable: true
+                type: array
+              reconciliationStrategy:
+                description: ReconciliationStrategy is a strategy to reconcile client.
+                enum:
+                - full
+                - addOnly
+                type: string
+              redirectUris:
+                description: |-
+                  RedirectUris is a list of valid URI pattern a browser can redirect to after a successful login.
+                  Simple wildcards are allowed such as 'https://example.com/*'.
+                  Relative path can be specified too, such as /my/relative/path/*. Relative paths are relative to the client root URL.
+                  If not specified, spec.webUrl + "/*" will be used.
+                example:
+                - https://example.com/*
+                - /my/relative/path/*
+                items:
+                  type: string
+                nullable: true
+                type: array
+              secret:
+                description: |-
+                  Secret is kubernetes secret name where the client's secret will be stored.
+                  Secret should have the following format: $secretName:secretKey.
+                  If not specified, a client secret will be generated and stored in a secret with the name keycloak-client-{metadata.name}-secret.
+                  If keycloak client is public, secret property will be ignored.
+                example: $keycloak-secret:client_secret
+                type: string
+              serviceAccount:
+                description: ServiceAccount is a service account configuration.
+                nullable: true
+                properties:
+                  attributes:
+                    additionalProperties:
+                      type: string
+                    description: Attributes is a map of service account attributes.
+                    nullable: true
+                    type: object
+                  clientRoles:
+                    description: ClientRoles is a list of client roles assigned to
+                      service account.
+                    items:
+                      properties:
+                        clientId:
+                          description: ClientID is a client ID.
+                          type: string
+                        roles:
+                          description: Roles is a list of client roles names assigned
+                            to service account.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      required:
+                      - clientId
+                      type: object
+                    nullable: true
+                    type: array
+                  enabled:
+                    description: Enabled is a flag to enable service account.
+                    type: boolean
+                  realmRoles:
+                    description: RealmRoles is a list of realm roles assigned to service
+                      account.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                type: object
+              standardFlowEnabled:
+                default: true
+                description: StandardFlowEnabled is a flag to enable standard flow.
+                type: boolean
+              surrogateAuthRequired:
+                description: SurrogateAuthRequired is a flag to enable surrogate auth.
+                type: boolean
+              targetRealm:
+                description: |-
+                  Deprecated: use RealmRef instead.
+                  TargetRealm is a realm name where client will be created.
+                  It has higher priority than RealmRef for backward compatibility.
+                  If both TargetRealm and RealmRef are specified, TargetRealm will be used for client creation.
+                type: string
+              webOrigins:
+                description: |-
+                  WebOrigins is a list of allowed CORS origins.
+                  To permit all origins of Valid Redirect URIs, add '+'. This does not include the '*' wildcard though.
+                  To permit all origins, explicitly add '*'.
+                  If not specified, the value from `WebUrl` is used
+                example:
+                - https://example.com/*
+                items:
+                  type: string
+                nullable: true
+                type: array
+              webUrl:
+                description: WebUrl is a client web url.
+                type: string
+            required:
+            - clientId
+            type: object
+          status:
+            description: KeycloakClientStatus defines the observed state of KeycloakClient.
+            properties:
+              clientId:
+                type: string
+              failureCount:
+                format: int64
+                type: integer
+              value:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakclientscopes.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakclientscopes.yaml
@@ -1,0 +1,127 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: keycloakclientscopes.v1.edp.epam.com
+spec:
+  group: v1.edp.epam.com
+  names:
+    kind: KeycloakClientScope
+    listKind: KeycloakClientScopeList
+    plural: keycloakclientscopes
+    singular: keycloakclientscope
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Reconcilation status
+      jsonPath: .status.value
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakClientScope is the Schema for the keycloakclientscopes
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakClientScopeSpec defines the desired state of KeycloakClientScope.
+            properties:
+              attributes:
+                additionalProperties:
+                  type: string
+                description: Attributes is a map of client scope attributes.
+                nullable: true
+                type: object
+              default:
+                description: Default is a flag to set client scope as default.
+                type: boolean
+              description:
+                description: Description is a description of client scope.
+                type: string
+              name:
+                description: Name of keycloak client scope.
+                type: string
+              protocol:
+                description: Protocol is SSO protocol configuration which is being
+                  supplied by this client scope.
+                type: string
+              protocolMappers:
+                description: ProtocolMappers is a list of protocol mappers assigned
+                  to client scope.
+                items:
+                  properties:
+                    config:
+                      additionalProperties:
+                        type: string
+                      description: Config is a map of protocol mapper configuration.
+                      nullable: true
+                      type: object
+                    name:
+                      description: Name is a protocol mapper name.
+                      type: string
+                    protocol:
+                      description: Protocol is a protocol name.
+                      type: string
+                    protocolMapper:
+                      description: ProtocolMapper is a protocol mapper name.
+                      type: string
+                  type: object
+                nullable: true
+                type: array
+              realm:
+                description: |-
+                  Deprecated: use RealmRef instead.
+                  Realm is name of KeycloakRealm custom resource.
+                type: string
+              realmRef:
+                description: RealmRef is reference to Realm custom resource.
+                properties:
+                  kind:
+                    description: Kind specifies the kind of the Keycloak resource.
+                    enum:
+                    - KeycloakRealm
+                    - ClusterKeycloakRealm
+                    type: string
+                  name:
+                    description: Name specifies the name of the Keycloak resource.
+                    type: string
+                type: object
+            required:
+            - name
+            - protocol
+            type: object
+          status:
+            description: KeycloakClientScopeStatus defines the observed state of KeycloakClientScope.
+            properties:
+              failureCount:
+                format: int64
+                type: integer
+              id:
+                type: string
+              value:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmcomponents.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmcomponents.yaml
@@ -1,0 +1,129 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: keycloakrealmcomponents.v1.edp.epam.com
+spec:
+  group: v1.edp.epam.com
+  names:
+    kind: KeycloakRealmComponent
+    listKind: KeycloakRealmComponentList
+    plural: keycloakrealmcomponents
+    singular: keycloakrealmcomponent
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Reconcilation status
+      jsonPath: .status.value
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakRealmComponent is the Schema for the keycloak component
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakComponentSpec defines the desired state of KeycloakRealmComponent.
+            properties:
+              config:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: |-
+                  Config is a map of component configuration.
+                  Map key is a name of configuration property, map value is an array value of configuration properties.
+                  Any configuration property can be a reference to k8s secret, in this case the property should be in format $secretName:secretKey.
+                example:
+                  bindCredential: '["$clientSecret:secretKey"]'
+                  bindDn: '["provider-client"]'
+                nullable: true
+                type: object
+              name:
+                description: Name of keycloak component.
+                type: string
+              parentRef:
+                description: |-
+                  ParentRef specifies a parent resource.
+                  If not specified, then parent is realm specified in realm field.
+                nullable: true
+                properties:
+                  kind:
+                    default: KeycloakRealm
+                    description: Kind is a kind of parent component. By default, it
+                      is KeycloakRealm.
+                    enum:
+                    - KeycloakRealm
+                    - KeycloakRealmComponent
+                    type: string
+                  name:
+                    description: |-
+                      Name is a name of parent component custom resource.
+                      For example, if Kind is KeycloakRealm, then Name is name of KeycloakRealm custom resource.
+                    type: string
+                required:
+                - name
+                type: object
+              providerId:
+                description: ProviderID is a provider ID of component.
+                type: string
+              providerType:
+                description: ProviderType is a provider type of component.
+                type: string
+              realm:
+                description: |-
+                  Deprecated: use RealmRef instead.
+                  Realm is name of KeycloakRealm custom resource.
+                type: string
+              realmRef:
+                description: RealmRef is reference to Realm custom resource.
+                properties:
+                  kind:
+                    description: Kind specifies the kind of the Keycloak resource.
+                    enum:
+                    - KeycloakRealm
+                    - ClusterKeycloakRealm
+                    type: string
+                  name:
+                    description: Name specifies the name of the Keycloak resource.
+                    type: string
+                type: object
+            required:
+            - name
+            - providerId
+            - providerType
+            type: object
+          status:
+            description: KeycloakComponentStatus defines the observed state of KeycloakRealmComponent.
+            properties:
+              failureCount:
+                format: int64
+                type: integer
+              value:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmgroups.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmgroups.yaml
@@ -1,0 +1,135 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: keycloakrealmgroups.v1.edp.epam.com
+spec:
+  group: v1.edp.epam.com
+  names:
+    kind: KeycloakRealmGroup
+    listKind: KeycloakRealmGroupList
+    plural: keycloakrealmgroups
+    singular: keycloakrealmgroup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Reconcilation status
+      jsonPath: .status.value
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakRealmGroup is the Schema for the keycloak group API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakRealmGroupSpec defines the desired state of KeycloakRealmGroup.
+            properties:
+              access:
+                additionalProperties:
+                  type: boolean
+                description: Access is a map of group access.
+                nullable: true
+                type: object
+              attributes:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: Attributes is a map of group attributes.
+                nullable: true
+                type: object
+              clientRoles:
+                description: ClientRoles is a list of client roles assigned to group.
+                items:
+                  properties:
+                    clientId:
+                      description: ClientID is a client ID.
+                      type: string
+                    roles:
+                      description: Roles is a list of client roles names assigned
+                        to service account.
+                      items:
+                        type: string
+                      nullable: true
+                      type: array
+                  required:
+                  - clientId
+                  type: object
+                nullable: true
+                type: array
+              name:
+                description: Name of keycloak group.
+                type: string
+              path:
+                description: Path is a group path.
+                type: string
+              realm:
+                description: |-
+                  Deprecated: use RealmRef instead.
+                  Realm is name of KeycloakRealm custom resource.
+                type: string
+              realmRef:
+                description: RealmRef is reference to Realm custom resource.
+                properties:
+                  kind:
+                    description: Kind specifies the kind of the Keycloak resource.
+                    enum:
+                    - KeycloakRealm
+                    - ClusterKeycloakRealm
+                    type: string
+                  name:
+                    description: Name specifies the name of the Keycloak resource.
+                    type: string
+                type: object
+              realmRoles:
+                description: RealmRoles is a list of realm roles assigned to group.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              subGroups:
+                description: SubGroups is a list of subgroups assigned to group.
+                items:
+                  type: string
+                nullable: true
+                type: array
+            required:
+            - name
+            type: object
+          status:
+            description: KeycloakRealmGroupStatus defines the observed state of KeycloakRealmGroup.
+            properties:
+              failureCount:
+                format: int64
+                type: integer
+              id:
+                description: ID is a group ID.
+                type: string
+              value:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmidentityproviders.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmidentityproviders.yaml
@@ -1,0 +1,152 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: keycloakrealmidentityproviders.v1.edp.epam.com
+spec:
+  group: v1.edp.epam.com
+  names:
+    kind: KeycloakRealmIdentityProvider
+    listKind: KeycloakRealmIdentityProviderList
+    plural: keycloakrealmidentityproviders
+    singular: keycloakrealmidentityprovider
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Reconcilation status
+      jsonPath: .status.value
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakRealmIdentityProvider is the Schema for the keycloak
+          realm identity provider API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakRealmIdentityProviderSpec defines the desired state
+              of KeycloakRealmIdentityProvider.
+            properties:
+              addReadTokenRoleOnCreate:
+                description: AddReadTokenRoleOnCreate is a flag to add read token
+                  role on create.
+                type: boolean
+              alias:
+                description: Alias is a alias of identity provider.
+                type: string
+              authenticateByDefault:
+                description: AuthenticateByDefault is a flag to authenticate by default.
+                type: boolean
+              config:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Config is a map of identity provider configuration.
+                  Map key is a name of configuration property, map value is a value of configuration property.
+                  Any value can be a reference to k8s secret, in this case value should be in format $secretName:secretKey.
+                example:
+                  clientId: provider-client
+                  clientSecret: $clientSecret:secretKey
+                type: object
+              displayName:
+                description: DisplayName is a display name of identity provider.
+                type: string
+              enabled:
+                description: Enabled is a flag to enable/disable identity provider.
+                type: boolean
+              firstBrokerLoginFlowAlias:
+                description: FirstBrokerLoginFlowAlias is a first broker login flow
+                  alias.
+                type: string
+              linkOnly:
+                description: LinkOnly is a flag to link only.
+                type: boolean
+              mappers:
+                description: Mappers is a list of identity provider mappers.
+                items:
+                  properties:
+                    config:
+                      additionalProperties:
+                        type: string
+                      description: Config is a map of identity provider mapper configuration.
+                      nullable: true
+                      type: object
+                    identityProviderAlias:
+                      description: IdentityProviderAlias is a identity provider alias.
+                      type: string
+                    identityProviderMapper:
+                      description: IdentityProviderMapper is a identity provider mapper.
+                      type: string
+                    name:
+                      description: Name is a name of identity provider mapper.
+                      type: string
+                  type: object
+                nullable: true
+                type: array
+              providerId:
+                description: ProviderID is a provider ID of identity provider.
+                type: string
+              realm:
+                description: |-
+                  Deprecated: use RealmRef instead.
+                  Realm is name of KeycloakRealm custom resource.
+                type: string
+              realmRef:
+                description: RealmRef is reference to Realm custom resource.
+                properties:
+                  kind:
+                    description: Kind specifies the kind of the Keycloak resource.
+                    enum:
+                    - KeycloakRealm
+                    - ClusterKeycloakRealm
+                    type: string
+                  name:
+                    description: Name specifies the name of the Keycloak resource.
+                    type: string
+                type: object
+              storeToken:
+                description: StoreToken is a flag to store token.
+                type: boolean
+              trustEmail:
+                description: TrustEmail is a flag to trust email.
+                type: boolean
+            required:
+            - alias
+            - config
+            - enabled
+            - providerId
+            type: object
+          status:
+            description: KeycloakRealmIdentityProviderStatus defines the observed
+              state of KeycloakRealmIdentityProvider.
+            properties:
+              failureCount:
+                format: int64
+                type: integer
+              value:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmrolebatches.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmrolebatches.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: keycloakrealmrolebatches.v1.edp.epam.com
+spec:
+  group: v1.edp.epam.com
+  names:
+    kind: KeycloakRealmRoleBatch
+    listKind: KeycloakRealmRoleBatchList
+    plural: keycloakrealmrolebatches
+    singular: keycloakrealmrolebatch
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Reconcilation status
+      jsonPath: .status.value
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakRealmRoleBatch is the Schema for the keycloak roles API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakRealmRoleBatchSpec defines the desired state of KeycloakRealmRoleBatch.
+            properties:
+              realm:
+                description: |-
+                  Deprecated: use RealmRef instead.
+                  Realm is name of KeycloakRealm custom resource.
+                type: string
+              realmRef:
+                description: RealmRef is reference to Realm custom resource.
+                properties:
+                  kind:
+                    description: Kind specifies the kind of the Keycloak resource.
+                    enum:
+                    - KeycloakRealm
+                    - ClusterKeycloakRealm
+                    type: string
+                  name:
+                    description: Name specifies the name of the Keycloak resource.
+                    type: string
+                type: object
+              roles:
+                description: Roles is a list of roles to be created.
+                items:
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        items:
+                          type: string
+                        type: array
+                      description: Attributes is a map of role attributes.
+                      nullable: true
+                      type: object
+                    composite:
+                      description: Composite is a flag if role is composite.
+                      type: boolean
+                    composites:
+                      description: Composites is a list of composites roles assigned
+                        to role.
+                      items:
+                        properties:
+                          name:
+                            description: Name is a name of composite role.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      nullable: true
+                      type: array
+                    description:
+                      description: Description is a role description.
+                      type: string
+                    isDefault:
+                      description: IsDefault is a flag if role is default.
+                      type: boolean
+                    name:
+                      description: Name of keycloak role.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - roles
+            type: object
+          status:
+            description: KeycloakRealmRoleBatchStatus defines the observed state of
+              KeycloakRealmRoleBatch.
+            properties:
+              failureCount:
+                format: int64
+                type: integer
+              value:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmroles.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmroles.yaml
@@ -1,0 +1,138 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: keycloakrealmroles.v1.edp.epam.com
+spec:
+  group: v1.edp.epam.com
+  names:
+    kind: KeycloakRealmRole
+    listKind: KeycloakRealmRoleList
+    plural: keycloakrealmroles
+    singular: keycloakrealmrole
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Reconcilation status
+      jsonPath: .status.value
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakRealmRole is the Schema for the keycloak group API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakRealmRoleSpec defines the desired state of KeycloakRealmRole.
+            properties:
+              attributes:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: Attributes is a map of role attributes.
+                nullable: true
+                type: object
+              composite:
+                description: Composite is a flag if role is composite.
+                type: boolean
+              composites:
+                description: Composites is a list of composites roles assigned to
+                  role.
+                items:
+                  properties:
+                    name:
+                      description: Name is a name of composite role.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                nullable: true
+                type: array
+              compositesClientRoles:
+                additionalProperties:
+                  items:
+                    properties:
+                      name:
+                        description: Name is a name of composite role.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+                description: CompositesClientRoles is a map of composites client roles
+                  assigned to role.
+                example:
+                  client1:
+                  - name: role1
+                  - name: role2
+                  client2:
+                    name: role3
+                nullable: true
+                type: object
+              description:
+                description: Description is a role description.
+                type: string
+              isDefault:
+                description: IsDefault is a flag if role is default.
+                type: boolean
+              name:
+                description: Name of keycloak role.
+                type: string
+              realm:
+                description: |-
+                  Deprecated: use RealmRef instead.
+                  Realm is name of KeycloakRealm custom resource.
+                type: string
+              realmRef:
+                description: RealmRef is reference to Realm custom resource.
+                properties:
+                  kind:
+                    description: Kind specifies the kind of the Keycloak resource.
+                    enum:
+                    - KeycloakRealm
+                    - ClusterKeycloakRealm
+                    type: string
+                  name:
+                    description: Name specifies the name of the Keycloak resource.
+                    type: string
+                type: object
+            required:
+            - name
+            type: object
+          status:
+            description: KeycloakRealmRoleStatus defines the observed state of KeycloakRealmRole.
+            properties:
+              failureCount:
+                format: int64
+                type: integer
+              id:
+                description: ID is a role ID.
+                type: string
+              value:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealms.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealms.yaml
@@ -1,0 +1,284 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: keycloakrealms.v1.edp.epam.com
+spec:
+  group: v1.edp.epam.com
+  names:
+    kind: KeycloakRealm
+    listKind: KeycloakRealmList
+    plural: keycloakrealms
+    singular: keycloakrealm
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Is the resource available
+      jsonPath: .status.available
+      name: Available
+      type: boolean
+    - description: Reconcilation status
+      jsonPath: .status.value
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakRealm is the Schema for the keycloak realms API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakRealmSpec defines the desired state of KeycloakRealm.
+            properties:
+              browserFlow:
+                description: BrowserFlow specifies the authentication flow to use
+                  for the realm's browser clients.
+                nullable: true
+                type: string
+              browserSecurityHeaders:
+                additionalProperties:
+                  type: string
+                description: BrowserSecurityHeaders is a map of security headers to
+                  apply to HTTP responses from the realm's browser clients.
+                nullable: true
+                type: object
+              displayHtmlName:
+                description: DisplayHTMLName name to render in the UI
+                type: string
+              displayName:
+                description: DisplayName is the display name of the realm.
+                type: string
+              frontendUrl:
+                description: FrontendURL Set the frontend URL for the realm. Use in
+                  combination with the default hostname provider to override the base
+                  URL for frontend requests for a specific realm.
+                type: string
+              id:
+                description: ID is the ID of the realm.
+                nullable: true
+                type: string
+              keycloakOwner:
+                description: |-
+                  Deprecated: use KeycloakRef instead.
+                  KeycloakOwner specifies the name of the Keycloak instance that owns the realm.
+                nullable: true
+                type: string
+              keycloakRef:
+                description: KeycloakRef is reference to Keycloak custom resource.
+                properties:
+                  kind:
+                    description: Kind specifies the kind of the Keycloak resource.
+                    enum:
+                    - Keycloak
+                    - ClusterKeycloak
+                    type: string
+                  name:
+                    description: Name specifies the name of the Keycloak resource.
+                    type: string
+                type: object
+              passwordPolicy:
+                description: PasswordPolicies is a list of password policies to apply
+                  to the realm.
+                items:
+                  properties:
+                    type:
+                      description: Type of password policy.
+                      type: string
+                    value:
+                      description: Value of password policy.
+                      type: string
+                  required:
+                  - type
+                  - value
+                  type: object
+                nullable: true
+                type: array
+              realmEventConfig:
+                description: RealmEventConfig is the configuration for events in the
+                  realm.
+                nullable: true
+                properties:
+                  adminEventsDetailsEnabled:
+                    description: AdminEventsDetailsEnabled indicates whether to enable
+                      detailed admin events.
+                    type: boolean
+                  adminEventsEnabled:
+                    description: AdminEventsEnabled indicates whether to enable admin
+                      events.
+                    type: boolean
+                  enabledEventTypes:
+                    description: EnabledEventTypes is a list of event types to enable.
+                    items:
+                      type: string
+                    type: array
+                  eventsEnabled:
+                    description: EventsEnabled indicates whether to enable events.
+                    type: boolean
+                  eventsExpiration:
+                    description: EventsExpiration is the number of seconds after which
+                      events expire.
+                    type: integer
+                  eventsListeners:
+                    description: EventsListeners is a list of event listeners to enable.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              realmName:
+                description: RealmName specifies the name of the realm.
+                type: string
+              themes:
+                description: Themes is a map of themes to apply to the realm.
+                nullable: true
+                properties:
+                  accountTheme:
+                    description: AccountTheme specifies the account theme to use for
+                      the realm.
+                    nullable: true
+                    type: string
+                  adminConsoleTheme:
+                    description: AdminConsoleTheme specifies the admin console theme
+                      to use for the realm.
+                    nullable: true
+                    type: string
+                  emailTheme:
+                    description: EmailTheme specifies the email theme to use for the
+                      realm.
+                    nullable: true
+                    type: string
+                  internationalizationEnabled:
+                    description: InternationalizationEnabled indicates whether to
+                      enable internationalization.
+                    nullable: true
+                    type: boolean
+                  loginTheme:
+                    description: LoginTheme specifies the login theme to use for the
+                      realm.
+                    nullable: true
+                    type: string
+                type: object
+              tokenSettings:
+                description: TokenSettings is the configuration for tokens in the
+                  realm.
+                nullable: true
+                properties:
+                  accessCodeLifespan:
+                    default: 60
+                    description: |-
+                      AccessCodeLifespan specifies max time(in seconds)a client has to finish the access token protocol.
+                      This should normally be 1 minute.
+                    type: integer
+                  accessToken:
+                    default: 900
+                    description: AccessTokenLifespanForImplicitFlow specifies max
+                      time(in seconds) before an access token is expired for implicit
+                      flow.
+                    type: integer
+                  accessTokenLifespan:
+                    default: 300
+                    description: |-
+                      AccessTokenLifespan specifies max time(in seconds) before an access token is expired.
+                      This value is recommended to be short relative to the SSO timeout.
+                    type: integer
+                  actionTokenGeneratedByAdminLifespan:
+                    default: 43200
+                    description: |-
+                      ActionTokenGeneratedByAdminLifespan specifies max time(in seconds) before an action permit sent to a user by administrator is expired.
+                      This value is recommended to be long to allow administrators to send e-mails for users that are currently offline.
+                      The default timeout can be overridden immediately before issuing the token.
+                    type: integer
+                  actionTokenGeneratedByUserLifespan:
+                    default: 300
+                    description: |-
+                      AccessCodeLifespanUserAction specifies max time(in seconds) before an action permit sent by a user (such as a forgot password e-mail) is expired.
+                      This value is recommended to be short because it's expected that the user would react to self-created action quickly.
+                    type: integer
+                  defaultSignatureAlgorithm:
+                    default: RS256
+                    description: DefaultSignatureAlgorithm specifies the default algorithm
+                      used to sign tokens for the realm
+                    enum:
+                    - ES256
+                    - ES384
+                    - ES512
+                    - EdDSA
+                    - HS256
+                    - HS384
+                    - HS512
+                    - PS256
+                    - PS384
+                    - PS512
+                    - RS256
+                    - RS384
+                    - RS512
+                    example: RS256
+                    type: string
+                  refreshTokenMaxReuse:
+                    default: 0
+                    description: |-
+                      RefreshTokenMaxReuse specifies maximum number of times a refresh token can be reused.
+                      When a different token is used, revocation is immediate.
+                    type: integer
+                  revokeRefreshToken:
+                    default: false
+                    description: |-
+                      RevokeRefreshToken if enabled a refresh token can only be used up to 'refreshTokenMaxReuse' and
+                      is revoked when a different token is used.
+                      Otherwise, refresh tokens are not revoked when used and can be used multiple times.
+                    type: boolean
+                type: object
+              users:
+                description: Users is a list of users to create in the realm.
+                items:
+                  properties:
+                    realmRoles:
+                      description: RealmRoles is a list of roles attached to keycloak
+                        user.
+                      items:
+                        type: string
+                      type: array
+                    username:
+                      description: Username of keycloak user.
+                      type: string
+                  required:
+                  - username
+                  type: object
+                nullable: true
+                type: array
+            required:
+            - realmName
+            type: object
+          status:
+            description: KeycloakRealmStatus defines the observed state of KeycloakRealm.
+            properties:
+              available:
+                type: boolean
+              failureCount:
+                format: int64
+                type: integer
+              value:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmusers.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmusers.yaml
@@ -1,0 +1,157 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: keycloakrealmusers.v1.edp.epam.com
+spec:
+  group: v1.edp.epam.com
+  names:
+    kind: KeycloakRealmUser
+    listKind: KeycloakRealmUserList
+    plural: keycloakrealmusers
+    singular: keycloakrealmuser
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Reconcilation status
+      jsonPath: .status.value
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakRealmUser is the Schema for the keycloak user API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakRealmUserSpec defines the desired state of KeycloakRealmUser.
+            properties:
+              attributes:
+                additionalProperties:
+                  type: string
+                description: Attributes is a map of user attributes.
+                nullable: true
+                type: object
+              email:
+                description: Email is a user email.
+                type: string
+              emailVerified:
+                description: EmailVerified is a user email verified flag.
+                type: boolean
+              enabled:
+                description: Enabled is a user enabled flag.
+                type: boolean
+              firstName:
+                description: FirstName is a user first name.
+                type: string
+              groups:
+                description: Groups is a list of groups assigned to user.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              keepResource:
+                default: true
+                description: |-
+                  KeepResource, when set to false, results in the deletion of the KeycloakRealmUser Custom Resource (CR)
+                  from the cluster after the corresponding user is created in Keycloak. The user will continue to exist in Keycloak.
+                  When set to true, the CR will not be deleted after processing.
+                type: boolean
+              lastName:
+                description: LastName is a user last name.
+                type: string
+              password:
+                description: Password is a user password. Allows to keep user password
+                  within Custom Resource. For security concerns, it is recommended
+                  to use PasswordSecret instead.
+                type: string
+              passwordSecret:
+                description: PasswordSecret defines Kubernetes secret Name and Key,
+                  which holds User secret.
+                nullable: true
+                properties:
+                  key:
+                    description: Key is the key in the secret.
+                    type: string
+                  name:
+                    description: Name is the name of the secret.
+                    type: string
+                required:
+                - key
+                - name
+                type: object
+              realm:
+                description: |-
+                  Deprecated: use RealmRef instead.
+                  Realm is name of KeycloakRealm custom resource.
+                type: string
+              realmRef:
+                description: RealmRef is reference to Realm custom resource.
+                properties:
+                  kind:
+                    description: Kind specifies the kind of the Keycloak resource.
+                    enum:
+                    - KeycloakRealm
+                    - ClusterKeycloakRealm
+                    type: string
+                  name:
+                    description: Name specifies the name of the Keycloak resource.
+                    type: string
+                type: object
+              reconciliationStrategy:
+                description: |-
+                  ReconciliationStrategy is a strategy for reconciliation. Possible values: full, create-only.
+                  Default value: full. If set to create-only, user will be created only if it does not exist. If user exists, it will not be updated.
+                  If set to full, user will be created if it does not exist, or updated if it exists.
+                type: string
+              requiredUserActions:
+                description: 'RequiredUserActions is required action when user log
+                  in, example: CONFIGURE_TOTP, UPDATE_PASSWORD, UPDATE_PROFILE, VERIFY_EMAIL.'
+                items:
+                  type: string
+                nullable: true
+                type: array
+              roles:
+                description: Roles is a list of roles assigned to user.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              username:
+                description: Username is a username in keycloak.
+                type: string
+            required:
+            - username
+            type: object
+          status:
+            description: KeycloakRealmUserStatus defines the observed state of KeycloakRealmUser.
+            properties:
+              failureCount:
+                format: int64
+                type: integer
+              value:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloaks.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloaks.yaml
@@ -1,0 +1,125 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: keycloaks.v1.edp.epam.com
+spec:
+  group: v1.edp.epam.com
+  names:
+    kind: Keycloak
+    listKind: KeycloakList
+    plural: keycloaks
+    singular: keycloak
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Is connected to keycloak
+      jsonPath: .status.connected
+      name: Connected
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Keycloak is the Schema for the keycloaks API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakSpec defines the desired state of Keycloak.
+            properties:
+              adminType:
+                description: AdminType can be user or serviceAccount, if serviceAccount
+                  was specified, then client_credentials grant type should be used
+                  for getting admin realm token.
+                enum:
+                - serviceAccount
+                - user
+                type: string
+              caCert:
+                description: |-
+                  CACert defines the root certificate authority
+                  that api client use when verifying server certificates.
+                properties:
+                  configMapKeyRef:
+                    description: Selects a key of a ConfigMap.
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?
+                        type: string
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  secretKeyRef:
+                    description: Selects a key of a secret.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?
+                        type: string
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                type: object
+              insecureSkipVerify:
+                description: |-
+                  InsecureSkipVerify controls whether api client verifies the server's
+                  certificate chain and host name. If InsecureSkipVerify is true, api client
+                  accepts any certificate presented by the server and any host name in that
+                  certificate.
+                type: boolean
+              secret:
+                description: Secret is a secret name which contains admin credentials.
+                type: string
+              url:
+                description: URL of keycloak service.
+                type: string
+            required:
+            - secret
+            - url
+            type: object
+          status:
+            default:
+              connected: false
+            description: KeycloakStatus defines the observed state of Keycloak.
+            properties:
+              connected:
+                description: Connected shows if keycloak service is up and running.
+                type: boolean
+            required:
+            - connected
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/templates/_helpers.tpl
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "keycloak-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "keycloak-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "keycloak-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "keycloak-operator.labels" -}}
+helm.sh/chart: {{ include "keycloak-operator.chart" . }}
+{{ include "keycloak-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "keycloak-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "keycloak-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "keycloak-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "keycloak-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/templates/clusterrole.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/templates/clusterrole.yaml
@@ -1,0 +1,367 @@
+{{- if .Values.clusterReconciliationEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "keycloak-operator.labels" . | nindent 4 }}
+  name: edp-{{ .Release.Namespace }}-clusterrole
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - clusterkeycloakrealms
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - clusterkeycloakrealms/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - clusterkeycloakrealms/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - clusterkeycloaks
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - clusterkeycloaks/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - clusterkeycloaks/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakauthflows
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakauthflows/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakauthflows/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakclients
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakclients/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakclients/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakclientscopes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakclientscopes/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakclientscopes/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmcomponents
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmcomponents/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmcomponents/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmgroups
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmgroups/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmgroups/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmidentityproviders
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmidentityproviders/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmidentityproviders/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmrolebatches
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmrolebatches/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmrolebatches/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmroles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmroles/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmroles/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealms
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealms/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealms/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmusers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmusers/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmusers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloaks
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloaks/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloaks/status
+    verbs:
+      - get
+      - patch
+      - update
+{{- end }}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/templates/clusterrolebinding.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.clusterReconciliationEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: edp-{{ .Release.Namespace }}-servicebindings
+  labels:
+    {{- include "keycloak-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edp-{{ .Release.Namespace }}-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: edp-{{ .Values.name }}
+    namespace: {{ .Release.Namespace }}
+{{- end}}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/templates/deployment.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/templates/deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    {{- include "keycloak-operator.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ .Values.name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.name }}
+    spec:
+      serviceAccountName: edp-{{ .Values.name }}
+      securityContext:
+        runAsNonRoot: true
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Values.name }}
+          # Replace this with the built image name
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+          command:
+            - /manager
+          securityContext:
+            allowPrivilegeEscalation: false
+          env:
+            - name: WATCH_NAMESPACE
+              {{- if .Values.clusterReconciliationEnabled }}
+              value: ""
+              {{- else }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+              {{- end }}
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+        {{- if .Values.extraVolumeMounts }}
+          volumeMounts:
+          {{- if .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
+        {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.extraVolumes }}
+      volumes:
+      {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}
+    {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/templates/leader_election_role.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/templates/leader_election_role.yaml
@@ -1,0 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: edp-{{ .Values.name }}-leader-election-role
+  labels:
+    {{- include "keycloak-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch

--- a/packages/system/keycloak-operator/charts/keycloak-operator/templates/leader_election_rolebinding.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/templates/leader_election_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: edp-{{ .Values.name }}-leader-election-rolebinding
+  labels:
+    {{- include "keycloak-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: edp-{{ .Values.name }}-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: edp-{{ .Values.name }}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/templates/operator_role.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/templates/operator_role.yaml
@@ -1,0 +1,313 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: edp-{{ .Values.name }}-role
+  labels:
+      {{- include "keycloak-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakauthflows
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakauthflows/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakauthflows/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakclients
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakclients/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakclients/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakclientscopes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakclientscopes/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakclientscopes/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmcomponents
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmcomponents/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmcomponents/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmgroups
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmgroups/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmgroups/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmidentityproviders
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmidentityproviders/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmidentityproviders/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmrolebatches
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmrolebatches/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmrolebatches/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmroles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmroles/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmroles/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealms
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealms/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealms/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmusers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmusers/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakrealmusers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloaks
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloaks/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloaks/status
+    verbs:
+      - get
+      - patch
+      - update

--- a/packages/system/keycloak-operator/charts/keycloak-operator/templates/operator_rolebinding.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/templates/operator_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: edp-{{ .Values.name }}-rolebinding
+  labels:
+    {{- include "keycloak-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: edp-{{ .Values.name }}-role
+subjects:
+  - kind: ServiceAccount
+    name: edp-{{ .Values.name }}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/templates/serviceaccount.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: edp-{{ .Values.name }}
+  labels:
+    {{- include "keycloak-operator.labels" . | nindent 4 }}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/values.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/values.yaml
@@ -1,0 +1,46 @@
+# -- Application name string
+name: keycloak-operator
+# -- Annotations to be added to the Deployment
+annotations: {}
+# -- Node labels for pod assignment
+nodeSelector: {}
+# -- Node tolerations for server scheduling to nodes with taints
+tolerations: []
+# -- Affinity for pod assignment
+affinity: {}
+image:
+  # -- KubeRocketCI keycloak-operator Docker image name. The released image can be found on [Dockerhub](https://hub.docker.com/r/epamedp/keycloak-operator)
+  repository: epamedp/keycloak-operator
+  # if not defined then .Chart.AppVersion is used
+  # -- KubeRocketCI keycloak-operator Docker image tag. The released image can be found on [Dockerhub](https://hub.docker.com/r/epamedp/keycloak-operator/tags)
+  tag:
+# -- If defined, a imagePullPolicy applied to the deployment
+imagePullPolicy: "IfNotPresent"
+# -- If defined, imagePullSecrets are applied to deployment
+imagePullSecrets: []
+
+# -- Resource limits and requests for the pod
+resources:
+  limits:
+    memory: 192Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi
+
+# -- Additional volumes to be added to the pod
+extraVolumes: []
+#  - name: custom-ca
+#    secret:
+#      defaultMode: 420
+#      secretName: custom-ca
+
+# -- Additional volumeMounts to be added to the container
+extraVolumeMounts: []
+#  - name: custom-ca
+#    mountPath: /etc/ssl/certs/CA.crt
+#    readOnly: true
+#    subPath: CA.crt
+
+# -- If clusterReconciliationEnabled is true, the operator reconciles all Keycloak instances in the cluster;
+#  otherwise, it only reconciles instances in the same namespace by default, and cluster-scoped resources are ignored.
+clusterReconciliationEnabled: false

--- a/packages/system/keycloak-operator/templates/configure-kk.yaml
+++ b/packages/system/keycloak-operator/templates/configure-kk.yaml
@@ -1,7 +1,7 @@
 {{- $cozyConfig := lookup "v1" "ConfigMap" "cozy-system" "cozystack" }}
 {{- $host := index $cozyConfig.data "root-host" }}
 {{- $apiServerAdress := index $cozyConfig.data "api-server-adress" }}
-{{- $k8sClient := randAlphaNum 48 -}}
+{{- $k8sClient := randAlphaNum 32 -}}
 
 apiVersion: v1.edp.epam.com/v1
 kind: Keycloak
@@ -54,7 +54,7 @@ kind: Secret
 metadata:
   name: k8s-client
 type: Opaque
-data:
+stringData:
   client-secret-key: {{ $k8sClient }}
 
 ---

--- a/packages/system/keycloak-operator/templates/configure-kk.yaml
+++ b/packages/system/keycloak-operator/templates/configure-kk.yaml
@@ -1,0 +1,86 @@
+{{- $cozyConfig := lookup "v1" "ConfigMap" "cozy-system" "cozystack" }}
+{{- $host := index $cozyConfig.data "root-host" }}
+{{- $apiServerAdress := index $cozyConfig.data "api-server-adress" }}
+{{- $k8sClient := randAlphaNum 48 -}}
+
+apiVersion: v1.edp.epam.com/v1
+kind: Keycloak
+metadata:
+  name: keycloak-cozy
+spec:
+  secret: keycloak-credentials
+  url: https://keycloak.{{ $host }}
+
+---
+
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakRealm
+metadata:
+  name: keycloakrealm-cozy
+spec:
+ realmName: cozy
+ keycloakRef:
+   name: keycloak-cozy
+   kind: Keycloak
+
+---
+
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakClientScope
+metadata:
+  name: keycloakclientscope-cozy
+spec:
+  name: groups
+  realmRef:
+    name: keycloakrealm-cozy
+    kind: KeycloakRealm
+  description: "Group Membership"
+  protocol: openid-connect
+  protocolMappers:
+    - name: groups
+      protocol: openid-connect
+      protocolMapper: "oidc-group-membership-mapper"
+      config:
+        "access.token.claim": "true"
+        "claim.name": "groups"
+        "full.path": "false"
+        "id.token.claim": "true"
+        "userinfo.token.claim": "true"
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: k8s-client
+type: Opaque
+data:
+  client-secret-key: {{ $k8sClient }}
+
+---
+
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakClient
+metadata:
+  name: keycloakclient
+spec:
+  serviceAccount:
+    enabled: true
+  realmRef:
+    name: keycloakrealm-cozy
+    kind: KeycloakRealm
+  secret: $k8s-client:client-secret-key
+  advancedProtocolMappers: true
+  authorizationServicesEnabled: true
+  name: kubernetes
+  clientId: kubernetes
+  directAccess: true
+  public: false
+  webUrl: https://{{ $apiServerAdress }}/oauth2/callback
+  webOrigins:
+    - /*
+  defaultClientScopes:
+    - groups
+  redirectUris:
+    - http://localhost:18000
+    - http://localhost:8000

--- a/packages/system/keycloak/templates/sts.yaml
+++ b/packages/system/keycloak/templates/sts.yaml
@@ -7,7 +7,8 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-credentials
 stringData:
-  admin: {{ $password }}
+  username: admin
+  password: {{ $password }}
 
 ---
 
@@ -124,12 +125,4 @@ spec:
               port: http
             initialDelaySeconds: 60
             timeoutSeconds: 1
-      volumes:
-        - name: init-script
-          configMap:
-            name: keycloak-init-script
-      volumeMounts:
-        - name: init-script
-          mountPath: /scripts
-          readOnly: true
       terminationGracePeriodSeconds: 60


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the `keycloak-operator` as an optional component in multiple deployment configurations.
	- Added a Helm chart for the `keycloak-operator`, enabling streamlined deployment and management of Keycloak instances.
	- Enhanced documentation with a new README file for the Keycloak Operator Helm chart, detailing installation and usage instructions.
	- Added various Custom Resource Definitions (CRDs) for managing Keycloak resources effectively within Kubernetes.

- **Bug Fixes**
	- Improved handling of user credentials and realm configurations in the Keycloak operator.

- **Documentation**
	- Comprehensive updates to the README and configuration files to assist users in deploying and managing Keycloak.

- **Chores**
	- Added various Custom Resource Definitions (CRDs) for managing Keycloak resources effectively within Kubernetes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->