### PR TITLE
Recreate etcd pods and certificates on update

### DIFF
--- a/packages/extra/etcd/Chart.yaml
+++ b/packages/extra/etcd/Chart.yaml
@@ -3,4 +3,4 @@ name: etcd
 description: Storage for Kubernetes clusters
 icon: /logos/etcd.svg
 type: application
-version: 2.6.0
+version: 2.6.1

--- a/packages/extra/etcd/templates/hook/job.yaml
+++ b/packages/extra/etcd/templates/hook/job.yaml
@@ -1,0 +1,39 @@
+{{- $shouldUpdateCerts := true }}
+{{- $configMap := lookup "v1" "ConfigMap" .Release.Namespace "etcd-deployed-version" }}
+{{- if $configMap }}
+  {{- $deployedVersion := index $configMap "data" "version" }}
+  {{- if $deployedVersion | semverCompare ">= 2.6.1" }}
+    {{- $shouldUpdateCerts = false }}
+  {{- end }}
+{{- end }}
+
+{{- if $shouldUpdateCerts }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: etcd-hook
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        policy.cozystack.io/allow-to-apiserver: "true"
+    spec:
+      serviceAccountName: etcd-hook
+      containers:
+        - name: kubectl
+          image: bitnami/kubectl:latest
+          command:
+          - sh
+          args:
+            - -exc
+            - |-
+              kubectl --namespace={{ .Release.Namespace }} delete secrets etcd-ca-tls etcd-peer-ca-tls 
+              sleep 10
+              kubectl --namespace={{ .Release.Namespace }} delete secrets etcd-client-tls etcd-peer-tls etcd-server-tls
+              kubectl --namespace={{ .Release.Namespace }} delete pods --selector=app.kubernetes.io/instance=etcd,app.kubernetes.io/managed-by=etcd-operator,app.kubernetes.io/name=etcd,cozystack.io/service=etcd
+      restartPolicy: Never
+{{- end }}

--- a/packages/extra/etcd/templates/hook/role.yaml
+++ b/packages/extra/etcd/templates/hook/role.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  name: etcd-hook
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch

--- a/packages/extra/etcd/templates/hook/rolebinding.yaml
+++ b/packages/extra/etcd/templates/hook/rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-hook
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: etcd-hook
+subjects:
+  - kind: ServiceAccount
+    name: etcd-hook
+    namespace: {{ .Release.Namespace | quote }}

--- a/packages/extra/etcd/templates/hook/serviceaccount.yaml
+++ b/packages/extra/etcd/templates/hook/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-hook
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded

--- a/packages/extra/etcd/templates/version.yaml
+++ b/packages/extra/etcd/templates/version.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etcd-deployed-version
+data:
+  version: {{ .Chart.Version }}

--- a/packages/extra/versions_map
+++ b/packages/extra/versions_map
@@ -7,7 +7,8 @@ etcd 2.2.0 5ca8823
 etcd 2.3.0 b908400d
 etcd 2.4.0 cb7b8158
 etcd 2.5.0 861e6c46
-etcd 2.6.0 HEAD
+etcd 2.6.0 a7425b0
+etcd 2.6.1 HEAD
 info 1.0.0 HEAD
 ingress 1.0.0 f642698
 ingress 1.1.0 838bee5d


### PR DESCRIPTION
Since updating from 2.5.0 to 2.6.0 renews all certificates including the trusted CAs for etcd, all etcd pods need a restart. As many people had problems with their etcds post-update, we decided to script the procedure, so the renewal of certs and pods is done automatically and in a predictable order. The hook fires when upgrading from <2.6.0 to >=2.6.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced pre- and post-upgrade tasks for the etcd package.
	- Added supporting resources, including roles, role bindings, service accounts, and a ConfigMap to facilitate smoother upgrade operations.
- **Chores**
	- Updated the application version from 2.6.0 to 2.6.1.
	- Revised version mapping entries to reflect the updated release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->