### PR TITLE
fix-vm-logs-url

### DIFF
--- a/packages/extra/monitoring/Chart.yaml
+++ b/packages/extra/monitoring/Chart.yaml
@@ -3,4 +3,4 @@ name: monitoring
 description: Monitoring and observability stack
 icon: /logos/monitoring.svg
 type: application
-version: 1.5.2
+version: 1.5.3

--- a/packages/extra/monitoring/templates/grafana/grafana.yaml
+++ b/packages/extra/monitoring/templates/grafana/grafana.yaml
@@ -1,5 +1,5 @@
 {{- $cozyConfig := lookup "v1" "ConfigMap" "cozy-system" "cozystack" }}
-{{- $issuerType := (index $cozyConfig.data "clusterissuer") | default "http01" }} 
+{{- $issuerType := (index $cozyConfig.data "clusterissuer") | default "http01" }}
 
 {{- $myNS := lookup "v1" "Namespace" "" .Release.Namespace }}
 {{- $ingress := index $myNS.metadata.annotations "namespace.cozystack.io/ingress" }}
@@ -30,7 +30,7 @@ spec:
       admin_user: user
       admin_password: ${GF_PASSWORD}
     plugins:
-      allow_loading_unsigned_plugins: "victorialogs-datasource"
+      allow_loading_unsigned_plugins: "victoriametrics-logs-datasource"
   deployment:
     spec:
       replicas: 2
@@ -51,7 +51,7 @@ spec:
                   set -ex
                   mkdir -p /var/lib/grafana/plugins/
                   ver=$(curl -s https://api.github.com/repos/VictoriaMetrics/victorialogs-datasource/releases/latest | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-                  curl -L https://github.com/VictoriaMetrics/victorialogs-datasource/releases/download/$ver/victorialogs-datasource-$ver.tar.gz -o /var/lib/grafana/plugins/vl-plugin.tar.gz
+                  curl -L https://github.com/VictoriaMetrics/victorialogs-datasource/releases/download/$ver/victoriametrics-logs-datasource-$ver.tar.gz -o /var/lib/grafana/plugins/vl-plugin.tar.gz
                   tar -xf /var/lib/grafana/plugins/vl-plugin.tar.gz -C /var/lib/grafana/plugins/
                   rm /var/lib/grafana/plugins/vl-plugin.tar.gz
               volumeMounts:

--- a/packages/extra/monitoring/templates/vlogs/grafana-datasource.yaml
+++ b/packages/extra/monitoring/templates/vlogs/grafana-datasource.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   datasource:
     access: proxy
-    type: victorialogs-datasource
+    type: victoriametrics-logs-datasource
     name: vlogs-{{ .name }}
     url: http://vlogs-{{ .name }}.{{ $.Release.Namespace }}.svc:9428
   instanceSelector:

--- a/packages/extra/versions_map
+++ b/packages/extra/versions_map
@@ -16,7 +16,8 @@ monitoring 1.3.0 6c5cf5b
 monitoring 1.4.0 adaf603b
 monitoring 1.5.0 4b90bf5a
 monitoring 1.5.1 57e90b70
-monitoring 1.5.2 HEAD
+monitoring 1.5.2 898374b5
+monitoring 1.5.3 HEAD
 seaweedfs 0.1.0 5ca8823
 seaweedfs 0.2.0 9e33dc0
 seaweedfs 0.2.1 HEAD


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated monitoring application version to 1.5.3.
	- Changed the data source type in Grafana configuration to `victoriametrics-logs-datasource`.
- **Bug Fixes**
	- Corrected plugin loading configuration in Grafana.
- **Chores**
	- Updated version mapping for the monitoring package in the versions map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->