### PR TITLE
Increase VMSelect default cpu limit

### DIFF
--- a/packages/extra/monitoring/templates/vm/vmcluster.yaml
+++ b/packages/extra/monitoring/templates/vm/vmcluster.yaml
@@ -22,6 +22,10 @@ spec:
     replicaCount: 2
     resources:
       limits:
+        # if we don't set the cpu limit, victoriametrics-operator will set 500m here, which is ridiculous small
+        # see internal/config/config.go in victoriametrics-operator
+        # 2 vcpu is the bare minimum for **single** Grafana user
+        cpu: {{ . | dig "vmselect" "resources" "limits" "cpu" "2000m" }}
         memory: {{ . | dig "vmselect" "resources" "limits" "memory" "1000Mi" }}
       requests:
         cpu: {{ . | dig "vmselect" "resources" "requests" "cpu" "500m" }}

--- a/packages/extra/monitoring/templates/vm/vmcluster.yaml
+++ b/packages/extra/monitoring/templates/vm/vmcluster.yaml
@@ -10,27 +10,19 @@ spec:
   vminsert:
     replicaCount: 2
     resources:
-      {{- if and (hasKey . "vminsert") (hasKey .vminsert "resources") }}
-      {{- toYaml .vminsert.resources | nindent 6 }}
-      {{- else }}
       limits:
-        memory: 1000Mi
+        memory: {{ . | dig "vminsert" "resources" "limits" "memory" "1000Mi" }}
       requests:
-        cpu: 100m
-        memory: 500Mi
-      {{- end }}
+        cpu: {{ . | dig "vminsert" "resources" "requests" "cpu" "500m" }}
+        memory: {{ . | dig "vminsert" "resources" "requests" "memory" "500Mi" }}
   vmselect:
     replicaCount: 2
     resources:
-      {{- if and (hasKey . "vmselect") (hasKey .vmselect "resources") }}
-      {{- toYaml .vmselect.resources | nindent 6 }}
-      {{- else }}
       limits:
-        memory: 1000Mi
+        memory: {{ . | dig "vmselect" "resources" "limits" "memory" "1000Mi" }}
       requests:
-        cpu: 100m
-        memory: 500Mi
-      {{- end }}
+        cpu: {{ . | dig "vmselect" "resources" "requests" "cpu" "500m" }}
+        memory: {{ . | dig "vmselect" "resources" "requests" "memory" "500Mi" }}
     extraArgs:
       search.maxUniqueTimeseries: "600000"
       vmalert.proxyURL: http://vmalert-{{ .name }}.{{ $.Release.Namespace }}.svc:8080
@@ -48,15 +40,11 @@ spec:
   vmstorage:
     replicaCount: 2
     resources:
-      {{- if and (hasKey . "vmstorage") (hasKey .vmstorage "resources") }}
-      {{- toYaml .vmstorage.resources | nindent 6 }}
-      {{- else }}
       limits:
-        memory: 2048Mi
+        memory: {{ . | dig "vmstorage" "resources" "limits" "memory" "2048Mi" }}
       requests:
-        cpu: 100m
-        memory: 500Mi
-      {{- end }}
+        cpu: {{ . | dig "vmstorage" "resources" "requests" "cpu" "100m" }}
+        memory: {{ . | dig "vmstorage" "resources" "requests" "memory" "500Mi" }}
     storage:
       volumeClaimTemplate:
         spec:

--- a/packages/extra/monitoring/templates/vm/vmcluster.yaml
+++ b/packages/extra/monitoring/templates/vm/vmcluster.yaml
@@ -11,6 +11,9 @@ spec:
     replicaCount: 2
     resources:
       limits:
+        {{- with . | dig "vminsert" "resources" "limits" "cpu" nil }}
+        cpu: {{ . | quote }}
+        {{- end }}
         memory: {{ . | dig "vminsert" "resources" "limits" "memory" "1000Mi" }}
       requests:
         cpu: {{ . | dig "vminsert" "resources" "requests" "cpu" "500m" }}
@@ -41,6 +44,9 @@ spec:
     replicaCount: 2
     resources:
       limits:
+        {{- with . | dig "vmstorage" "resources" "limits" "cpu" nil }}
+        cpu: {{ . | quote }}
+        {{- end }}
         memory: {{ . | dig "vmstorage" "resources" "limits" "memory" "2048Mi" }}
       requests:
         cpu: {{ . | dig "vmstorage" "resources" "requests" "cpu" "100m" }}


### PR DESCRIPTION
1. Now the default `resources` definitions are forwarded to the actual VMCluster if user hasn't specified any.
2. The default cpu limit of 500m that is set by the VM-operator has been increased to 2000m, which is the bare minimum to render a single average Grafana page without glitches.