### PR TITLE
Bugfix/fix deps

### DIFF
--- a/packages/core/platform/bundles/paas-full.yaml
+++ b/packages/core/platform/bundles/paas-full.yaml
@@ -89,7 +89,7 @@ releases:
   releaseName: victoria-metrics-operator
   chart: cozy-victoria-metrics-operator
   namespace: cozy-victoria-metrics-operator
-  dependsOn: [cilium,kubeovn,cert-manager]
+  dependsOn: [cert-manager]
 
 - name: monitoring-agents
   releaseName: monitoring-agents
@@ -102,7 +102,7 @@ releases:
   releaseName: kubevirt-operator
   chart: cozy-kubevirt-operator
   namespace: cozy-kubevirt
-  dependsOn: [cilium,kubeovn]
+  dependsOn: [victoria-metrics-operator]
 
 - name: kubevirt
   releaseName: kubevirt

--- a/packages/system/kubevirt-operator/alerts/PrometheusRule.yaml
+++ b/packages/system/kubevirt-operator/alerts/PrometheusRule.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: vm-not-running-alert
-  namespace: monitoring
 spec:
   groups:
   - name: kubevirt-alerts


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Modified dependency relationships for `victoria-metrics-operator` and `kubevirt-operator`
	- Simplified dependencies for both operators

- **Monitoring Configuration**
	- Removed namespace specification from PrometheusRule alert definition
	- Existing VM and VMI monitoring alerts remain unchanged

<!-- end of auto-generated comment: release notes by coderabbit.ai -->