### PR TITLE
Prepare release v0.23.1

### DIFF
--- a/manifests/cozystack-installer.yaml
+++ b/manifests/cozystack-installer.yaml
@@ -68,7 +68,7 @@ spec:
       serviceAccountName: cozystack
       containers:
       - name: cozystack
-        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.23.0"
+        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.23.1"
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: localhost
@@ -87,7 +87,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
       - name: darkhttpd
-        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.23.0"
+        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.23.1"
         command:
         - /usr/bin/darkhttpd
         - /cozystack/assets

--- a/packages/apps/clickhouse/images/clickhouse-backup.tag
+++ b/packages/apps/clickhouse/images/clickhouse-backup.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/clickhouse-backup:0.6.1@sha256:15d251c98b03b76ccbbd0f83d12303f766955f43494821847636cee448948105
+ghcr.io/aenix-io/cozystack/clickhouse-backup:0.6.1@sha256:7a99cabdfd541f863aa5d1b2f7b49afd39838fb94c8448986634a1dc9050751c

--- a/packages/apps/ferretdb/images/postgres-backup.tag
+++ b/packages/apps/ferretdb/images/postgres-backup.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/postgres-backup:0.8.0@sha256:b140bcdbc2f3aec6d59f82ba8504a950a922e4b554f887ae1dd352dcb9429349
+ghcr.io/aenix-io/cozystack/postgres-backup:0.8.0@sha256:6a8ec7e7052f2d02ec5457d7cbac6ee52b3ed93a883988a192d1394fc7c88117

--- a/packages/apps/http-cache/images/nginx-cache.tag
+++ b/packages/apps/http-cache/images/nginx-cache.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/nginx-cache:0.3.1@sha256:8b445b038ef806a47d8a499b62559a7a329ee832b0c9044a10334991ae793d3c
+ghcr.io/aenix-io/cozystack/nginx-cache:0.3.1@sha256:a3c25199acb8e8426e6952658ccc4acaadb50fe2cfa6359743b64e5166b3fc70

--- a/packages/apps/kubernetes/images/cluster-autoscaler.tag
+++ b/packages/apps/kubernetes/images/cluster-autoscaler.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/cluster-autoscaler:0.15.0@sha256:3d7fb956c81b8c4abe20dd1b5991aa80febe1a5af0629bf730c00d43f3c5d7a0
+ghcr.io/aenix-io/cozystack/cluster-autoscaler:0.15.0@sha256:538ee308f16c9e627ed16ee7c4aaa65919c2e6c4c2778f964a06e4797610d1cd

--- a/packages/apps/kubernetes/images/kubevirt-cloud-provider.tag
+++ b/packages/apps/kubernetes/images/kubevirt-cloud-provider.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/kubevirt-cloud-provider:0.15.0@sha256:60c4a664f8273cbbe0d11828aa0625952e12afe5ed2999b3b49bff0efae6aaec
+ghcr.io/aenix-io/cozystack/kubevirt-cloud-provider:0.15.0@sha256:7716c88947d13dc90ccfcc3e60bfdd6e6fa9b201339a75e9c84bf825c76e2b1f

--- a/packages/apps/kubernetes/images/kubevirt-csi-driver.tag
+++ b/packages/apps/kubernetes/images/kubevirt-csi-driver.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/kubevirt-csi-driver:0.15.0@sha256:9557be53700fdbcf91aeca9945991a5d8c7d172274053de435db1f301b38a59c
+ghcr.io/aenix-io/cozystack/kubevirt-csi-driver:0.15.0@sha256:be5e0eef92dada3ace5cddda5c68b30c9fe4682774c5e6e938ed31efba11ebbf

--- a/packages/apps/kubernetes/images/ubuntu-container-disk.tag
+++ b/packages/apps/kubernetes/images/ubuntu-container-disk.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/ubuntu-container-disk:v1.30.1@sha256:e9050d88066d890ba05edc172416c1151921a6b891f9fdc6daf7184ee46c4097
+ghcr.io/aenix-io/cozystack/ubuntu-container-disk:v1.30.1@sha256:8392f00a7182294ce6fd417d254f7c2aa09fb9203d829dec70344a8050369430

--- a/packages/apps/mysql/images/mariadb-backup.tag
+++ b/packages/apps/mysql/images/mariadb-backup.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/mariadb-backup:0.5.2@sha256:fdf9b53b5e304b80a72806543f3421fbd3efdfda288182887930284cf50532d0
+ghcr.io/aenix-io/cozystack/mariadb-backup:0.5.2@sha256:4bbfbb397bd7ecea45507ca47989c51429c4a24f40853ac92583e5b5b352fbea

--- a/packages/apps/postgres/images/postgres-backup.tag
+++ b/packages/apps/postgres/images/postgres-backup.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/postgres-backup:0.8.0@sha256:b140bcdbc2f3aec6d59f82ba8504a950a922e4b554f887ae1dd352dcb9429349
+ghcr.io/aenix-io/cozystack/postgres-backup:0.8.0@sha256:6a8ec7e7052f2d02ec5457d7cbac6ee52b3ed93a883988a192d1394fc7c88117

--- a/packages/core/installer/values.yaml
+++ b/packages/core/installer/values.yaml
@@ -1,2 +1,2 @@
 cozystack:
-  image: ghcr.io/aenix-io/cozystack/cozystack:v0.23.0@sha256:ef1742e666f398d777a45cd65af1058e15338ca8c7ebc37c4030e0bc3cb581bf
+  image: ghcr.io/aenix-io/cozystack/cozystack:v0.23.1@sha256:dfa803a3e02ec9ea221029d361aa9d7aef0b5eb0a36d66c949b265d4ac4fc114

--- a/packages/core/testing/values.yaml
+++ b/packages/core/testing/values.yaml
@@ -1,2 +1,2 @@
 e2e:
-  image: ghcr.io/aenix-io/cozystack/e2e-sandbox:v0.23.0@sha256:38229517c86e179984a6d39f5510b859d13d965e35b216bc01ce456f9ab5f8b5
+  image: ghcr.io/aenix-io/cozystack/e2e-sandbox:v0.23.1@sha256:0f4ffa7f23d6cdc633c0c4a0b852fde9710edbce96486fd9bd29c7d0d7710380

--- a/packages/system/bucket/images/s3manager.tag
+++ b/packages/system/bucket/images/s3manager.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/s3manager:v0.5.0@sha256:badeda0c29bbf49bede8235cf05eb09d2738779fbe0c2054e06f31c2a108bbea
+ghcr.io/aenix-io/cozystack/s3manager:v0.5.0@sha256:35e9a8ba7e1a3b0cee634f6d2bd92d2b08c47c7ed3316559c9ea25ff733eb5d5

--- a/packages/system/cilium/values.yaml
+++ b/packages/system/cilium/values.yaml
@@ -13,6 +13,6 @@ cilium:
   image:
     repository: ghcr.io/aenix-io/cozystack/cilium
     tag: 1.16.5
-    digest: "sha256:22193eb07f7245fcac138a2c09bf44eeb9f1ae3657b69a3acce126ea630bb3b4"
+    digest: "sha256:eae9d5531c115f8946990a731bfaaebc905b020a2957559b3c9f2ce1c655a834"
   envoy:
     enabled: false

--- a/packages/system/cozystack-api/values.yaml
+++ b/packages/system/cozystack-api/values.yaml
@@ -1,2 +1,2 @@
 cozystackAPI:
-  image: ghcr.io/aenix-io/cozystack/cozystack-api:v0.23.0@sha256:169997a723c99e65da34232fb93e15c1d8645a1a779f5cbec08a6a231d660caf
+  image: ghcr.io/aenix-io/cozystack/cozystack-api:v0.23.1@sha256:b25faba99a8b98c1d3576b47986266c4f391c1998d89b599e9139f43727c5b4c

--- a/packages/system/cozystack-controller/values.yaml
+++ b/packages/system/cozystack-controller/values.yaml
@@ -1,5 +1,5 @@
 cozystackController:
-  image: ghcr.io/aenix-io/cozystack/cozystack-controller:v0.23.0@sha256:6aeef6b8f6ea4be987b7a5f5ad422604a4dd8bba95c758d4b4b3366948f80458
+  image: ghcr.io/aenix-io/cozystack/cozystack-controller:v0.23.1@sha256:ca7801e33fbd38e01b3abe9645956bb235ba7b0f2381bd622d18d4dc5e280020
   debug: false
   disableTelemetry: false
-  cozystackVersion: "v0.23.0"
+  cozystackVersion: "v0.23.1"

--- a/packages/system/dashboard/charts/kubeapps/templates/dashboard/configmap.yaml
+++ b/packages/system/dashboard/charts/kubeapps/templates/dashboard/configmap.yaml
@@ -76,7 +76,7 @@ data:
       "kubeappsNamespace": {{ .Release.Namespace | quote }},
       "helmGlobalNamespace": {{ include "kubeapps.helmGlobalPackagingNamespace" . | quote }},
       "carvelGlobalNamespace": {{ .Values.kubeappsapis.pluginConfig.kappController.packages.v1alpha1.globalPackagingNamespace | quote }},
-      "appVersion": "v0.23.0",
+      "appVersion": "v0.23.1",
       "authProxyEnabled": {{ .Values.authProxy.enabled }},
       "oauthLoginURI": {{ .Values.authProxy.oauthLoginURI | quote }},
       "oauthLogoutURI": {{ .Values.authProxy.oauthLogoutURI | quote }},

--- a/packages/system/dashboard/values.yaml
+++ b/packages/system/dashboard/values.yaml
@@ -40,14 +40,14 @@ kubeapps:
     image:
       registry: ghcr.io/aenix-io/cozystack
       repository: dashboard
-      tag: v0.23.0
-      digest: "sha256:cdf9d93a9733ce6f59d467a03a34bb66177eb4b42715fcf81f84705b150d9dad"
+      tag: v0.23.1
+      digest: "sha256:81e7b625c667bce5fc339eb97c8e115eafb82f66df4501550b3677ac53f6e234"
   kubeappsapis:
     image:
       registry: ghcr.io/aenix-io/cozystack
       repository: kubeapps-apis
-      tag: v0.23.0
-      digest: "sha256:05e81aa24c1616122c0a812aaf1a49f98b7d256334922c601dbdbfb6436c065c"
+      tag: v0.23.1
+      digest: "sha256:d3767354cf6c785447f30e87bb2017ec45843edfc02635f526d2ecacc82f5d26"
     pluginConfig:
       flux:
         packages:

--- a/packages/system/kamaji/values.yaml
+++ b/packages/system/kamaji/values.yaml
@@ -3,7 +3,7 @@ kamaji:
     deploy: false
   image:
     pullPolicy: IfNotPresent
-    tag: v0.23.0@sha256:af61eae4a6a718cc79bc20f9606218858a541fc95d6dfafe876c4694987e1194
+    tag: v0.23.1@sha256:87166056685e4dab9de030ad9389ce58f0d96e7f6c191674fe93483fbe99490f
     repository: ghcr.io/aenix-io/cozystack/kamaji
   resources:
     limits:

--- a/packages/system/kubeovn/values.yaml
+++ b/packages/system/kubeovn/values.yaml
@@ -22,4 +22,4 @@ global:
   images:
     kubeovn:
       repository: kubeovn
-      tag: v1.13.2@sha256:9d584f604eb645105e531d531b253c3550e222457e2b679f72068b0aeef51ff7
+      tag: v1.13.2@sha256:ee658a003cd77a1f7b9df1d108255a8b5a69e67dd59fa6a6161c869b00207d4f


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Image Updates**
    - Updated Cozystack installer to version v0.23.1
    - Updated multiple application images with new digests, including:
        - ClickHouse backup
        - Postgres backup
        - Nginx cache
        - Cluster autoscaler
        - KubeVirt components
        - S3 manager
        - Dashboard
        - Kamaji
        - KubeOVN

- **Version Bumps**
    - Incremented Cozystack core components to v0.23.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->