### PR TITLE
Flux Operator v0.15

### DIFF
--- a/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.14.0
+appVersion: v0.15.0
 description: 'A Helm chart for deploying the Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.14.0
+version: 0.15.0

--- a/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.13.0
+appVersion: v0.14.0
 description: 'A Helm chart for deploying the Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.13.0
+version: 0.14.0

--- a/packages/system/fluxcd-operator/charts/flux-operator/README.md
+++ b/packages/system/fluxcd-operator/charts/flux-operator/README.md
@@ -1,6 +1,6 @@
 # flux-operator
 
-![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.13.0](https://img.shields.io/badge/AppVersion-v0.13.0-informational?style=flat-square)
+![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.14.0](https://img.shields.io/badge/AppVersion-v0.14.0-informational?style=flat-square)
 
 The [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator) provides a
 declarative API for the installation and upgrade of CNCF [Flux](https://fluxcd.io) and the

--- a/packages/system/fluxcd-operator/charts/flux-operator/README.md
+++ b/packages/system/fluxcd-operator/charts/flux-operator/README.md
@@ -1,6 +1,6 @@
 # flux-operator
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.14.0](https://img.shields.io/badge/AppVersion-v0.14.0-informational?style=flat-square)
+![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.15.0](https://img.shields.io/badge/AppVersion-v0.15.0-informational?style=flat-square)
 
 The [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator) provides a
 declarative API for the installation and upgrade of CNCF [Flux](https://fluxcd.io) and the
@@ -44,9 +44,12 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 | livenessProbe | object | `{"httpGet":{"path":"/healthz","port":8081},"initialDelaySeconds":15,"periodSeconds":20}` | Container liveness probe settings. |
 | logLevel | string | `"info"` | Container logging level flag. |
 | marketplace | object | `{"account":"","license":"","type":""}` | Marketplace settings. |
+| multitenancy | object | `{"defaultServiceAccount":"flux-operator","enabled":false}` | Enable [multitenancy lockdown](https://fluxcd.control-plane.io/operator/resourceset/#role-based-access-control) for the ResourceSet APIs. |
 | nameOverride | string | `""` |  |
 | podSecurityContext | object | `{}` | Pod security context settings. |
 | priorityClassName | string | `""` | Pod priority class name. Recommended value is system-cluster-critical. |
+| rbac.create | bool | `true` | Grant the cluster-admin role to the flux-operator service account (required for the Flux Instance deployment). |
+| rbac.createAggregation | bool | `true` | Grant the Kubernetes view, edit and admin roles access to ResourceSet APIs. |
 | readinessProbe | object | `{"httpGet":{"path":"/readyz","port":8081},"initialDelaySeconds":5,"periodSeconds":10}` | Container readiness probe settings. |
 | resources | object | `{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"64Mi"}}` | Container resources requests and limits settings. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context settings. The default is compliant with the pod security restricted profile. |

--- a/packages/system/fluxcd-operator/charts/flux-operator/templates/admin-clusterrole.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/templates/admin-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -19,3 +20,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "flux-operator.fullname" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/packages/system/fluxcd-operator/charts/flux-operator/templates/aggregate-clusterrole.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/templates/aggregate-clusterrole.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.rbac.createAggregation }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "flux-operator.fullname" . }}-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    {{- include "flux-operator.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups:
+      - fluxcd.controlplane.io
+    resources:
+      - resourcesets
+      - resourcesetinputproviders
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "flux-operator.fullname" . }}-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    {{- include "flux-operator.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups:
+      - fluxcd.controlplane.io
+    resources:
+      - resourcesets
+      - resourcesetinputproviders
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}

--- a/packages/system/fluxcd-operator/charts/flux-operator/templates/crds.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/templates/crds.yaml
@@ -142,6 +142,11 @@ spec:
                       e.g. 'oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest'.
                     pattern: ^oci://.*$
                     type: string
+                  artifactPullSecret:
+                    description: |-
+                      ArtifactPullSecret is the name of the Kubernetes secret
+                      to use for pulling the Kubernetes manifests for the distribution specified in the Artifact field.
+                    type: string
                   imagePullSecret:
                     description: |-
                       ImagePullSecret is the name of the Kubernetes secret
@@ -722,6 +727,515 @@ spec:
                   - type
                   type: object
                 type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ .Chart.Name }}'
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}'
+  name: resourcesetinputproviders.fluxcd.controlplane.io
+spec:
+  group: fluxcd.controlplane.io
+  names:
+    kind: ResourceSetInputProvider
+    listKind: ResourceSetInputProviderList
+    plural: resourcesetinputproviders
+    shortNames:
+    - rsip
+    singular: resourcesetinputprovider
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ResourceSetInputProvider is the Schema for the ResourceSetInputProviders
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ResourceSetInputProviderSpec defines the desired state of
+              ResourceSetInputProvider
+            properties:
+              certSecretRef:
+                description: |-
+                  CertSecretRef specifies the Kubernetes Secret containing either or both of
+
+                  - a PEM-encoded CA certificate (`ca.crt`)
+                  - a PEM-encoded client certificate (`tls.crt`) and private key (`tls.key`)
+
+                  When connecting to a Git provider that uses self-signed certificates, the CA certificate
+                  must be set in the Secret under the 'ca.crt' key to establish the trust relationship.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              defaultValues:
+                additionalProperties:
+                  x-kubernetes-preserve-unknown-fields: true
+                description: |-
+                  DefaultValues contains the default values for the inputs.
+                  These values are used to populate the inputs when the provider
+                  response does not contain them.
+                type: object
+              filter:
+                description: Filter defines the filter to apply to the input provider
+                  response.
+                properties:
+                  excludeBranch:
+                    description: |-
+                      ExcludeBranch specifies the regular expression to filter the branches
+                      that the input provider should exclude.
+                    type: string
+                  includeBranch:
+                    description: |-
+                      IncludeBranch specifies the regular expression to filter the branches
+                      that the input provider should include.
+                    type: string
+                  labels:
+                    description: Labels specifies the list of labels to filter the
+                      input provider response.
+                    items:
+                      type: string
+                    type: array
+                  limit:
+                    description: |-
+                      Limit specifies the maximum number of input sets to return.
+                      When not set, the default limit is 100.
+                    type: integer
+                type: object
+              secretRef:
+                description: |-
+                  SecretRef specifies the Kubernetes Secret containing the basic-auth credentials
+                  to access the input provider. The secret must contain the keys
+                  'username' and 'password'.
+                  When connecting to a Git provider, the password should be a personal access token
+                  that grants read-only access to the repository.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              type:
+                description: Type specifies the type of the input provider.
+                enum:
+                - GitHubBranch
+                - GitHubPullRequest
+                - GitLabBranch
+                - GitLabMergeRequest
+                type: string
+              url:
+                description: |-
+                  URL specifies the HTTP/S address of the input provider API.
+                  When connecting to a Git provider, the URL should point to the repository address.
+                pattern: ^(http|https)://.*$
+                type: string
+            required:
+            - type
+            - url
+            type: object
+          status:
+            description: ResourceSetInputProviderStatus defines the observed state
+              of ResourceSetInputProvider.
+            properties:
+              conditions:
+                description: Conditions contains the readiness conditions of the object.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              exportedInputs:
+                description: ExportedInputs contains the list of inputs exported by
+                  the provider.
+                items:
+                  additionalProperties:
+                    x-kubernetes-preserve-unknown-fields: true
+                  description: ResourceSetInput defines the key-value pairs of the
+                    ResourceSet input.
+                  type: object
+                type: array
+              lastExportedRevision:
+                description: |-
+                  LastExportedRevision is the digest of the
+                  inputs that were last reconcile.
+                type: string
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ .Chart.Name }}'
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}'
+  name: resourcesets.fluxcd.controlplane.io
+spec:
+  group: fluxcd.controlplane.io
+  names:
+    kind: ResourceSet
+    listKind: ResourceSetList
+    plural: resourcesets
+    shortNames:
+    - rset
+    singular: resourceset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ResourceSet is the Schema for the ResourceSets API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ResourceSetSpec defines the desired state of ResourceSet
+            properties:
+              commonMetadata:
+                description: |-
+                  CommonMetadata specifies the common labels and annotations that are
+                  applied to all resources. Any existing label or annotation will be
+                  overridden if its key matches a common one.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations to be added to the object's metadata.
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels to be added to the object's metadata.
+                    type: object
+                type: object
+              dependsOn:
+                description: |-
+                  DependsOn specifies the list of Kubernetes resources that must
+                  exist on the cluster before the reconciliation process starts.
+                items:
+                  description: Dependency defines a ResourceSet dependency on a Kubernetes
+                    resource.
+                  properties:
+                    apiVersion:
+                      description: APIVersion of the resource to depend on.
+                      type: string
+                    kind:
+                      description: Kind of the resource to depend on.
+                      type: string
+                    name:
+                      description: Name of the resource to depend on.
+                      type: string
+                    namespace:
+                      description: Namespace of the resource to depend on.
+                      type: string
+                    ready:
+                      description: Ready checks if the resource Ready status condition
+                        is true.
+                      type: boolean
+                    readyExpr:
+                      description: |-
+                        ReadyExpr checks if the resource satisfies the given CEL expression.
+                        The expression replaces the default readiness check and
+                        is only evaluated if Ready is set to 'true'.
+                      type: string
+                  required:
+                  - apiVersion
+                  - kind
+                  - name
+                  type: object
+                type: array
+              inputs:
+                description: Inputs contains the list of ResourceSet inputs.
+                items:
+                  additionalProperties:
+                    x-kubernetes-preserve-unknown-fields: true
+                  description: ResourceSetInput defines the key-value pairs of the
+                    ResourceSet input.
+                  type: object
+                type: array
+              inputsFrom:
+                description: |-
+                  InputsFrom contains the list of references to input providers.
+                  When set, the inputs are fetched from the providers and concatenated
+                  with the in-line inputs defined in the ResourceSet.
+                items:
+                  properties:
+                    apiVersion:
+                      description: |-
+                        APIVersion of the input provider resource.
+                        When not set, the APIVersion of the ResourceSet is used.
+                      type: string
+                    kind:
+                      description: Kind of the input provider resource.
+                      enum:
+                      - ResourceSetInputProvider
+                      type: string
+                    name:
+                      description: Name of the input provider resource.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              resources:
+                description: Resources contains the list of Kubernetes resources to
+                  reconcile.
+                items:
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
+              resourcesTemplate:
+                description: |-
+                  ResourcesTemplate is a Go template that generates the list of
+                  Kubernetes resources to reconcile. The template is rendered
+                  as multi-document YAML, the resources should be separated by '---'.
+                  When both Resources and ResourcesTemplate are set, the resulting
+                  objects are merged and deduplicated, with the ones from Resources taking precedence.
+                type: string
+              serviceAccountName:
+                description: |-
+                  The name of the Kubernetes service account to impersonate
+                  when reconciling the generated resources.
+                type: string
+              wait:
+                description: |-
+                  Wait instructs the controller to check the health
+                  of all the reconciled resources.
+                type: boolean
+            type: object
+          status:
+            description: ResourceSetStatus defines the observed state of ResourceSet.
+            properties:
+              conditions:
+                description: Conditions contains the readiness conditions of the object.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              inventory:
+                description: |-
+                  Inventory contains a list of Kubernetes resource object references
+                  last applied on the cluster.
+                properties:
+                  entries:
+                    description: Entries of Kubernetes resource object references.
+                    items:
+                      description: ResourceRef contains the information necessary
+                        to locate a resource within a cluster.
+                      properties:
+                        id:
+                          description: |-
+                            ID is the string representation of the Kubernetes resource object's metadata,
+                            in the format '<namespace>_<name>_<group>_<kind>'.
+                          type: string
+                        v:
+                          description: Version is the API version of the Kubernetes
+                            resource object's kind.
+                          type: string
+                      required:
+                      - id
+                      - v
+                      type: object
+                    type: array
+                required:
+                - entries
+                type: object
+              lastAppliedRevision:
+                description: |-
+                  LastAppliedRevision is the digest of the
+                  generated resources that were last reconcile.
+                type: string
               lastHandledReconcileAt:
                 description: |-
                   LastHandledReconcileAt holds the value of the most recent

--- a/packages/system/fluxcd-operator/charts/flux-operator/templates/deployment.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
         - name: manager
           args:
             - --log-level={{ .Values.logLevel }}
+            {{- if .Values.multitenancy.enabled }}
+            - --default-service-account={{ .Values.multitenancy.defaultServiceAccount }}
+            {{- end }}
             {{- range .Values.extraArgs }}
             - {{ . }}
             {{- end }}

--- a/packages/system/fluxcd-operator/charts/flux-operator/values.schema.json
+++ b/packages/system/fluxcd-operator/charts/flux-operator/values.schema.json
@@ -169,6 +169,20 @@
             },
             "type": "object"
         },
+        "multitenancy": {
+            "properties": {
+                "defaultServiceAccount": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "defaultServiceAccount"
+            ],
+            "type": "object"
+        },
         "nameOverride": {
             "type": "string"
         },
@@ -182,6 +196,17 @@
         "priorityClassName": {
             "default": "system-cluster-critical",
             "type": "string"
+        },
+        "rbac": {
+            "properties": {
+                "create": {
+                    "type": "boolean"
+                },
+                "createAggregation": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
         },
         "readinessProbe": {
             "default": {

--- a/packages/system/fluxcd-operator/charts/flux-operator/values.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/values.yaml
@@ -3,6 +3,11 @@
 nameOverride: ""
 fullnameOverride: ""
 
+# -- Enable [multitenancy lockdown](https://fluxcd.control-plane.io/operator/resourceset/#role-based-access-control) for the ResourceSet APIs.
+multitenancy:
+  enabled: false
+  defaultServiceAccount: "flux-operator" # @schema required: true
+
 # -- Install and upgrade the custom resource definitions.
 installCRDs: true # @schema default: true
 
@@ -54,6 +59,12 @@ serviceAccount: # @schema default: {"create":true,"automount":true,"name":""}
   create: true
   automount: true
   name: ""
+
+rbac:
+   # -- Grant the cluster-admin role to the flux-operator service account (required for the Flux Instance deployment).
+  create: true
+  # -- Grant the Kubernetes view, edit and admin roles access to ResourceSet APIs.
+  createAggregation: true
 
 # -- Pod security context settings.
 podSecurityContext: { } # @schema default: {"fsGroup":1337}

--- a/packages/system/fluxcd/charts/flux-instance/Chart.yaml
+++ b/packages/system/fluxcd/charts/flux-instance/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.14.0
+appVersion: v0.15.0
 description: 'A Helm chart for deploying a Flux instance managed by Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.14.0
+version: 0.15.0

--- a/packages/system/fluxcd/charts/flux-instance/Chart.yaml
+++ b/packages/system/fluxcd/charts/flux-instance/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.13.0
+appVersion: v0.14.0
 description: 'A Helm chart for deploying a Flux instance managed by Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.13.0
+version: 0.14.0

--- a/packages/system/fluxcd/charts/flux-instance/README.md
+++ b/packages/system/fluxcd/charts/flux-instance/README.md
@@ -1,6 +1,6 @@
 # flux-instance
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.14.0](https://img.shields.io/badge/AppVersion-v0.14.0-informational?style=flat-square)
+![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.15.0](https://img.shields.io/badge/AppVersion-v0.15.0-informational?style=flat-square)
 
 This chart is a thin wrapper around the `FluxInstance` custom resource, which is
 used by the [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator)

--- a/packages/system/fluxcd/charts/flux-instance/README.md
+++ b/packages/system/fluxcd/charts/flux-instance/README.md
@@ -1,6 +1,6 @@
 # flux-instance
 
-![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.13.0](https://img.shields.io/badge/AppVersion-v0.13.0-informational?style=flat-square)
+![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.14.0](https://img.shields.io/badge/AppVersion-v0.14.0-informational?style=flat-square)
 
 This chart is a thin wrapper around the `FluxInstance` custom resource, which is
 used by the [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator)
@@ -40,11 +40,11 @@ helm -n flux-system uninstall flux
 | instance.cluster | object | `{"domain":"cluster.local","multitenant":false,"networkPolicy":true,"tenantDefaultServiceAccount":"default","type":"kubernetes"}` | Cluster https://fluxcd.control-plane.io/operator/fluxinstance/#cluster-configuration |
 | instance.commonMetadata | object | `{"annotations":{},"labels":{}}` | Common metadata https://fluxcd.control-plane.io/operator/fluxinstance/#common-metadata |
 | instance.components | list | `["source-controller","kustomize-controller","helm-controller","notification-controller"]` | Components https://fluxcd.control-plane.io/operator/fluxinstance/#components-configuration |
-| instance.distribution | object | `{"artifact":"oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest","imagePullSecret":"","registry":"ghcr.io/fluxcd","version":"2.x"}` | Distribution https://fluxcd.control-plane.io/operator/fluxinstance/#distribution-configuration |
+| instance.distribution | object | `{"artifact":"oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest","artifactPullSecret":"","imagePullSecret":"","registry":"ghcr.io/fluxcd","version":"2.x"}` | Distribution https://fluxcd.control-plane.io/operator/fluxinstance/#distribution-configuration |
 | instance.kustomize.patches | list | `[]` | Kustomize patches https://fluxcd.control-plane.io/operator/fluxinstance/#kustomize-patches |
 | instance.sharding | object | `{"key":"sharding.fluxcd.io/key","shards":[]}` | Sharding https://fluxcd.control-plane.io/operator/fluxinstance/#sharding-configuration |
 | instance.storage | object | `{"class":"","size":""}` | Storage https://fluxcd.control-plane.io/operator/fluxinstance/#storage-configuration |
-| instance.sync | object | `{"kind":"GitRepository","name":"","path":"","pullSecret":"","ref":"","url":""}` | Sync https://fluxcd.control-plane.io/operator/fluxinstance/#sync-configuration |
+| instance.sync | object | `{"interval":"1m","kind":"GitRepository","name":"","path":"","pullSecret":"","ref":"","url":""}` | Sync https://fluxcd.control-plane.io/operator/fluxinstance/#sync-configuration |
 | nameOverride | string | `""` |  |
 
 ## Source Code

--- a/packages/system/fluxcd/charts/flux-instance/templates/instance.yaml
+++ b/packages/system/fluxcd/charts/flux-instance/templates/instance.yaml
@@ -17,6 +17,9 @@ spec:
     version: {{ .Values.instance.distribution.version }}
     registry: {{ .Values.instance.distribution.registry }}
     artifact: {{ .Values.instance.distribution.artifact }}
+    {{- if .Values.instance.distribution.artifactPullSecret }}
+    artifactPullSecret: {{ .Values.instance.distribution.artifactPullSecret }}
+    {{- end }}
     {{- if .Values.instance.distribution.imagePullSecret }}
     imagePullSecret: {{ .Values.instance.distribution.imagePullSecret }}
     {{- end }}
@@ -37,6 +40,7 @@ spec:
   {{- if .Values.instance.sync.url }}
   sync:
     kind: {{ .Values.instance.sync.kind }}
+    interval: {{ .Values.instance.sync.interval }}
     url: {{ .Values.instance.sync.url }}
     ref: {{ .Values.instance.sync.ref }}
     path: {{ .Values.instance.sync.path }}

--- a/packages/system/fluxcd/charts/flux-instance/values.schema.json
+++ b/packages/system/fluxcd/charts/flux-instance/values.schema.json
@@ -74,6 +74,9 @@
                         "artifact": {
                             "type": "string"
                         },
+                        "artifactPullSecret": {
+                            "type": "string"
+                        },
                         "imagePullSecret": {
                             "type": "string"
                         },
@@ -128,6 +131,9 @@
                 },
                 "sync": {
                     "properties": {
+                        "interval": {
+                            "type": "string"
+                        },
                         "kind": {
                             "enum": [
                                 "GitRepository",

--- a/packages/system/fluxcd/charts/flux-instance/values.yaml
+++ b/packages/system/fluxcd/charts/flux-instance/values.yaml
@@ -9,6 +9,7 @@ instance:
     version: "2.x" # @schema required: true
     registry: "ghcr.io/fluxcd" # @schema required: true
     artifact: "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest"
+    artifactPullSecret: ""
     imagePullSecret: ""
   # -- Components https://fluxcd.control-plane.io/operator/fluxinstance/#components-configuration
   components: # @schema item: string; uniqueItems: true; itemEnum: [source-controller,kustomize-controller,helm-controller,notification-controller,image-reflector-controller,image-automation-controller]
@@ -37,6 +38,7 @@ instance:
     shards: [] # @schema item: string
   # -- Sync https://fluxcd.control-plane.io/operator/fluxinstance/#sync-configuration
   sync: # @schema required: false
+    interval: 1m
     kind: "GitRepository" # @schema enum:[GitRepository,OCIRepository,Bucket]
     url: ""
     ref: ""

--- a/packages/system/fluxcd/values.yaml
+++ b/packages/system/fluxcd/values.yaml
@@ -4,7 +4,7 @@ flux-instance:
       networkPolicy: true
       domain: cozy.local # -- default value is overriden in patches
     distribution:
-      version: 2.4.x
+      version: 2.5.x
       registry: ghcr.io/fluxcd
     components:
       - source-controller


### PR DESCRIPTION
A new release of the Flux Operator (v0.15.0) - to go with the newly created Flux v2.5.0 release

(And to go with that, a new version of the flux-instance chart.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced operator capabilities by adding new resource types, including `ResourceSetInputProvider` and `ResourceSet`.
  - Expanded configuration options for deployments, including settings for artifact pull secrets and customizable synchronization intervals.
  - Added support for multitenancy and role-based access control configurations.

- **Documentation**
  - Updated version information and badges to reflect the upgrade to version 0.15.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->