### PR TITLE
Fix kamaji make update

### DIFF
--- a/packages/system/kamaji/Makefile
+++ b/packages/system/kamaji/Makefile
@@ -9,7 +9,7 @@ update:
 	tag=$$(git ls-remote --tags --sort="v:refname" https://github.com/clastix/kamaji | grep refs/tags/edge- | awk -F'[/^]' 'END{print $$3}') && \
 	curl -sSL https://github.com/clastix/kamaji/archive/refs/tags/$${tag}.tar.gz | \
 	tar -xzvf - --strip 1 kamaji-$${tag}/charts && \
-	sed -i "/^FROM clastix/ s|:.*|:$${tag}|g" images/kamaji/Dockerfile
+	sed -i "/ARG VERSION/ s|=.*|=$${tag}|g" images/kamaji/Dockerfile
 
 image:
 	docker buildx build images/kamaji \

--- a/packages/system/kamaji/charts/kamaji/Chart.lock
+++ b/packages/system/kamaji/charts/kamaji/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kamaji-etcd
   repository: https://clastix.github.io/charts
-  version: 0.8.0
-digest: sha256:525b0eb2b5bae709d62de9328312d42c54b5219c6df67061de0da79eeca04fb3
-generated: "2024-08-25T08:44:24.92211307+02:00"
+  version: 0.8.1
+digest: sha256:381d8ef9619c2daeea37e40c6a9772ae3e5cee80887148879db04e887d5364ad
+generated: "2024-10-25T19:28:40.880766186+02:00"

--- a/packages/system/kamaji/charts/kamaji/Chart.yaml
+++ b/packages/system/kamaji/charts/kamaji/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.0.0
+appVersion: v0.0.0
 description: Kamaji is the Hosted Control Plane Manager for Kubernetes.
 home: https://github.com/clastix/kamaji
 icon: https://github.com/clastix/kamaji/raw/master/assets/logo-colored.png
@@ -17,11 +17,11 @@ name: kamaji
 sources:
 - https://github.com/clastix/kamaji
 type: application
-version: 2.0.0
+version: 0.0.0
 dependencies:
 - name: kamaji-etcd
   repository: https://clastix.github.io/charts
-  version: ">=0.7.0"
+  version: ">=0.8.1"
   condition: kamaji-etcd.deploy
 annotations:
   catalog.cattle.io/certified: partner

--- a/packages/system/kamaji/charts/kamaji/README.md
+++ b/packages/system/kamaji/charts/kamaji/README.md
@@ -1,6 +1,6 @@
 # kamaji
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.0](https://img.shields.io/badge/AppVersion-v0.0.0-informational?style=flat-square)
 
 Kamaji is the Hosted Control Plane Manager for Kubernetes.
 
@@ -22,7 +22,7 @@ Kubernetes: `>=1.21.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://clastix.github.io/charts | kamaji-etcd | >=0.7.0 |
+| https://clastix.github.io/charts | kamaji-etcd | >=0.8.1 |
 
 [Kamaji](https://github.com/clastix/kamaji) requires a [multi-tenant `etcd`](https://github.com/clastix/kamaji-internal/blob/master/deploy/getting-started-with-kamaji.md#setup-internal-multi-tenant-etcd) cluster.
 This Helm Chart starting from v0.1.1 provides the installation of an internal `etcd` in order to streamline the local test. If you'd like to use an externally managed etcd instance, you can specify the overrides and by setting the value `etcd.deploy=false`.
@@ -70,7 +70,7 @@ Here the values you can override:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Kubernetes affinity rules to apply to Kamaji controller pods |
-| defaultDatastoreName | string | `"default"` | Specify the default DataStore name for the Kamaji instance. |
+| defaultDatastoreName | string | `"default"` | If specified, all the Kamaji instances with an unassigned DataStore will inherit this default value. |
 | extraArgs | list | `[]` | A list of extra arguments to add to the kamaji controller default ones |
 | fullnameOverride | string | `""` |  |
 | healthProbeBindAddress | string | `":8081"` | The address the probe endpoint binds to. (default ":8081") |

--- a/packages/system/kamaji/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/packages/system/kamaji/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -66,7 +66,6 @@ spec:
             metadata:
               type: object
             spec:
-              description: TenantControlPlaneSpec defines the desired state of TenantControlPlane.
               properties:
                 addons:
                   description: Addons contain which addons are enabled
@@ -6413,10 +6412,23 @@ spec:
                   type: object
                 dataStore:
                   description: |-
-                    DataStore allows to specify a DataStore that should be used to store the Kubernetes data for the given Tenant Control Plane.
-                    This parameter is optional and acts as an override over the default one which is used by the Kamaji Operator.
-                    Migration from a different DataStore to another one is not yet supported and the reconciliation will be blocked.
+                    DataStore specifies the DataStore that should be used to store the Kubernetes data for the given Tenant Control Plane.
+                    When Kamaji runs with the default DataStore flag, all empty values will inherit the default value.
+                    By leaving it empty and running Kamaji with no default DataStore flag, it is possible to achieve automatic assignment to a specific DataStore object.
+
+                    Migration from one DataStore to another backed by the same Driver is possible. See: https://kamaji.clastix.io/guides/datastore-migration/
+                    Migration from one DataStore to another backed by a different Driver is not supported.
                   type: string
+                dataStoreSchema:
+                  description: |-
+                    DataStoreSchema allows to specify the name of the database (for relational DataStores) or the key prefix (for etcd). This
+                    value is optional and immutable. Note that Kamaji currently doesn't ensure that DataStoreSchema values are unique. It's up
+                    to the user to avoid clashes between different TenantControlPlanes. If not set upon creation, Kamaji will default the
+                    DataStoreSchema by concatenating the namespace and name of the TenantControlPlane.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: changing the dataStoreSchema is not supported
+                      rule: self == oldSelf
                 kubernetes:
                   description: Kubernetes specification for tenant control plane
                   properties:
@@ -6539,15 +6551,47 @@ spec:
                       items:
                         type: string
                       type: array
+                    clusterDomain:
+                      default: cluster.local
+                      description: The default domain name used for DNS resolution within the cluster.
+                      pattern: .*\..*
+                      type: string
+                      x-kubernetes-validations:
+                        - message: changing the cluster domain is not supported
+                          rule: self == oldSelf
                     dnsServiceIPs:
-                      default:
-                        - 10.96.0.10
+                      description: |-
+                        The DNS Service for internal resolution, it must match the Service CIDR.
+                        In case of an empty value, it is automatically computed according to the Service CIDR, e.g.:
+                        Service CIDR 10.96.0.0/16, the resulting DNS Service IP will be 10.96.0.10 for IPv4,
+                        for IPv6 from the CIDR 2001:db8:abcd::/64 the resulting DNS Service IP will be 2001:db8:abcd::10.
+                      items:
+                        type: string
+                      type: array
+                    loadBalancerClass:
+                      description: |-
+                        Specify the LoadBalancer class in case of multiple load balancer implementations.
+                        Field supported only for Tenant Control Plane instances exposed using a LoadBalancer Service.
+                      minLength: 1
+                      type: string
+                      x-kubernetes-validations:
+                        - message: LoadBalancerClass is immutable
+                          rule: self == oldSelf
+                    loadBalancerSourceRanges:
+                      description: |-
+                        LoadBalancerSourceRanges restricts the IP ranges that can access
+                        the LoadBalancer type Service. This field defines a list of IP
+                        address ranges (in CIDR format) that are allowed to access the service.
+                        If left empty, the service will allow traffic from all IP ranges (0.0.0.0/0).
+                        This feature is useful for restricting access to API servers or services
+                        to specific networks for security purposes.
+                        Example: {"192.168.1.0/24", "10.0.0.0/8"}
                       items:
                         type: string
                       type: array
                     podCidr:
                       default: 10.244.0.0/16
-                      description: CIDR for Kubernetes Pods
+                      description: 'CIDR for Kubernetes Pods: if empty, defaulted to 10.244.0.0/16.'
                       type: string
                     port:
                       default: 6443
@@ -6556,13 +6600,24 @@ spec:
                       type: integer
                     serviceCidr:
                       default: 10.96.0.0/16
-                      description: Kubernetes Service
+                      description: 'CIDR for Kubernetes Services: if empty, defaulted to 10.96.0.0/16.'
                       type: string
                   type: object
               required:
                 - controlPlane
                 - kubernetes
               type: object
+              x-kubernetes-validations:
+                - message: unsetting the dataStore is not supported
+                  rule: '!has(oldSelf.dataStore) || has(self.dataStore)'
+                - message: unsetting the dataStoreSchema is not supported
+                  rule: '!has(oldSelf.dataStoreSchema) || has(self.dataStoreSchema)'
+                - message: LoadBalancer source ranges are supported only with LoadBalancer service type
+                  rule: '!has(self.networkProfile.loadBalancerSourceRanges) || (size(self.networkProfile.loadBalancerSourceRanges) == 0 || self.controlPlane.service.serviceType == ''LoadBalancer'')'
+                - message: LoadBalancerClass is supported only with LoadBalancer service type
+                  rule: '!has(self.networkProfile.loadBalancerClass) || self.controlPlane.service.serviceType == ''LoadBalancer'''
+                - message: LoadBalancerClass cannot be set or unset at runtime
+                  rule: self.controlPlane.service.serviceType != 'LoadBalancer' || (oldSelf.controlPlane.service.serviceType != 'LoadBalancer' && self.controlPlane.service.serviceType == 'LoadBalancer') || has(self.networkProfile.loadBalancerClass) == has(oldSelf.networkProfile.loadBalancerClass)
             status:
               description: TenantControlPlaneStatus defines the observed state of TenantControlPlane.
               properties:

--- a/packages/system/kamaji/charts/kamaji/templates/controller.yaml
+++ b/packages/system/kamaji/charts/kamaji/templates/controller.yaml
@@ -33,8 +33,9 @@ spec:
         - --leader-elect
         - --metrics-bind-address={{ .Values.metricsBindAddress }}
         - --tmp-directory={{ .Values.temporaryDirectoryPath }}
-        {{- $datastoreName := .Values.defaultDatastoreName | required ".Values.defaultDatastoreName is required!" }}
-        - --datastore={{ $datastoreName }}
+        {{- if not (eq .Values.defaultDatastoreName "") }}
+        - --datastore={{ .Values.defaultDatastoreName }}
+        {{- end }}
         {{- if .Values.telemetry.disabled }}
         - --disable-telemetry
         {{- end }}

--- a/packages/system/kamaji/charts/kamaji/values.yaml
+++ b/packages/system/kamaji/charts/kamaji/values.yaml
@@ -95,7 +95,7 @@ loggingDevel:
   # -- Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error) (default false)
   enable: false
 
-# -- Specify the default DataStore name for the Kamaji instance.
+# -- If specified, all the Kamaji instances with an unassigned DataStore will inherit this default value.
 defaultDatastoreName: default
 
 kamaji-etcd:

--- a/packages/system/kamaji/images/kamaji/Dockerfile
+++ b/packages/system/kamaji/images/kamaji/Dockerfile
@@ -1,7 +1,7 @@
 # Build the manager binary
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
-ARG VERSION=edge-24.9.2
+ARG VERSION=edge-24.12.1
 ARG TARGETOS TARGETARCH
 
 WORKDIR /workspace


### PR DESCRIPTION
Fix makefile update target for kamaji
Fix Dockerfile for kamaji (golang:1.23 as builder)
kamaji Chart updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced DataStore configuration with more flexible inheritance and schema definition
  - Added support for advanced network profile settings

- **Improvements**
  - Updated Kamaji application to version `edge-24.12.1`
  - Upgraded Go runtime to version 1.23
  - Improved documentation for DataStore and configuration settings

- **Dependency Updates**
  - Updated `kamaji-etcd` dependency to version `>=0.8.1`

- **Version Changes**
  - Reset application and chart versions to `0.0.0`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->