### PR TITLE
Prepare release v0.24.0

### DIFF
--- a/manifests/cozystack-installer.yaml
+++ b/manifests/cozystack-installer.yaml
@@ -68,7 +68,7 @@ spec:
       serviceAccountName: cozystack
       containers:
       - name: cozystack
-        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.23.1"
+        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.24.0"
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: localhost
@@ -86,13 +86,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-      - name: darkhttpd
-        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.23.1"
+      - name: assets
+        image: "ghcr.io/aenix-io/cozystack/cozystack:v0.24.0"
         command:
-        - /usr/bin/darkhttpd
-        - /cozystack/assets
-        - --port
-        - "8123"
+        - /usr/bin/cozystack-assets-server
+        - "-dir=/cozystack/assets"
+        - "-address=:8123"
         ports:
         - name: http
           containerPort: 8123

--- a/packages/apps/kubernetes/images/cluster-autoscaler.tag
+++ b/packages/apps/kubernetes/images/cluster-autoscaler.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/cluster-autoscaler:0.15.0@sha256:538ee308f16c9e627ed16ee7c4aaa65919c2e6c4c2778f964a06e4797610d1cd
+ghcr.io/aenix-io/cozystack/cluster-autoscaler:0.15.0@sha256:88773436a4f2441869a43fb0999181874d38add09906bb9a91ff438dbc474bca

--- a/packages/apps/kubernetes/images/kubevirt-cloud-provider.tag
+++ b/packages/apps/kubernetes/images/kubevirt-cloud-provider.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/kubevirt-cloud-provider:0.15.0@sha256:7716c88947d13dc90ccfcc3e60bfdd6e6fa9b201339a75e9c84bf825c76e2b1f
+ghcr.io/aenix-io/cozystack/kubevirt-cloud-provider:0.15.0@sha256:f947e82c50533df847e31f0d33597f10589065fccb1e462b6a9182772642d98e

--- a/packages/apps/kubernetes/images/kubevirt-csi-driver.tag
+++ b/packages/apps/kubernetes/images/kubevirt-csi-driver.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/kubevirt-csi-driver:0.15.0@sha256:be5e0eef92dada3ace5cddda5c68b30c9fe4682774c5e6e938ed31efba11ebbf
+ghcr.io/aenix-io/cozystack/kubevirt-csi-driver:0.15.0@sha256:f0367f809ec9f717e98b840d4d362b7afb366831f4692908c978dc23ffd885b3

--- a/packages/core/installer/values.yaml
+++ b/packages/core/installer/values.yaml
@@ -1,2 +1,2 @@
 cozystack:
-  image: ghcr.io/aenix-io/cozystack/cozystack:v0.23.1@sha256:dfa803a3e02ec9ea221029d361aa9d7aef0b5eb0a36d66c949b265d4ac4fc114
+  image: ghcr.io/aenix-io/cozystack/cozystack:v0.24.0@sha256:3560daf09e41b5a729b4377341cc01d51b272122640bd7c4db9d1f5fcb8008a9

--- a/packages/core/testing/values.yaml
+++ b/packages/core/testing/values.yaml
@@ -1,2 +1,2 @@
 e2e:
-  image: ghcr.io/aenix-io/cozystack/e2e-sandbox:v0.23.1@sha256:0f4ffa7f23d6cdc633c0c4a0b852fde9710edbce96486fd9bd29c7d0d7710380
+  image: ghcr.io/aenix-io/cozystack/e2e-sandbox:v0.24.0@sha256:38229517c86e179984a6d39f5510b859d13d965e35b216bc01ce456f9ab5f8b5

--- a/packages/extra/bootbox/images/matchbox.tag
+++ b/packages/extra/bootbox/images/matchbox.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/matchbox:v0.23.1
+ghcr.io/aenix-io/cozystack/matchbox:v0.24.0@sha256:6402f92454bfad6d81ff4d07c21c46e44bc2b890769963d5c0d8b6b31300384f

--- a/packages/extra/monitoring/images/grafana.tag
+++ b/packages/extra/monitoring/images/grafana.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/grafana:latest@sha256:0377abd3cb2c6e27b12ac297f1859aa4d550f1aa14989f824f2315d0dfd1a5b2
+ghcr.io/aenix-io/cozystack/grafana:1.8.0@sha256:0377abd3cb2c6e27b12ac297f1859aa4d550f1aa14989f824f2315d0dfd1a5b2

--- a/packages/system/bucket/images/s3manager.tag
+++ b/packages/system/bucket/images/s3manager.tag
@@ -1,1 +1,1 @@
-ghcr.io/aenix-io/cozystack/s3manager:v0.5.0@sha256:35e9a8ba7e1a3b0cee634f6d2bd92d2b08c47c7ed3316559c9ea25ff733eb5d5
+ghcr.io/aenix-io/cozystack/s3manager:v0.5.0@sha256:88502cd7dd31418e503a9eea39dd49845e3c56236f1480adcb701043efcf13e7

--- a/packages/system/cozystack-api/values.yaml
+++ b/packages/system/cozystack-api/values.yaml
@@ -1,2 +1,2 @@
 cozystackAPI:
-  image: ghcr.io/aenix-io/cozystack/cozystack-api:v0.23.1@sha256:b25faba99a8b98c1d3576b47986266c4f391c1998d89b599e9139f43727c5b4c
+  image: ghcr.io/aenix-io/cozystack/cozystack-api:v0.24.0@sha256:295e50fb1e08c9be272ca218b12fc90b649df6656879a3ed8f261f2ccd946b03

--- a/packages/system/cozystack-controller/values.yaml
+++ b/packages/system/cozystack-controller/values.yaml
@@ -1,5 +1,5 @@
 cozystackController:
-  image: ghcr.io/aenix-io/cozystack/cozystack-controller:v0.23.1@sha256:ca7801e33fbd38e01b3abe9645956bb235ba7b0f2381bd622d18d4dc5e280020
+  image: ghcr.io/aenix-io/cozystack/cozystack-controller:v0.24.0@sha256:6226224703de85835a66f5434d295958c0c0910f97c8fbeaae0021fef2829be6
   debug: false
   disableTelemetry: false
-  cozystackVersion: "v0.23.1"
+  cozystackVersion: "v0.24.0"

--- a/packages/system/dashboard/charts/kubeapps/templates/dashboard/configmap.yaml
+++ b/packages/system/dashboard/charts/kubeapps/templates/dashboard/configmap.yaml
@@ -76,7 +76,7 @@ data:
       "kubeappsNamespace": {{ .Release.Namespace | quote }},
       "helmGlobalNamespace": {{ include "kubeapps.helmGlobalPackagingNamespace" . | quote }},
       "carvelGlobalNamespace": {{ .Values.kubeappsapis.pluginConfig.kappController.packages.v1alpha1.globalPackagingNamespace | quote }},
-      "appVersion": "v0.23.1",
+      "appVersion": "v0.24.0",
       "authProxyEnabled": {{ .Values.authProxy.enabled }},
       "oauthLoginURI": {{ .Values.authProxy.oauthLoginURI | quote }},
       "oauthLogoutURI": {{ .Values.authProxy.oauthLogoutURI | quote }},

--- a/packages/system/dashboard/values.yaml
+++ b/packages/system/dashboard/values.yaml
@@ -40,14 +40,14 @@ kubeapps:
     image:
       registry: ghcr.io/aenix-io/cozystack
       repository: dashboard
-      tag: v0.23.1
+      tag: v0.24.0
       digest: "sha256:81e7b625c667bce5fc339eb97c8e115eafb82f66df4501550b3677ac53f6e234"
   kubeappsapis:
     image:
       registry: ghcr.io/aenix-io/cozystack
       repository: kubeapps-apis
-      tag: v0.23.1
-      digest: "sha256:d3767354cf6c785447f30e87bb2017ec45843edfc02635f526d2ecacc82f5d26"
+      tag: v0.24.0
+      digest: "sha256:e2a4caf976ff5d8b0092b7786d3aeb8e847964aa5bf186b1da900e413f729e0f"
     pluginConfig:
       flux:
         packages:

--- a/packages/system/kamaji/values.yaml
+++ b/packages/system/kamaji/values.yaml
@@ -3,7 +3,7 @@ kamaji:
     deploy: false
   image:
     pullPolicy: IfNotPresent
-    tag: v0.23.1@sha256:87166056685e4dab9de030ad9389ce58f0d96e7f6c191674fe93483fbe99490f
+    tag: v0.24.0@sha256:5084f6b58fc70bb4d27cb2e21b019c30d6895e1b2efcece388c747003ad82fb7
     repository: ghcr.io/aenix-io/cozystack/kamaji
   resources:
     limits:

--- a/packages/system/kubeovn/values.yaml
+++ b/packages/system/kubeovn/values.yaml
@@ -22,4 +22,4 @@ global:
   images:
     kubeovn:
       repository: kubeovn
-      tag: v1.13.2@sha256:ee658a003cd77a1f7b9df1d108255a8b5a69e67dd59fa6a6161c869b00207d4f
+      tag: v1.13.2@sha256:04c0f6892cf3dfd1c0db2f9b3c876c8cc05f5e25d3ebf0fb9c842bd29319352e


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes for CozyStack v0.24.0

- **Image Updates**
  - Upgraded CozyStack core components to version v0.24.0
  - Updated multiple system images, including cluster-autoscaler, kubevirt cloud provider, and CSI driver
  - Refreshed images for dashboard, API, and controller components
  - Updated Grafana image to version 1.8.0

- **Infrastructure Changes**
  - Replaced `darkhttpd` container with new `assets` container in deployment configuration
  - Updated image digests across various system components

- **Version Bump**
  - Incremented CozyStack version from v0.23.1 to v0.24.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->