### PR TITLE
Remove unnecessary allow-to-keycloak policy

### DIFF
--- a/packages/apps/tenant/templates/networkpolicy.yaml
+++ b/packages/apps/tenant/templates/networkpolicy.yaml
@@ -192,16 +192,4 @@ spec:
   - toEndpoints:
     - matchLabels:
         cozystack.io/service: ingress
----
-apiVersion: cilium.io/v2
-kind: CiliumNetworkPolicy
-metadata:
-  name: allow-to-keycloak
-  namespace: {{ include "tenant.name" . }}
-spec:
-  endpointSelector: {}
-  egress:
-  - toEndpoints:
-      - matchLabels:
-          "k8s:io.kubernetes.pod.namespace": cozy-keycloak
 {{- end }}

--- a/packages/system/keycloak-configure/templates/configure-kk.yaml
+++ b/packages/system/keycloak-configure/templates/configure-kk.yaml
@@ -112,8 +112,6 @@ spec:
 
 ---
 
----
-
 apiVersion: v1.edp.epam.com/v1
 kind: KeycloakClient
 metadata:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced Keycloak client configuration with new secrets for `k8s-client`, `kubeapps-client`, and `kubeapps-auth-config`.
	- Introduced new `ClusterKeycloak` and `ClusterKeycloakRealm` resources for improved management.
	- Updated Keycloak client scopes with additional attributes and protocol mappers.
	- Added multiple CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy configurations for better traffic control.

- **Improvements**
	- Logic added to check for existing Kubernetes secrets and generate new ones as needed, ensuring seamless configuration management.
	- Enhanced network policies to provide comprehensive control over ingress and egress traffic for various services within the tenant's namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->