### PR TITLE
Update fluxcd-operator to 0.13.0

### DIFF
--- a/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.12.0
+appVersion: v0.13.0
 description: 'A Helm chart for deploying the Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.12.0
+version: 0.13.0

--- a/packages/system/fluxcd-operator/charts/flux-operator/README.md
+++ b/packages/system/fluxcd-operator/charts/flux-operator/README.md
@@ -1,6 +1,6 @@
 # flux-operator
 
-![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.0](https://img.shields.io/badge/AppVersion-v0.12.0-informational?style=flat-square)
+![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.13.0](https://img.shields.io/badge/AppVersion-v0.13.0-informational?style=flat-square)
 
 The [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator) provides a
 declarative API for the installation and upgrade of CNCF [Flux](https://fluxcd.io) and the

--- a/packages/system/fluxcd/charts/flux-instance/Chart.yaml
+++ b/packages/system/fluxcd/charts/flux-instance/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.12.0
+appVersion: v0.13.0
 description: 'A Helm chart for deploying a Flux instance managed by Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.12.0
+version: 0.13.0

--- a/packages/system/fluxcd/charts/flux-instance/README.md
+++ b/packages/system/fluxcd/charts/flux-instance/README.md
@@ -1,6 +1,6 @@
 # flux-instance
 
-![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.0](https://img.shields.io/badge/AppVersion-v0.12.0-informational?style=flat-square)
+![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.13.0](https://img.shields.io/badge/AppVersion-v0.13.0-informational?style=flat-square)
 
 This chart is a thin wrapper around the `FluxInstance` custom resource, which is
 used by the [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator)
@@ -38,12 +38,13 @@ helm -n flux-system uninstall flux
 | commonLabels | object | `{}` | Common labels to add to all deployed objects including pods. |
 | fullnameOverride | string | `"flux"` |  |
 | instance.cluster | object | `{"domain":"cluster.local","multitenant":false,"networkPolicy":true,"tenantDefaultServiceAccount":"default","type":"kubernetes"}` | Cluster https://fluxcd.control-plane.io/operator/fluxinstance/#cluster-configuration |
+| instance.commonMetadata | object | `{"annotations":{},"labels":{}}` | Common metadata https://fluxcd.control-plane.io/operator/fluxinstance/#common-metadata |
 | instance.components | list | `["source-controller","kustomize-controller","helm-controller","notification-controller"]` | Components https://fluxcd.control-plane.io/operator/fluxinstance/#components-configuration |
 | instance.distribution | object | `{"artifact":"oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest","imagePullSecret":"","registry":"ghcr.io/fluxcd","version":"2.x"}` | Distribution https://fluxcd.control-plane.io/operator/fluxinstance/#distribution-configuration |
 | instance.kustomize.patches | list | `[]` | Kustomize patches https://fluxcd.control-plane.io/operator/fluxinstance/#kustomize-patches |
 | instance.sharding | object | `{"key":"sharding.fluxcd.io/key","shards":[]}` | Sharding https://fluxcd.control-plane.io/operator/fluxinstance/#sharding-configuration |
 | instance.storage | object | `{"class":"","size":""}` | Storage https://fluxcd.control-plane.io/operator/fluxinstance/#storage-configuration |
-| instance.sync | object | `{"kind":"GitRepository","path":"","pullSecret":"","ref":"","url":""}` | Sync https://fluxcd.control-plane.io/operator/fluxinstance/#sync-configuration |
+| instance.sync | object | `{"kind":"GitRepository","name":"","path":"","pullSecret":"","ref":"","url":""}` | Sync https://fluxcd.control-plane.io/operator/fluxinstance/#sync-configuration |
 | nameOverride | string | `""` |  |
 
 ## Source Code

--- a/packages/system/fluxcd/charts/flux-instance/templates/instance.yaml
+++ b/packages/system/fluxcd/charts/flux-instance/templates/instance.yaml
@@ -22,6 +22,17 @@ spec:
     {{- end }}
   components: {{ .Values.instance.components | toYaml | nindent 4 }}
   cluster: {{ .Values.instance.cluster | toYaml | nindent 4 }}
+  {{- if or .Values.instance.commonMetadata.annotations  .Values.instance.commonMetadata.labels }}
+  commonMetadata:
+    {{- with .Values.instance.commonMetadata.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.instance.commonMetadata.labels }}
+    labels:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
   kustomize: {{ .Values.instance.kustomize | toYaml | nindent 4 }}
   {{- if .Values.instance.sync.url }}
   sync:
@@ -29,6 +40,9 @@ spec:
     url: {{ .Values.instance.sync.url }}
     ref: {{ .Values.instance.sync.ref }}
     path: {{ .Values.instance.sync.path }}
+    {{- if .Values.instance.sync.name }}
+    name: {{ .Values.instance.sync.name }}
+    {{- end }}
     {{- if .Values.instance.sync.pullSecret }}
     pullSecret: {{ .Values.instance.sync.pullSecret }}
     {{- end }}

--- a/packages/system/fluxcd/charts/flux-instance/values.schema.json
+++ b/packages/system/fluxcd/charts/flux-instance/values.schema.json
@@ -41,6 +41,19 @@
                     },
                     "type": "object"
                 },
+                "commonMetadata": {
+                    "properties": {
+                        "annotations": {
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "labels": {
+                            "properties": {},
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
                 "components": {
                     "items": {
                         "enum": [
@@ -121,6 +134,9 @@
                                 "OCIRepository",
                                 "Bucket"
                             ],
+                            "type": "string"
+                        },
+                        "name": {
                             "type": "string"
                         },
                         "path": {

--- a/packages/system/fluxcd/charts/flux-instance/values.yaml
+++ b/packages/system/fluxcd/charts/flux-instance/values.yaml
@@ -23,6 +23,10 @@ instance:
     networkPolicy: true
     multitenant: false
     tenantDefaultServiceAccount: "default"
+  # -- Common metadata https://fluxcd.control-plane.io/operator/fluxinstance/#common-metadata
+  commonMetadata: # @schema required: false
+    labels: { }
+    annotations: { }
   # -- Storage https://fluxcd.control-plane.io/operator/fluxinstance/#storage-configuration
   storage: # @schema required: false
     class: ""
@@ -38,6 +42,7 @@ instance:
     ref: ""
     path: ""
     pullSecret: ""
+    name: ""
   kustomize: # @schema required: false
     # -- Kustomize patches https://fluxcd.control-plane.io/operator/fluxinstance/#kustomize-patches
     patches: [] # @schema item: object


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for common metadata (annotations and labels) in Flux instance configuration
  - Introduced a `name` field for sync configuration in Flux instance

- **Version Updates**
  - Upgraded Flux Operator chart from v0.12.0 to v0.13.0
  - Upgraded Flux Instance chart from v0.12.0 to v0.13.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->