### PR TITLE
Allow specifying mtu for kubeovn daemonset

### DIFF
--- a/packages/system/kubeovn/Makefile
+++ b/packages/system/kubeovn/Makefile
@@ -11,6 +11,7 @@ update:
 	curl -sSL https://github.com/kubeovn/kube-ovn/archive/refs/heads/master.tar.gz | \
 	tar xzvf - --strip 1 kube-ovn-master/charts
 	patch --no-backup-if-mismatch -p4 < patches/cozyconfig.diff
+	patch --no-backup-if-mismatch -p4 < patches/mtu.diff
 
 image:
 	docker buildx build images/kubeovn \

--- a/packages/system/kubeovn/charts/kube-ovn/templates/ovncni-ds.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/ovncni-ds.yaml
@@ -76,6 +76,9 @@ spec:
           - --kubelet-dir={{ .Values.kubelet_conf.KUBELET_DIR }}
           - --enable-tproxy={{ .Values.func.ENABLE_TPROXY }}
           - --ovs-vsctl-concurrency={{ .Values.performance.OVS_VSCTL_CONCURRENCY }}
+          {{- with .Values.mtu }}
+          - --mtu={{ . }}
+          {{- end }}
         securityContext:
           runAsUser: 0
           privileged: true

--- a/packages/system/kubeovn/patches/mtu.diff
+++ b/packages/system/kubeovn/patches/mtu.diff
@@ -1,0 +1,14 @@
+diff --git a/packages/system/kubeovn/charts/kube-ovn/templates/ovncni-ds.yaml b/packages/system/kubeovn/charts/kube-ovn/templates/ovncni-ds.yaml
+index c6834ef..423f66b 100644
+--- a/packages/system/kubeovn/charts/kube-ovn/templates/ovncni-ds.yaml
++++ b/packages/system/kubeovn/charts/kube-ovn/templates/ovncni-ds.yaml
+@@ -76,6 +76,9 @@ spec:
+           - --kubelet-dir={{ .Values.kubelet_conf.KUBELET_DIR }}
+           - --enable-tproxy={{ .Values.func.ENABLE_TPROXY }}
+           - --ovs-vsctl-concurrency={{ .Values.performance.OVS_VSCTL_CONCURRENCY }}
++          {{- with .Values.mtu }}
++          - --mtu={{ . }}
++          {{- end }}
+         securityContext:
+           runAsUser: 0
+           privileged: true


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new patch application step in the update process for KubeOVN.
	- Enhanced flexibility in the `kube-ovn-cni` configuration by allowing users to specify the Maximum Transmission Unit (MTU) for improved network performance.
  
- **Bug Fixes**
	- Applied a patch to ensure the new MTU configuration is properly integrated into the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->