### PR TITLE
Bugfix/fix kk configure reconciliation

### DIFF
--- a/packages/core/platform/bundles/paas-full.yaml
+++ b/packages/core/platform/bundles/paas-full.yaml
@@ -299,4 +299,7 @@ releases:
   chart: cozy-keycloak-configure
   namespace: cozy-keycloak
   dependsOn: [keycloak-operator]
+  values:
+    cozyValues: |
+      {{ (lookup "v1" "ConfigMap" "cozy-system" "cozystack").data | toJson | sha256sum }}
 {{- end }}

--- a/packages/core/platform/bundles/paas-full.yaml
+++ b/packages/core/platform/bundles/paas-full.yaml
@@ -300,6 +300,6 @@ releases:
   namespace: cozy-keycloak
   dependsOn: [keycloak-operator]
   values:
-    cozyValues: |
-      {{ (lookup "v1" "ConfigMap" "cozy-system" "cozystack").data | toJson | sha256sum }}
+    cozystack:
+      configHash: {{ $cozyConfig | toJson | sha256sum }}
 {{- end }}

--- a/packages/core/platform/bundles/paas-hosted.yaml
+++ b/packages/core/platform/bundles/paas-hosted.yaml
@@ -195,4 +195,7 @@ releases:
   chart: cozy-keycloak-configure
   namespace: cozy-keycloak
   dependsOn: [keycloak-operator]
+  values:
+    cozyValues: |
+      {{ (lookup "v1" "ConfigMap" "cozy-system" "cozystack").data | toJson | sha256sum }}
 {{- end }}

--- a/packages/core/platform/bundles/paas-hosted.yaml
+++ b/packages/core/platform/bundles/paas-hosted.yaml
@@ -196,6 +196,6 @@ releases:
   namespace: cozy-keycloak
   dependsOn: [keycloak-operator]
   values:
-    cozyValues: |
-      {{ (lookup "v1" "ConfigMap" "cozy-system" "cozystack").data | toJson | sha256sum }}
+    cozystack:
+      configHash: {{ $cozyConfig | toJson | sha256sum }}
 {{- end }}

--- a/packages/system/kubevirt-operator/alerts/PrometheusRule.yaml
+++ b/packages/system/kubevirt-operator/alerts/PrometheusRule.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: vm-not-running-alert
-  namespace: monitoring
 spec:
   groups:
   - name: kubevirt-alerts


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration Update**
	- Added a new `configHash` field in the `keycloak-configure` release for both `paas-full` and `paas-hosted` configurations.
	- Introduced a SHA256 checksum mechanism for the `cozyConfig` data to enhance configuration integrity checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->