### PR TITLE
feature/change-severity-for-kube-client-certificate-expiration

### DIFF
--- a/packages/system/monitoring-agents/alerts/kubernetes-system-apiserver.yaml
+++ b/packages/system/monitoring-agents/alerts/kubernetes-system-apiserver.yaml
@@ -19,7 +19,7 @@ spec:
         < 604800
       for: 5m
       labels:
-        severity: warning
+        severity: informational
         exported_instance: '{{ $labels.namespace }}/{{ $labels.pod }}'
         service: kubernetes-system-apiserver
     - alert: KubeClientCertificateExpiration
@@ -34,7 +34,7 @@ spec:
         < 86400
       for: 5m
       labels:
-        severity: critical
+        severity: informational
         exported_instance: '{{ $labels.namespace }}/{{ $labels.pod }}'
         service: kubernetes-system-apiserver
     - alert: KubeAggregatedAPIErrors


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Adjusted monitoring alert severity levels for certificate expiration alerts to report at an informational level instead of warning or critical. 
	- The alert for aggregated API downtime remains at the warning level.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->