### PR TITLE
Upgrade to Flux 2.5.0

### DIFF
--- a/packages/system/fluxcd/values.yaml
+++ b/packages/system/fluxcd/values.yaml
@@ -4,7 +4,7 @@ flux-instance:
       networkPolicy: true
       domain: cozy.local # -- default value is overriden in patches
     distribution:
-      version: 2.4.x
+      version: 2.5.x
       registry: ghcr.io/fluxcd
     components:
       - source-controller


### PR DESCRIPTION
Flux v2.5 is out:

* https://github.com/fluxcd/flux2/releases/tag/v2.5.0

* https://fluxcd.io/blog/2025/02/flux-v2.5.0/

🎉 🏆 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the FluxCD system from version 2.4.x to 2.5.x for improved integration and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->