### PR TITLE
Replace darkhttpd with cozystack-assets-server

### DIFF
--- a/cmd/cozystack-assets-server/main.go
+++ b/cmd/cozystack-assets-server/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"path/filepath"
+)
+
+func main() {
+	addr := flag.String("address", ":8123", "Address to listen on")
+	dir := flag.String("dir", "/cozystack/assets", "Directory to serve files from")
+	flag.Parse()
+
+	absDir, err := filepath.Abs(*dir)
+	if err != nil {
+		log.Fatalf("Error getting absolute path for %s: %v", *dir, err)
+	}
+
+	fs := http.FileServer(http.Dir(absDir))
+	http.Handle("/", fs)
+
+	log.Printf("Server starting on %s, serving directory %s", *addr, absDir)
+
+	err = http.ListenAndServe(*addr, nil)
+	if err != nil {
+		log.Fatalf("Server failed to start: %v", err)
+	}
+}

--- a/packages/core/installer/images/cozystack/Dockerfile
+++ b/packages/core/installer/images/cozystack/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine3.19 as k8s-await-election-builder
+FROM golang:alpine3.21 as k8s-await-election-builder
 
 ARG K8S_AWAIT_ELECTION_GITREPO=https://github.com/LINBIT/k8s-await-election
 ARG K8S_AWAIT_ELECTION_VERSION=0.4.1
@@ -13,7 +13,7 @@ RUN git clone ${K8S_AWAIT_ELECTION_GITREPO} /usr/local/go/k8s-await-election/ \
  && make \
  && mv ./out/k8s-await-election-${TARGETARCH} /k8s-await-election
 
-FROM alpine:3.19 AS builder
+FROM golang:alpine3.21 as builder
 
 RUN apk add --no-cache make git
 RUN apk add helm --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
@@ -21,12 +21,14 @@ RUN apk add helm --repository=https://dl-cdn.alpinelinux.org/alpine/edge/communi
 COPY . /src/
 WORKDIR /src
 
+RUN go build -o /cozystack-assets-server -ldflags '-extldflags "-static" -w -s' ./cmd/cozystack-assets-server
+
 # Check that versions_map is not changed
 RUN make repos
 
-FROM alpine:3.19
+FROM alpine:3.21
 
-RUN apk add --no-cache make darkhttpd
+RUN apk add --no-cache make
 RUN apk add helm kubectl --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
 
 COPY scripts /cozystack/scripts
@@ -34,6 +36,7 @@ COPY --from=builder /src/packages/core /cozystack/packages/core
 COPY --from=builder /src/packages/system /cozystack/packages/system
 COPY --from=builder /src/_out/repos /cozystack/assets/repos
 COPY --from=builder /src/_out/logos /cozystack/assets/logos
+COPY --from=builder /cozystack-assets-server /usr/bin/cozystack-assets-server
 COPY --from=k8s-await-election-builder /k8s-await-election /usr/bin/k8s-await-election
 COPY dashboards /cozystack/assets/dashboards
 

--- a/packages/core/installer/templates/cozystack.yaml
+++ b/packages/core/installer/templates/cozystack.yaml
@@ -67,13 +67,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-      - name: darkhttpd
+      - name: assets
         image: "{{ .Values.cozystack.image }}"
         command:
-        - /usr/bin/darkhttpd
-        - /cozystack/assets
-        - --port
-        - "8123"
+        - /usr/bin/cozystack-assets-server
+        - "-dir=/cozystack/assets"
+        - "-address=:8123"
         ports:
         - name: http
           containerPort: 8123


### PR DESCRIPTION
fixes https://github.com/aenix-io/cozystack/issues/602
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new custom assets server for serving static files
	- Replaced `darkhttpd` with a custom Go-based file server

- **Improvements**
	- Updated base images to Alpine Linux 3.21
	- Simplified container dependencies
	- Enhanced server configuration with command-line flags

- **Infrastructure**
	- Rebuilt Kubernetes deployment configuration for assets service
	- Updated server startup parameters and container settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->