### PR TITLE
up vmagent limit

### DIFF
--- a/packages/system/monitoring-agents/templates/vmagent.yaml
+++ b/packages/system/monitoring-agents/templates/vmagent.yaml
@@ -18,10 +18,10 @@ spec:
     key: prometheus-additional.yaml
   resources:
     limits:
-      memory: 500Mi
+      memory: 1024Mi
     requests:
       cpu: 50m
-      memory: 200Mi
+      memory: 768Mi
   #statefulMode: true
   #statefulStorage:
   #  volumeClaimTemplate:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Resource Configuration**
	- Updated VMAgent memory limits from 500Mi to 1024Mi.
	- Increased VMAgent memory requests from 200Mi to 768Mi.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->