### PR TITLE
Fix kube-state-mterics and flux alerts labels

### DIFF
--- a/packages/system/monitoring-agents/alerts/flux.yaml
+++ b/packages/system/monitoring-agents/alerts/flux.yaml
@@ -1,18 +1,7 @@
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
-  annotations:
-    meta.helm.sh/release-name: monitoring
-    meta.helm.sh/release-namespace: cozy-monitoring
-  labels:
-    app: victoria-metrics-k8s-stack
-    app.kubernetes.io/instance: monitoring
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: victoria-metrics-k8s-stack
-    app.kubernetes.io/version: v1.102.1
-    helm.sh/chart: victoria-metrics-k8s-stack-0.25.17
   name: alerts-flux-resources
-  namespace: cozy-monitoring
 spec:
   groups:
   - name: flux-resources-alerts

--- a/packages/system/monitoring-agents/templates/kube-state-metrics-scrape.yaml
+++ b/packages/system/monitoring-agents/templates/kube-state-metrics-scrape.yaml
@@ -8,7 +8,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: kube-state-metrics
-      app.kubernetes.io/instance: "monitoring"
   endpoints:
   - port: http
     honorLabels: true


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined metadata for monitoring agents by removing specific Helm-related annotations and labels.
	- Updated service scrape configuration to enhance target pod identification with a new relabeling entry.

- **Bug Fixes**
	- Adjusted label selection in the `VMServiceScrape` resource to improve service scrape functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->