### PR TITLE
CAPI-operator: Remove the invalid caBundle

### DIFF
--- a/packages/system/capi-operator/charts/cluster-api-operator/templates/operator-components.yaml
+++ b/packages/system/capi-operator/charts/cluster-api-operator/templates/operator-components.yaml
@@ -13,7 +13,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-operator-webhook-service
           namespace: '{{ .Release.Namespace }}'
@@ -1630,7 +1629,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-operator-webhook-service
           namespace: '{{ .Release.Namespace }}'
@@ -4832,7 +4830,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-operator-webhook-service
           namespace: '{{ .Release.Namespace }}'
@@ -8037,7 +8034,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-operator-webhook-service
           namespace: '{{ .Release.Namespace }}'
@@ -11239,7 +11235,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-operator-webhook-service
           namespace: '{{ .Release.Namespace }}'
@@ -14444,7 +14439,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-operator-webhook-service
           namespace: '{{ .Release.Namespace }}'
@@ -16061,7 +16055,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-operator-webhook-service
           namespace: '{{ .Release.Namespace }}'


### PR DESCRIPTION
Upstream:
- https://github.com/kubernetes-sigs/cluster-api-operator/issues/590
- https://github.com/kubernetes-sigs/cluster-api-operator/pull/591

Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed an outdated internal configuration setting for webhook communication. This cleanup streamlines the system’s setup while keeping public functionality unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->