### PR TITLE
Add cozystack-cluster-admin

### DIFF
--- a/packages/system/keycloak-configure/templates/configure-kk.yaml
+++ b/packages/system/keycloak-configure/templates/configure-kk.yaml
@@ -225,3 +225,16 @@ spec:
   realmRef:
     name: keycloakrealm-cozy
     kind: ClusterKeycloakRealm
+
+---
+
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakRealmGroup
+metadata:
+  name: cozystack-cluster-admin
+  namespace: cozy-dashboard
+spec:
+  name: cozystack-cluster-admin
+  realmRef:
+    name: keycloakrealm-cozy
+    kind: ClusterKeycloakRealm

--- a/packages/system/keycloak-configure/templates/configure-kk.yaml
+++ b/packages/system/keycloak-configure/templates/configure-kk.yaml
@@ -232,7 +232,7 @@ apiVersion: v1.edp.epam.com/v1
 kind: KeycloakRealmGroup
 metadata:
   name: cozystack-cluster-admin
-  namespace: cozy-dashboard
+  namespace: cozy-system
 spec:
   name: cozystack-cluster-admin
   realmRef:

--- a/packages/system/keycloak-configure/templates/rolebinding.yaml
+++ b/packages/system/keycloak-configure/templates/rolebinding.yaml
@@ -11,3 +11,19 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: kubeapps-admin
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cozystack-cluster-admin-group
+  namespace: cozy-dashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cozystack-cluster-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: cozystack-cluster-admin

--- a/packages/system/keycloak-configure/templates/rolebinding.yaml
+++ b/packages/system/keycloak-configure/templates/rolebinding.yaml
@@ -6,11 +6,27 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: admin
+  name: kubeapps-admin
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: kubeapps-admin
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubeapps-admin
+  namespace: cozy-public
+subjects:
+- kind: Group
+  name: kubeapps-admin
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: kubeapps-admin
+  apiGroup: rbac.authorization.k8s.io
 
 ---
 

--- a/packages/system/keycloak-configure/templates/rolebinding.yaml
+++ b/packages/system/keycloak-configure/templates/rolebinding.yaml
@@ -34,7 +34,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cozystack-cluster-admin-group
-  namespace: cozy-dashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/packages/system/keycloak-configure/templates/roles.yaml
+++ b/packages/system/keycloak-configure/templates/roles.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cozystack-cluster-admin
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - '*'

--- a/packages/system/keycloak-configure/templates/roles.yaml
+++ b/packages/system/keycloak-configure/templates/roles.yaml
@@ -1,6 +1,48 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: kubeapps-admin
+rules:
+- apiGroups: [""]
+  resources:
+  - "*"
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["apps.cozystack.io"]
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups: ["helm.toolkit.fluxcd.io"]
+  resources:
+  - helmreleases
+  verbs:
+  - '*'
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubeapps-admin
+  namespace: cozy-public
+rules:
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: ["helmrepositories"]
+    verbs:
+    - get
+    - list
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources:
+    - helmcharts
+    verbs: ["*"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: cozystack-cluster-admin
 rules:
 - apiGroups:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced new `Secret` resources for `k8s-client`, `kubeapps-client`, and `kubeapps-auth-config` to enhance Keycloak configuration.
	- Added a new `KeycloakRealmGroup` named `cozystack-cluster-admin` for improved access management.
	- Implemented a new `RoleBinding` for `kubeapps-admin` in the `cozy-public` namespace, linking it to the `kubeapps-admin` role.
	- Created a new `ClusterRoleBinding` named `cozystack-cluster-admin-group`, providing cluster-level permissions.
	- Added new `ClusterRole` named `kubeapps-admin`, granting specific permissions for resource management.

- **Bug Fixes**
	- None

- **Documentation**
	- None

- **Refactor**
	- None

- **Style**
	- None

- **Tests**
	- None

- **Chores**
	- None

- **Revert**
	- None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->