### PR TITLE
add grafana size configure

### DIFF
--- a/packages/extra/monitoring/Chart.yaml
+++ b/packages/extra/monitoring/Chart.yaml
@@ -3,4 +3,4 @@ name: monitoring
 description: Monitoring and observability stack
 icon: /logos/monitoring.svg
 type: application
-version: 1.5.2
+version: 1.5.3

--- a/packages/extra/monitoring/README.md
+++ b/packages/extra/monitoring/README.md
@@ -4,12 +4,13 @@
 
 ### Common parameters
 
-| Name                            | Description                                                                                               | Value                                            |
-| ------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| `host`                          | The hostname used to access the grafana externally (defaults to 'grafana' subdomain for the tenant host). | `""`                                             |
-| `metricsStorages`               | Configuration of metrics storage instances                                                                | `[]`                                             |
-| `logsStorages`                  | Configuration of logs storage instances                                                                   | `[]`                                             |
-| `alerta.storage`                | Persistent Volume size for alerta database                                                                | `10Gi`                                           |
-| `alerta.storageClassName`       | StorageClass used to store the data                                                                       | `""`                                             |
-| `alerta.alerts.telegram.token`  | telegram token for your bot                                                                               | `7262461387:AAGtwq16iwuVtWtzoN6TUEMpF00fpC9Xz34` |
-| `alerta.alerts.telegram.chatID` | specify multiple ID's separated by comma. Get yours in https://t.me/chatid_echo_bot                       | `-4520856007`                                    |
+| Name                            | Description                                                                                               | Value  |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------- | ------ |
+| `host`                          | The hostname used to access the grafana externally (defaults to 'grafana' subdomain for the tenant host). | `""`   |
+| `metricsStorages`               | Configuration of metrics storage instances                                                                | `[]`   |
+| `logsStorages`                  | Configuration of logs storage instances                                                                   | `[]`   |
+| `alerta.storage`                | Persistent Volume size for alerta database                                                                | `10Gi` |
+| `alerta.storageClassName`       | StorageClass used to store the data                                                                       | `""`   |
+| `alerta.alerts.telegram.token`  | telegram token for your bot                                                                               | `""`   |
+| `alerta.alerts.telegram.chatID` | specify multiple ID's separated by comma. Get yours in https://t.me/chatid_echo_bot                       | `""`   |
+| `grafana.db.size`               | Persistent Volume size for grafana database                                                               | `10Gi` |

--- a/packages/extra/monitoring/templates/grafana/db.yaml
+++ b/packages/extra/monitoring/templates/grafana/db.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   instances: 2
   storage:
-    size: 10Gi
+    size: {{ .Values.grafana.db.size }}
 
   inheritedMetadata:
     labels:

--- a/packages/extra/monitoring/values.schema.json
+++ b/packages/extra/monitoring/values.schema.json
@@ -45,14 +45,29 @@
                 "token": {
                   "type": "string",
                   "description": "telegram token for your bot",
-                  "default": "7262461387:AAGtwq16iwuVtWtzoN6TUEMpF00fpC9Xz34"
+                  "default": ""
                 },
                 "chatID": {
                   "type": "string",
                   "description": "specify multiple ID's separated by comma. Get yours in https://t.me/chatid_echo_bot",
-                  "default": "-4520856007"
+                  "default": ""
                 }
               }
+            }
+          }
+        }
+      }
+    },
+    "grafana": {
+      "type": "object",
+      "properties": {
+        "db": {
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "string",
+              "description": "Persistent Volume size for grafana database",
+              "default": "10Gi"
             }
           }
         }

--- a/packages/extra/monitoring/values.yaml
+++ b/packages/extra/monitoring/values.yaml
@@ -44,3 +44,9 @@ alerta:
     telegram:
       token: ""
       chatID: ""
+
+## Configuration for Grafana
+## @param grafana.db.size Persistent Volume size for grafana database
+grafana:
+  db:
+    size: 10Gi

--- a/packages/extra/versions_map
+++ b/packages/extra/versions_map
@@ -16,7 +16,8 @@ monitoring 1.3.0 6c5cf5b
 monitoring 1.4.0 adaf603b
 monitoring 1.5.0 4b90bf5a
 monitoring 1.5.1 57e90b70
-monitoring 1.5.2 HEAD
+monitoring 1.5.2 898374b5
+monitoring 1.5.3 HEAD
 seaweedfs 0.1.0 5ca8823
 seaweedfs 0.2.0 9e33dc0
 seaweedfs 0.2.1 HEAD


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new parameter for Grafana's database size with a default value of 10Gi.
  
- **Bug Fixes**
  - Updated default values for `alerta.alerts.telegram.token` and `alerta.alerts.telegram.chatID` to empty strings.

- **Documentation**
  - Revised the README to reflect changes in default parameter values and added new parameters for Grafana.

- **Chores**
  - Updated the monitoring application's version from 1.5.2 to 1.5.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->