### PR TITLE
Introduce externalMethod=WholeIP for VMs

### DIFF
--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -109,13 +109,15 @@ virtual-machine 0.4.0 4746d51
 virtual-machine 0.5.0 cad9cde
 virtual-machine 0.6.0 0e728870
 virtual-machine 0.7.0 af58018a
-virtual-machine 0.7.1 HEAD
+virtual-machine 0.7.1 05857b95
+virtual-machine 0.8.0 HEAD
 vm-disk 0.1.0 HEAD
 vm-instance 0.1.0 ced8e5b9
 vm-instance 0.2.0 4f767ee3
 vm-instance 0.3.0 0e728870
 vm-instance 0.4.0 af58018a
-vm-instance 0.4.1 HEAD
+vm-instance 0.4.1 05857b95
+vm-instance 0.5.0 HEAD
 vpn 0.1.0 f642698
 vpn 0.2.0 7151424
 vpn 0.3.0 a2bcf100

--- a/packages/apps/virtual-machine/Chart.yaml
+++ b/packages/apps/virtual-machine/Chart.yaml
@@ -17,10 +17,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.1
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.7.1"
+appVersion: "0.8.0"

--- a/packages/apps/virtual-machine/Makefile
+++ b/packages/apps/virtual-machine/Makefile
@@ -8,3 +8,4 @@ generate:
 	  && yq -i -o json ".properties.instanceProfile.optional=true | .properties.instanceProfile.enum = $${PREFERENCES}" values.schema.json
 	yq -i -o json '.properties.externalPorts.items.type = "integer"' values.schema.json
 	yq -i -o json '.properties.systemDisk.properties.image.enum = ["ubuntu", "cirros", "alpine", "fedora", "talos"]' values.schema.json
+	yq -i -o json '.properties.externalMethod.enum = ["ports", "wholeIP"]' values.schema.json

--- a/packages/apps/virtual-machine/Makefile
+++ b/packages/apps/virtual-machine/Makefile
@@ -8,4 +8,4 @@ generate:
 	  && yq -i -o json ".properties.instanceProfile.optional=true | .properties.instanceProfile.enum = $${PREFERENCES}" values.schema.json
 	yq -i -o json '.properties.externalPorts.items.type = "integer"' values.schema.json
 	yq -i -o json '.properties.systemDisk.properties.image.enum = ["ubuntu", "cirros", "alpine", "fedora", "talos"]' values.schema.json
-	yq -i -o json '.properties.externalMethod.enum = ["ports", "wholeIP"]' values.schema.json
+	yq -i -o json '.properties.externalMethod.enum = ["wholeIP", "PortList"]' values.schema.json

--- a/packages/apps/virtual-machine/README.md
+++ b/packages/apps/virtual-machine/README.md
@@ -39,7 +39,7 @@ virtctl ssh <user>@<vm>
 | Name                      | Description                                                                                                | Value            |
 | ------------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------- |
 | `external`                | Enable external access from outside the cluster                                                            | `false`          |
-| `externalMethod`          | specify method to passthrough the traffic to the virtual machine. Allowed values: `ports` and `wholeIP`    | `wholeIP`        |
+| `externalMethod`          | specify method to passthrough the traffic to the virtual machine. Allowed values: `WholeIP` and `PortList` | `WholeIP`        |
 | `externalPorts`           | Specify ports to forward from outside the cluster                                                          | `[]`             |
 | `running`                 | Determines if the virtual machine should be running                                                        | `true`           |
 | `instanceType`            | Virtual Machine instance type                                                                              | `u1.medium`      |

--- a/packages/apps/virtual-machine/README.md
+++ b/packages/apps/virtual-machine/README.md
@@ -39,6 +39,7 @@ virtctl ssh <user>@<vm>
 | Name                      | Description                                                                                                | Value            |
 | ------------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------- |
 | `external`                | Enable external access from outside the cluster                                                            | `false`          |
+| `externalMethod`          | specify method to passthrough the traffic to the virtual machine. Allowed values: `ports` and `wholeIP`    | `wholeIP`        |
 | `externalPorts`           | Specify ports to forward from outside the cluster                                                          | `[]`             |
 | `running`                 | Determines if the virtual machine should be running                                                        | `true`           |
 | `instanceType`            | Virtual Machine instance type                                                                              | `u1.medium`      |

--- a/packages/apps/virtual-machine/templates/service.yaml
+++ b/packages/apps/virtual-machine/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ include "virtual-machine.fullname" . }}
   labels:
     {{- include "virtual-machine.labels" . | nindent 4 }}
-  {{- if eq .Values.externalMethod "wholeIP" }}
+  {{- if eq .Values.externalMethod "WholeIP" }}
   annotations:
     networking.cozystack.io/wholeIP: "true"
   {{- end }}
@@ -17,7 +17,7 @@ spec:
   selector:
     {{- include "virtual-machine.labels" . | nindent 4 }}
   ports:
-    {{- if eq .Values.externalMethod "wholeIP" }}
+    {{- if eq .Values.externalMethod "WholeIP" }}
     - port: 65535
     {{- else }}
     {{- range .Values.externalPorts }}

--- a/packages/apps/virtual-machine/templates/service.yaml
+++ b/packages/apps/virtual-machine/templates/service.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ include "virtual-machine.fullname" . }}
   labels:
     {{- include "virtual-machine.labels" . | nindent 4 }}
+  {{- if eq .Values.externalMethod "wholeIP" }}
+  annotations:
+    networking.cozystack.io/wholeIP: "true"
+  {{- end }}
 spec:
   type: {{ ternary "LoadBalancer" "ClusterIP" .Values.external }}
   externalTrafficPolicy: Local
@@ -13,9 +17,13 @@ spec:
   selector:
     {{- include "virtual-machine.labels" . | nindent 4 }}
   ports:
+    {{- if eq .Values.externalMethod "wholeIP" }}
+    - port: 65535
+    {{- else }}
     {{- range .Values.externalPorts }}
     - name: port-{{ . }}
       port: {{ . }}
       targetPort: {{ . }}
+    {{- end }}
     {{- end }}
 {{- end }}

--- a/packages/apps/virtual-machine/values.schema.json
+++ b/packages/apps/virtual-machine/values.schema.json
@@ -7,6 +7,15 @@
       "description": "Enable external access from outside the cluster",
       "default": false
     },
+    "externalMethod": {
+      "type": "string",
+      "description": "specify method to passthrough the traffic to the virtual machine. Allowed values: `ports` and `wholeIP`",
+      "default": "wholeIP",
+      "enum": [
+        "ports",
+        "wholeIP"
+      ]
+    },
     "externalPorts": {
       "type": "array",
       "description": "Specify ports to forward from outside the cluster",

--- a/packages/apps/virtual-machine/values.schema.json
+++ b/packages/apps/virtual-machine/values.schema.json
@@ -9,11 +9,11 @@
     },
     "externalMethod": {
       "type": "string",
-      "description": "specify method to passthrough the traffic to the virtual machine. Allowed values: `ports` and `wholeIP`",
-      "default": "wholeIP",
+      "description": "specify method to passthrough the traffic to the virtual machine. Allowed values: `WholeIP` and `PortList`",
+      "default": "WholeIP",
       "enum": [
-        "ports",
-        "wholeIP"
+        "wholeIP",
+        "PortList"
       ]
     },
     "externalPorts": {

--- a/packages/apps/virtual-machine/values.yaml
+++ b/packages/apps/virtual-machine/values.yaml
@@ -1,8 +1,10 @@
 ## @section Common parameters
 
 ## @param external Enable external access from outside the cluster
+## @param externalMethod specify method to passthrough the traffic to the virtual machine. Allowed values: `ports` and `wholeIP`
 ## @param externalPorts [array] Specify ports to forward from outside the cluster
 external: false
+externalMethod: "wholeIP"
 externalPorts:
 - 22
 

--- a/packages/apps/virtual-machine/values.yaml
+++ b/packages/apps/virtual-machine/values.yaml
@@ -1,10 +1,10 @@
 ## @section Common parameters
 
 ## @param external Enable external access from outside the cluster
-## @param externalMethod specify method to passthrough the traffic to the virtual machine. Allowed values: `ports` and `wholeIP`
+## @param externalMethod specify method to passthrough the traffic to the virtual machine. Allowed values: `WholeIP` and `PortList`
 ## @param externalPorts [array] Specify ports to forward from outside the cluster
 external: false
-externalMethod: "wholeIP"
+externalMethod: WholeIP
 externalPorts:
 - 22
 

--- a/packages/apps/vm-instance/Chart.yaml
+++ b/packages/apps/vm-instance/Chart.yaml
@@ -17,10 +17,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.1"
+appVersion: "0.5.0"

--- a/packages/apps/vm-instance/Makefile
+++ b/packages/apps/vm-instance/Makefile
@@ -8,4 +8,4 @@ generate:
 	PREFERENCES=$$(yq e '.metadata.name' -o=json -r ../../system/kubevirt-instancetypes/templates/preferences.yaml | yq 'split(" ") | . + [""]' -o json) \
 	  && yq -i -o json ".properties.instanceProfile.optional=true | .properties.instanceProfile.enum = $${PREFERENCES}" values.schema.json
 	yq -i -o json '.properties.externalPorts.items.type = "integer"' values.schema.json
-	yq -i -o json '.properties.externalMethod.enum = ["ports", "wholeIP"]' values.schema.json
+	yq -i -o json '.properties.externalMethod.enum = ["WholeIP", "PortList"]' values.schema.json

--- a/packages/apps/vm-instance/Makefile
+++ b/packages/apps/vm-instance/Makefile
@@ -8,3 +8,4 @@ generate:
 	PREFERENCES=$$(yq e '.metadata.name' -o=json -r ../../system/kubevirt-instancetypes/templates/preferences.yaml | yq 'split(" ") | . + [""]' -o json) \
 	  && yq -i -o json ".properties.instanceProfile.optional=true | .properties.instanceProfile.enum = $${PREFERENCES}" values.schema.json
 	yq -i -o json '.properties.externalPorts.items.type = "integer"' values.schema.json
+	yq -i -o json '.properties.externalMethod.enum = ["ports", "wholeIP"]' values.schema.json

--- a/packages/apps/vm-instance/README.md
+++ b/packages/apps/vm-instance/README.md
@@ -36,18 +36,19 @@ virtctl ssh <user>@<vm>
 
 ### Common parameters
 
-| Name               | Description                                                                        | Value            |
-| ------------------ | ---------------------------------------------------------------------------------- | ---------------- |
-| `external`         | Enable external access from outside the cluster                                    | `false`          |
-| `externalPorts`    | Specify ports to forward from outside the cluster                                  | `[]`             |
-| `running`          | Determines if the virtual machine should be running                                | `true`           |
-| `instanceType`     | Virtual Machine instance type                                                      | `u1.medium`      |
-| `instanceProfile`  | Virtual Machine prefferences profile                                               | `ubuntu`         |
-| `disks`            | List of disks to attach                                                            | `[]`             |
-| `resources.cpu`    | The number of CPU cores allocated to the virtual machine                           | `""`             |
-| `resources.memory` | The amount of memory allocated to the virtual machine                              | `""`             |
-| `sshKeys`          | List of SSH public keys for authentication. Can be a single key or a list of keys. | `[]`             |
-| `cloudInit`        | cloud-init user data config. See cloud-init documentation for more details.        | `#cloud-config
+| Name               | Description                                                                                             | Value            |
+| ------------------ | ------------------------------------------------------------------------------------------------------- | ---------------- |
+| `external`         | Enable external access from outside the cluster                                                         | `false`          |
+| `externalMethod`   | specify method to passthrough the traffic to the virtual machine. Allowed values: `ports` and `wholeIP` | `wholeIP`        |
+| `externalPorts`    | Specify ports to forward from outside the cluster                                                       | `[]`             |
+| `running`          | Determines if the virtual machine should be running                                                     | `true`           |
+| `instanceType`     | Virtual Machine instance type                                                                           | `u1.medium`      |
+| `instanceProfile`  | Virtual Machine prefferences profile                                                                    | `ubuntu`         |
+| `disks`            | List of disks to attach                                                                                 | `[]`             |
+| `resources.cpu`    | The number of CPU cores allocated to the virtual machine                                                | `""`             |
+| `resources.memory` | The amount of memory allocated to the virtual machine                                                   | `""`             |
+| `sshKeys`          | List of SSH public keys for authentication. Can be a single key or a list of keys.                      | `[]`             |
+| `cloudInit`        | cloud-init user data config. See cloud-init documentation for more details.                             | `#cloud-config
 ` |
 
 ## U Series

--- a/packages/apps/vm-instance/README.md
+++ b/packages/apps/vm-instance/README.md
@@ -36,19 +36,19 @@ virtctl ssh <user>@<vm>
 
 ### Common parameters
 
-| Name               | Description                                                                                             | Value            |
-| ------------------ | ------------------------------------------------------------------------------------------------------- | ---------------- |
-| `external`         | Enable external access from outside the cluster                                                         | `false`          |
-| `externalMethod`   | specify method to passthrough the traffic to the virtual machine. Allowed values: `ports` and `wholeIP` | `wholeIP`        |
-| `externalPorts`    | Specify ports to forward from outside the cluster                                                       | `[]`             |
-| `running`          | Determines if the virtual machine should be running                                                     | `true`           |
-| `instanceType`     | Virtual Machine instance type                                                                           | `u1.medium`      |
-| `instanceProfile`  | Virtual Machine prefferences profile                                                                    | `ubuntu`         |
-| `disks`            | List of disks to attach                                                                                 | `[]`             |
-| `resources.cpu`    | The number of CPU cores allocated to the virtual machine                                                | `""`             |
-| `resources.memory` | The amount of memory allocated to the virtual machine                                                   | `""`             |
-| `sshKeys`          | List of SSH public keys for authentication. Can be a single key or a list of keys.                      | `[]`             |
-| `cloudInit`        | cloud-init user data config. See cloud-init documentation for more details.                             | `#cloud-config
+| Name               | Description                                                                                                | Value            |
+| ------------------ | ---------------------------------------------------------------------------------------------------------- | ---------------- |
+| `external`         | Enable external access from outside the cluster                                                            | `false`          |
+| `externalMethod`   | specify method to passthrough the traffic to the virtual machine. Allowed values: `WholeIP` and `PortList` | `WholeIP`        |
+| `externalPorts`    | Specify ports to forward from outside the cluster                                                          | `[]`             |
+| `running`          | Determines if the virtual machine should be running                                                        | `true`           |
+| `instanceType`     | Virtual Machine instance type                                                                              | `u1.medium`      |
+| `instanceProfile`  | Virtual Machine prefferences profile                                                                       | `ubuntu`         |
+| `disks`            | List of disks to attach                                                                                    | `[]`             |
+| `resources.cpu`    | The number of CPU cores allocated to the virtual machine                                                   | `""`             |
+| `resources.memory` | The amount of memory allocated to the virtual machine                                                      | `""`             |
+| `sshKeys`          | List of SSH public keys for authentication. Can be a single key or a list of keys.                         | `[]`             |
+| `cloudInit`        | cloud-init user data config. See cloud-init documentation for more details.                                | `#cloud-config
 ` |
 
 ## U Series

--- a/packages/apps/vm-instance/templates/service.yaml
+++ b/packages/apps/vm-instance/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ include "virtual-machine.fullname" . }}
   labels:
     {{- include "virtual-machine.labels" . | nindent 4 }}
-  {{- if eq .Values.externalMethod "wholeIP" }}
+  {{- if eq .Values.externalMethod "WholeIP" }}
   annotations:
     networking.cozystack.io/wholeIP: "true"
   {{- end }}
@@ -17,7 +17,7 @@ spec:
   selector:
     {{- include "virtual-machine.labels" . | nindent 4 }}
   ports:
-    {{- if eq .Values.externalMethod "wholeIP" }}
+    {{- if eq .Values.externalMethod "WholeIP" }}
     - port: 65535
     {{- else }}
     {{- range .Values.externalPorts }}

--- a/packages/apps/vm-instance/templates/service.yaml
+++ b/packages/apps/vm-instance/templates/service.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ include "virtual-machine.fullname" . }}
   labels:
     {{- include "virtual-machine.labels" . | nindent 4 }}
+  {{- if eq .Values.externalMethod "wholeIP" }}
+  annotations:
+    networking.cozystack.io/wholeIP: "true"
+  {{- end }}
 spec:
   type: {{ ternary "LoadBalancer" "ClusterIP" .Values.external }}
   externalTrafficPolicy: Local
@@ -13,9 +17,13 @@ spec:
   selector:
     {{- include "virtual-machine.labels" . | nindent 4 }}
   ports:
+    {{- if eq .Values.externalMethod "wholeIP" }}
+    - port: 65535
+    {{- else }}
     {{- range .Values.externalPorts }}
     - name: port-{{ . }}
       port: {{ . }}
       targetPort: {{ . }}
+    {{- end }}
     {{- end }}
 {{- end }}

--- a/packages/apps/vm-instance/values.schema.json
+++ b/packages/apps/vm-instance/values.schema.json
@@ -9,11 +9,11 @@
     },
     "externalMethod": {
       "type": "string",
-      "description": "specify method to passthrough the traffic to the virtual machine. Allowed values: `ports` and `wholeIP`",
-      "default": "wholeIP",
+      "description": "specify method to passthrough the traffic to the virtual machine. Allowed values: `WholeIP` and `PortList`",
+      "default": "WholeIP",
       "enum": [
-        "ports",
-        "wholeIP"
+        "WholeIP",
+        "PortList"
       ]
     },
     "externalPorts": {

--- a/packages/apps/vm-instance/values.schema.json
+++ b/packages/apps/vm-instance/values.schema.json
@@ -7,6 +7,15 @@
       "description": "Enable external access from outside the cluster",
       "default": false
     },
+    "externalMethod": {
+      "type": "string",
+      "description": "specify method to passthrough the traffic to the virtual machine. Allowed values: `ports` and `wholeIP`",
+      "default": "wholeIP",
+      "enum": [
+        "ports",
+        "wholeIP"
+      ]
+    },
     "externalPorts": {
       "type": "array",
       "description": "Specify ports to forward from outside the cluster",

--- a/packages/apps/vm-instance/values.yaml
+++ b/packages/apps/vm-instance/values.yaml
@@ -1,8 +1,10 @@
 ## @section Common parameters
 
 ## @param external Enable external access from outside the cluster
+## @param externalMethod specify method to passthrough the traffic to the virtual machine. Allowed values: `ports` and `wholeIP`
 ## @param externalPorts [array] Specify ports to forward from outside the cluster
 external: false
+externalMethod: "wholeIP"
 externalPorts:
 - 22
 

--- a/packages/apps/vm-instance/values.yaml
+++ b/packages/apps/vm-instance/values.yaml
@@ -1,10 +1,10 @@
 ## @section Common parameters
 
 ## @param external Enable external access from outside the cluster
-## @param externalMethod specify method to passthrough the traffic to the virtual machine. Allowed values: `ports` and `wholeIP`
+## @param externalMethod specify method to passthrough the traffic to the virtual machine. Allowed values: `WholeIP` and `PortList`
 ## @param externalPorts [array] Specify ports to forward from outside the cluster
 external: false
-externalMethod: "wholeIP"
+externalMethod: WholeIP
 externalPorts:
 - 22
 


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option for specifying the method to handle external traffic. Users can now choose between "WholeIP" and "PortList" (default) across virtual machine and instance deployments.
  - Service settings now adjust automatically based on the selected external traffic method.

- **Documentation**
  - Updated configuration guides to include details on the new `externalMethod` parameter and its usage for managing external traffic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->