### PR TITLE
Fix vm-update hook access to api

### DIFF
--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -108,12 +108,14 @@ virtual-machine 0.3.0 b908400
 virtual-machine 0.4.0 4746d51
 virtual-machine 0.5.0 cad9cde
 virtual-machine 0.6.0 0e728870
-virtual-machine 0.7.0 HEAD
+virtual-machine 0.7.0 af58018a
+virtual-machine 0.7.1 HEAD
 vm-disk 0.1.0 HEAD
 vm-instance 0.1.0 ced8e5b9
 vm-instance 0.2.0 4f767ee3
 vm-instance 0.3.0 0e728870
-vm-instance 0.4.0 HEAD
+vm-instance 0.4.0 af58018a
+vm-instance 0.4.1 HEAD
 vpn 0.1.0 f642698
 vpn 0.2.0 7151424
 vpn 0.3.0 a2bcf100

--- a/packages/apps/virtual-machine/Chart.yaml
+++ b/packages/apps/virtual-machine/Chart.yaml
@@ -17,10 +17,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.7.0"
+appVersion: "0.7.1"

--- a/packages/apps/virtual-machine/templates/vm-update-hook.yaml
+++ b/packages/apps/virtual-machine/templates/vm-update-hook.yaml
@@ -45,6 +45,7 @@ spec:
     metadata:
       labels:
         app: "{{ $.Release.Name }}-update-hook"
+        policy.cozystack.io/allow-to-apiserver: "true"
     spec:
       serviceAccountName: {{ $.Release.Name }}-update-hook
       restartPolicy: Never

--- a/packages/apps/vm-instance/Chart.yaml
+++ b/packages/apps/vm-instance/Chart.yaml
@@ -17,10 +17,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.0"
+appVersion: "0.4.1"

--- a/packages/apps/vm-instance/templates/vm-update-hook.yaml
+++ b/packages/apps/vm-instance/templates/vm-update-hook.yaml
@@ -35,6 +35,7 @@ spec:
     metadata:
       labels:
         app: "{{ $.Release.Name }}-update-hook"
+        policy.cozystack.io/allow-to-apiserver: "true"
     spec:
       serviceAccountName: {{ $.Release.Name }}-update-hook
       restartPolicy: Never


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Updates**
	- Updated `virtual-machine` package version from `0.7.0` to `0.7.1`
	- Updated `vm-instance` package version from `0.4.0` to `0.4.1`

- **Configuration Changes**
	- Added new policy annotation `policy.cozystack.io/allow-to-apiserver: "true"` to update hook templates for both virtual machine and VM instance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->