### PR TITLE
Fix version-map for updated application

### DIFF
--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -42,7 +42,7 @@ kubernetes 0.12.0 74649f8
 kubernetes 0.12.1 28fca4e
 kubernetes 0.13.0 ced8e5b9
 kubernetes 0.14.0 bfbde07c
-kubernetes 0.14.1 d14b66ce
+kubernetes 0.14.1 fde4bcfa
 kubernetes 0.15.0 HEAD
 mysql 0.1.0 f642698
 mysql 0.2.0 8b975ff0
@@ -66,7 +66,7 @@ postgres 0.5.0 c07c4bbd
 postgres 0.6.0 2a4768a
 postgres 0.6.2 54fd61c
 postgres 0.7.0 dc9d8bb
-postgres 0.7.1 620871a5
+postgres 0.7.1 175a65f
 postgres 0.8.0 HEAD
 rabbitmq 0.1.0 f642698
 rabbitmq 0.2.0 5ca8823
@@ -79,7 +79,7 @@ redis 0.1.1 f642698
 redis 0.2.0 5ca8823
 redis 0.3.0 c07c4bbd
 redis 0.3.1 b7375f73
-redis 0.4.0 b43c9586
+redis 0.4.0 abc8f082
 redis 0.5.0 HEAD
 tcp-balancer 0.1.0 f642698
 tcp-balancer 0.2.0 HEAD
@@ -105,11 +105,11 @@ virtual-machine 0.1.5 7cd7de7
 virtual-machine 0.2.0 5ca8823
 virtual-machine 0.3.0 b908400
 virtual-machine 0.4.0 4746d51
-virtual-machine 0.5.0 48128743
+virtual-machine 0.5.0 cad9cde
 virtual-machine 0.6.0 HEAD
 vm-disk 0.1.0 HEAD
 vm-instance 0.1.0 ced8e5b9
-vm-instance 0.2.0 175a65f8
+vm-instance 0.2.0 4f767ee3
 vm-instance 0.3.0 HEAD
 vpn 0.1.0 f642698
 vpn 0.2.0 7151424

--- a/packages/extra/versions_map
+++ b/packages/extra/versions_map
@@ -3,12 +3,12 @@ etcd 2.0.0 a6d0f7cf
 etcd 2.0.1 6fc1cc7d
 etcd 2.1.0 2b00fcf8
 etcd 2.2.0 5ca8823
-etcd 2.3.0 5ca88230
+etcd 2.3.0 b908400d
 etcd 2.4.0 HEAD
 ingress 1.0.0 f642698
 ingress 1.1.0 838bee5d
 ingress 1.2.0 ced8e5b
-ingress 1.3.0 ced8e5b9
+ingress 1.3.0 edbbb9be
 ingress 1.4.0 HEAD
 monitoring 1.0.0 f642698
 monitoring 1.1.0 15478a88
@@ -20,9 +20,9 @@ monitoring 1.5.0 4b90bf5a
 monitoring 1.5.1 57e90b70
 monitoring 1.5.2 898374b5
 monitoring 1.5.3 c1ca19dc
-monitoring 1.5.4 7a533787
+monitoring 1.5.4 d4634797
 monitoring 1.6.0 HEAD
 seaweedfs 0.1.0 5ca8823
 seaweedfs 0.2.0 9e33dc0
-seaweedfs 0.2.1 c2b6636f
+seaweedfs 0.2.1 249bf35
 seaweedfs 0.3.0 HEAD


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated version identifiers for multiple packages:
    - Kubernetes (0.14.1)
    - Postgres (0.7.1)
    - Redis (0.4.0)
    - Virtual Machine (0.5.0)
    - VM Instance (0.2.0)
    - ETCD (2.3.0)
    - Ingress (1.3.0)
    - Monitoring (1.5.4)
    - SeaweedFS (0.2.1)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->