### PR TITLE
add cnpg alerts

### DIFF
--- a/packages/system/postgres-operator/templates/prometheusrule.yaml
+++ b/packages/system/postgres-operator/templates/prometheusrule.yaml
@@ -1,0 +1,84 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cnpg-default-alerts
+spec:
+  groups:
+  - name: cnpg-default.rules
+    rules:
+    - alert: LongRunningTransaction
+      annotations:
+        description: >-
+          Pod {{ $labels.pod }} has a transaction running longer than 5 minutes (300 seconds).
+          This could indicate a potential lock issue or unoptimized query execution.
+        summary: Long-running transaction detected.
+      expr: rate(cnpg_backends_max_tx_duration_seconds[5m]) > 300
+      for: 1m
+      labels:
+        severity: warning
+
+    - alert: BackendsWaiting
+      annotations:
+        description: >-
+          Pod {{ $labels.pod }} has backends waiting for queries to complete for longer than 5 minutes.
+          This may indicate resource contention or slow query performance.
+        summary: Waiting backends detected.
+      expr: rate(cnpg_backends_waiting_total[5m]) > 300
+      for: 1m
+      labels:
+        severity: warning
+
+    - alert: PGDatabaseXidAge
+      annotations:
+        description: >-
+          Pod {{ $labels.pod }} has exceeded the transaction ID age limit of 150,000,000.
+          This may lead to transaction wraparound and data corruption if not resolved.
+        summary: Transaction ID age limit exceeded.
+      expr: max(cnpg_pg_database_xid_age) > 300000000
+      for: 1m
+      labels:
+        severity: critical
+
+    - alert: PGReplication
+      annotations:
+        description: >-
+          Standby on pod {{ $labels.pod }} is lagging behind the primary by more than 5 minutes (300 seconds).
+          This can lead to outdated data on replicas.
+        summary: Replication lag detected.
+      expr: rate(cnpg_pg_replication_lag[5m]) > 300
+      for: 1m
+      labels:
+        severity: critical
+
+    - alert: LastFailedArchiveTime
+      annotations:
+        description: >-
+          Archiving on pod {{ $labels.pod }} failed more recently than the last successful archive.
+          Investigate logs for archiving errors.
+        summary: Archiving failure detected.
+      expr: (cnpg_pg_stat_archiver_last_failed_time - cnpg_pg_stat_archiver_last_archived_time) > time() - 60
+      for: 1m
+      labels:
+        severity: warning
+
+    - alert: DatabaseDeadlockConflicts
+      annotations:
+        description: >-
+          Pod {{ $labels.pod }} has experienced more than 10 deadlock conflicts.
+          Review database logs and queries to identify potential locking issues.
+        summary: Deadlock conflicts detected.
+      expr: increase(cnpg_pg_stat_database_deadlocks[10m]) > 10
+      for: 1m
+      labels:
+        severity: warning
+
+    - alert: ReplicaFailingReplication
+      annotations:
+        description: >-
+          Replica pod {{ $labels.pod }} is failing to replicate due to issues with WAL receiver.
+          Verify network connectivity, disk space, and replica configuration.
+        summary: Replica replication failure detected.
+      expr: cnpg_pg_replication_in_recovery > 0 and cnpg_pg_replication_is_wal_receiver_up == 0
+      for: 1m
+      labels:
+        severity: critical

--- a/packages/system/postgres-operator/templates/prometheusrule.yaml
+++ b/packages/system/postgres-operator/templates/prometheusrule.yaml
@@ -8,13 +8,15 @@ spec:
     rules:
     - alert: LongRunningTransaction
       annotations:
-        description: Namespace {{ $labels.namespace }} App {{ $labels.application_name }} Pod {{ $labels.pod }} is taking more than 5 minutes (300 seconds) for a query.
+        description: Namespace {{ $labels.namespace }} Job {{ $labels.job }} Pod {{ $labels.pod }} is taking more than 5 minutes (300 seconds) for a query.
         summary: A query is taking longer than 5 minutes.
       expr: |-
         cnpg_backends_max_tx_duration_seconds > 300
       for: 1m
       labels:
         severity: warning
+        namespace: {{ $labels.namespace }}
+        job: {{ $labels.job }}
     - alert: BackendsWaiting
       annotations:
         description: Namespace {{ $labels.namespace }} Job {{ $labels.job }} Pod {{ $labels.pod }} has been waiting for longer than 5 minutes
@@ -24,6 +26,8 @@ spec:
       for: 1m
       labels:
         severity: warning
+        namespace: {{ $labels.namespace }}
+        job: {{ $labels.job }}
     - alert: PGDatabaseXidAge
       annotations:
         description: Over 300,000,000 transactions from frozen xid on Namespace {{ $labels.namespace }} Job {{ $labels.job }} Pod {{ $labels.pod }}
@@ -33,6 +37,8 @@ spec:
       for: 1m
       labels:
         severity: warning
+        namespace: {{ $labels.namespace }}
+        job: {{ $labels.job }}
     - alert: PGReplication
       annotations:
         description: Namespace {{ $labels.namespace }} Job {{ $labels.job }} Pod {{ $labels.pod }} Standby is lagging behind by over 300 seconds (5 minutes)
@@ -42,6 +48,8 @@ spec:
       for: 1m
       labels:
         severity: warning
+        namespace: {{ $labels.namespace }}
+        job: {{ $labels.job }}
     - alert: LastFailedArchiveTime
       annotations:
         description: Archiving failed for Namespace {{ $labels.namespace }} Job {{ $labels.job }} Pod {{ $labels.pod }}
@@ -51,6 +59,8 @@ spec:
       for: 1m
       labels:
         severity: warning
+        namespace: {{ $labels.namespace }}
+        job: {{ $labels.job }}
     - alert: DatabaseDeadlockConflicts
       annotations:
         description: There are over 10 deadlock conflicts in Namespace {{ $labels.namespace }} Job {{ $labels.job }} Pod {{ $labels.pod }}
@@ -60,6 +70,8 @@ spec:
       for: 1m
       labels:
         severity: warning
+        namespace: {{ $labels.namespace }}
+        job: {{ $labels.job }}
     - alert: ReplicaFailingReplication
       annotations:
         description: Namespace {{ $labels.namespace }} Job {{ $labels.job }} Pod {{ $labels.pod }} Replica is failing to replicate
@@ -69,3 +81,21 @@ spec:
       for: 1m
       labels:
         severity: warning
+        namespace: {{ $labels.namespace }}
+        job: {{ $labels.job }}
+    - alert: CNPGClusterOffline
+      annotations:
+        summary: CNPG Cluster has no running instances!
+        description: |-
+          CloudNativePG Cluster Namespace: {{ $labels.namespace }} Job: {{ $labels.job }} Pod: {{ $labels.pod }} has no ready instances.
+          Having an offline cluster means your applications will not be able to access the database, leading to
+          potential service disruption and/or data loss.
+        runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterOffline.md
+      expr: |
+        sum by (namespace, pod) (cnpg_collector_up)) OR on() vector(0) == 0
+      for: 5m
+      labels:
+        severity: critical
+        namespace: {{ $labels.namespace }}
+        job: {{ $labels.job }}
+        pod: {{ $labels.pod }}

--- a/packages/system/postgres-operator/templates/prometheusrule.yaml
+++ b/packages/system/postgres-operator/templates/prometheusrule.yaml
@@ -4,81 +4,68 @@ metadata:
   name: cnpg-default-alerts
 spec:
   groups:
-  - name: cnpg-default.rules
+  - name: cnp-default.rules
     rules:
     - alert: LongRunningTransaction
       annotations:
-        description: >-
-          Pod {{ $labels.pod }} has a transaction running longer than 5 minutes (300 seconds).
-          This could indicate a potential lock issue or unoptimized query execution.
-        summary: Long-running transaction detected.
-      expr: rate(cnpg_backends_max_tx_duration_seconds[5m]) > 300
+        description: Namespace {{ $labels.namespace }} App {{ $labels.application_name }} Pod {{ $labels.pod }} is taking more than 5 minutes (300 seconds) for a query.
+        summary: A query is taking longer than 5 minutes.
+      expr: |-
+        cnpg_backends_max_tx_duration_seconds > 300
       for: 1m
       labels:
         severity: warning
-
     - alert: BackendsWaiting
       annotations:
-        description: >-
-          Pod {{ $labels.pod }} has backends waiting for queries to complete for longer than 5 minutes.
-          This may indicate resource contention or slow query performance.
-        summary: Waiting backends detected.
-      expr: rate(cnpg_backends_waiting_total[5m]) > 300
+        description: Namespace {{ $labels.namespace }} Job {{ $labels.job }} Pod {{ $labels.pod }} has been waiting for longer than 5 minutes
+        summary: If a backend is waiting for longer than 5 minutes
+      expr: |-
+        cnpg_backends_waiting_total > 300
       for: 1m
       labels:
         severity: warning
-
     - alert: PGDatabaseXidAge
       annotations:
-        description: >-
-          Pod {{ $labels.pod }} has exceeded the transaction ID age limit of 150,000,000.
-          This may lead to transaction wraparound and data corruption if not resolved.
-        summary: Transaction ID age limit exceeded.
-      expr: max(cnpg_pg_database_xid_age) > 300000000
+        description: Over 300,000,000 transactions from frozen xid on Namespace {{ $labels.namespace }} Job {{ $labels.job }} Pod {{ $labels.pod }}
+        summary: Number of transactions from the frozen XID to the current one
+      expr: |-
+        cnpg_pg_database_xid_age > 300000000
       for: 1m
       labels:
-        severity: critical
-
+        severity: warning
     - alert: PGReplication
       annotations:
-        description: >-
-          Standby on pod {{ $labels.pod }} is lagging behind the primary by more than 5 minutes (300 seconds).
-          This can lead to outdated data on replicas.
-        summary: Replication lag detected.
-      expr: rate(cnpg_pg_replication_lag[5m]) > 300
+        description: Namespace {{ $labels.namespace }} Job {{ $labels.job }} Pod {{ $labels.pod }} Standby is lagging behind by over 300 seconds (5 minutes)
+        summary: The standby is lagging behind the primary
+      expr: |-
+        cnpg_pg_replication_lag > 300
       for: 1m
       labels:
-        severity: critical
-
+        severity: warning
     - alert: LastFailedArchiveTime
       annotations:
-        description: >-
-          Archiving on pod {{ $labels.pod }} failed more recently than the last successful archive.
-          Investigate logs for archiving errors.
-        summary: Archiving failure detected.
-      expr: (cnpg_pg_stat_archiver_last_failed_time - cnpg_pg_stat_archiver_last_archived_time) > time() - 60
+        description: Archiving failed for Namespace {{ $labels.namespace }} Job {{ $labels.job }} Pod {{ $labels.pod }}
+        summary: Checks the last time archiving failed. Will be < 0 when it has not failed.
+      expr: |-
+        sum by (namespace, job) (cnpg_pg_stat_archiver_last_failed_time) - sum by (namespace, job) (cnpg_pg_stat_archiver_last_archived_time) > 1
       for: 1m
       labels:
         severity: warning
-
     - alert: DatabaseDeadlockConflicts
       annotations:
-        description: >-
-          Pod {{ $labels.pod }} has experienced more than 10 deadlock conflicts.
-          Review database logs and queries to identify potential locking issues.
-        summary: Deadlock conflicts detected.
-      expr: increase(cnpg_pg_stat_database_deadlocks[10m]) > 10
+        description: There are over 10 deadlock conflicts in Namespace {{ $labels.namespace }} Job {{ $labels.job }} Pod {{ $labels.pod }}
+        summary: Checks the number of database conflicts
+      expr: |-
+        cnpg_pg_stat_database_deadlocks > 10
       for: 1m
       labels:
         severity: warning
-
     - alert: ReplicaFailingReplication
       annotations:
-        description: >-
-          Replica pod {{ $labels.pod }} is failing to replicate due to issues with WAL receiver.
-          Verify network connectivity, disk space, and replica configuration.
-        summary: Replica replication failure detected.
-      expr: cnpg_pg_replication_in_recovery > 0 and cnpg_pg_replication_is_wal_receiver_up == 0
+        description: Namespace {{ $labels.namespace }} Job {{ $labels.job }} Pod {{ $labels.pod }} Replica is failing to replicate
+        summary: Checks if the replica is failing to replicate
+      expr: |-
+        sum by (namespace, job) (cnpg_pg_replication_in_recovery) - sum by (namespace, job) (cnpg_pg_replication_is_wal_receiver_up) > 0
       for: 1m
       labels:
-        severity: critical
+        severity: warning


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added comprehensive monitoring and alerting rules for PostgreSQL instances.
	- Introduced alerts for:
		- Long-running transactions
		- Backend waiting times
		- Transaction ID age
		- Replication lag
		- Archiving failures
		- Deadlock conflicts
		- Replication status
	- New resource: `PrometheusRule` named `cnpg-default-alerts`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->