### PR TITLE
Patch kamaji to hardcode ControlplaneEndpoint port

### DIFF
--- a/packages/system/kamaji/images/kamaji/patches/hardcode-port.diff
+++ b/packages/system/kamaji/images/kamaji/patches/hardcode-port.diff
@@ -1,0 +1,13 @@
+diff --git a/internal/resources/kubeadm_config.go b/internal/resources/kubeadm_config.go
+index ae4cfc0..ec7a7da 100644
+--- a/internal/resources/kubeadm_config.go
++++ b/internal/resources/kubeadm_config.go
+@@ -96,7 +96,7 @@ func (r *KubeadmConfigResource) mutate(ctx context.Context, tenantControlPlane *
+ 			TenantControlPlanePort:          port,
+ 			TenantControlPlaneName:          tenantControlPlane.GetName(),
+ 			TenantControlPlaneNamespace:     tenantControlPlane.GetNamespace(),
+-			TenantControlPlaneEndpoint:      r.getControlPlaneEndpoint(tenantControlPlane.Spec.ControlPlane.Ingress, address, port),
++			TenantControlPlaneEndpoint:      r.getControlPlaneEndpoint(tenantControlPlane.Spec.ControlPlane.Ingress, address, 443),
+ 			TenantControlPlaneCertSANs:      tenantControlPlane.Spec.NetworkProfile.CertSANs,
+ 			TenantControlPlaneClusterDomain: tenantControlPlane.Spec.NetworkProfile.ClusterDomain,
+ 			TenantControlPlanePodCIDR:       tenantControlPlane.Spec.NetworkProfile.PodCIDR,


### PR DESCRIPTION
When the port number is omitted in TenantControlPlane.spec.controlPlane.ingress.hostname, Kamaji defaults to using the assigned port number from TenantControlPlane.status. But usually the internal port is 6443, while we expect to have 443 for external clients of the k8s API. If we explicitly do hostname:443, we run into clastix/kamaji#679, so for a quick hotfix we are temporarily hardcoding 443.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the control plane connection configuration to consistently use the secure port 443, ensuring reliable and predictable endpoint behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->