### PR TITLE
Fix cluster-autoscaler

### DIFF
--- a/packages/apps/kubernetes/images/cluster-autoscaler.tag
+++ b/packages/apps/kubernetes/images/cluster-autoscaler.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/cluster-autoscaler:0.14.1@sha256:0ea139c71e08db5adb275d81a7efa9a0d8b8db61a1fc1a67167a33a347c07fd8
+ghcr.io/aenix-io/cozystack/cluster-autoscaler:latest@sha256:a8035edb5abee8e88c9153ea4f612d03f490c9bba757c2e57f61ae66cc6fe972

--- a/packages/apps/kubernetes/images/cluster-autoscaler/Dockerfile
+++ b/packages/apps/kubernetes/images/cluster-autoscaler/Dockerfile
@@ -1,12 +1,14 @@
 # Source: https://raw.githubusercontent.com/kubernetes/autoscaler/refs/heads/master/cluster-autoscaler/Dockerfile.amd64
-ARG builder_image=docker.io/library/golang:1.22.5
+ARG builder_image=docker.io/library/golang:1.23.4
 ARG BASEIMAGE=gcr.io/distroless/static:nonroot-amd64
 FROM ${builder_image} AS builder
 RUN git clone https://github.com/kubernetes/autoscaler /src/autoscaler \
  && cd /src/autoscaler/cluster-autoscaler \
- && git checkout cluster-autoscaler-1.31.0
+ && git checkout cluster-autoscaler-1.32.0
 
 WORKDIR /src/autoscaler/cluster-autoscaler
+COPY fix-downscale.diff /fix-downscale.diff
+RUN git apply /fix-downscale.diff
 RUN make build
 
 FROM $BASEIMAGE

--- a/packages/apps/kubernetes/images/cluster-autoscaler/fix-downscale.diff
+++ b/packages/apps/kubernetes/images/cluster-autoscaler/fix-downscale.diff
@@ -1,0 +1,13 @@
+diff --git a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+index 4eec0e4bf..f28fd9241 100644
+--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
++++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+@@ -106,8 +106,6 @@ func (r unstructuredScalableResource) Replicas() (int, error) {
+ 
+ func (r unstructuredScalableResource) SetSize(nreplicas int) error {
+ 	switch {
+-	case nreplicas > r.maxSize:
+-		return fmt.Errorf("size increase too large - desired:%d max:%d", nreplicas, r.maxSize)
+ 	case nreplicas < r.minSize:
+ 		return fmt.Errorf("size decrease too large - desired:%d min:%d", nreplicas, r.minSize)
+ 	}

--- a/packages/apps/kubernetes/templates/cluster-autoscaler/deployment.yaml
+++ b/packages/apps/kubernetes/templates/cluster-autoscaler/deployment.yaml
@@ -30,6 +30,12 @@ spec:
         - /cluster-autoscaler
         args:
         - --cloud-provider=clusterapi
+        - --enforce-node-group-min-size=true
+        - --ignore-daemonsets-utilization=true
+        - --ignore-mirror-pods-utilization=true
+        - --scale-down-unneeded-time=30s
+        - --scan-interval=25s
+        - --force-delete-unregistered-nodes=true
         - --kubeconfig=/etc/kubernetes/kubeconfig/super-admin.svc
         - --clusterapi-cloud-config-authoritative
         - --node-group-auto-discovery=clusterapi:namespace={{ .Release.Namespace }},clusterName={{ .Release.Name }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated Cluster Autoscaler to version 1.32.0
	- Added new configuration options for more granular node scaling and management
	- Introduced custom patch for scaling behavior

- **Improvements**
	- Upgraded Go build environment to version 1.23.4
	- Switched to latest Cluster Autoscaler image tag
	- Enhanced node scaling flexibility with new command-line arguments

- **Technical Updates**
	- Modified cluster autoscaler deployment configuration
	- Updated image references and build process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->