### PR TITLE
[ingress] Refactor proxy functionality

### DIFF
--- a/packages/extra/ingress/Chart.yaml
+++ b/packages/extra/ingress/Chart.yaml
@@ -3,4 +3,4 @@ name: ingress
 description: NGINX Ingress Controller
 icon: /logos/ingress-nginx.svg
 type: application
-version: 1.5.1
+version: 1.6.0

--- a/packages/extra/ingress/README.md
+++ b/packages/extra/ingress/README.md
@@ -13,4 +13,5 @@
 | `dashboard`       | Should ingress serve Cozystack service dashboard                  | `false` |
 | `cdiUploadProxy`  | Should ingress serve CDI upload proxy                             | `false` |
 | `virtExportProxy` | Should ingress serve KubeVirt export proxy                        | `false` |
+| `api`             | Should ingress serve Cozystack API                                | `true`  |
 

--- a/packages/extra/ingress/templates/api.yaml
+++ b/packages/extra/ingress/templates/api.yaml
@@ -1,0 +1,29 @@
+{{- $cozyConfig := lookup "v1" "ConfigMap" "cozy-system" "cozystack" }}
+{{- $issuerType := (index $cozyConfig.data "clusterissuer") | default "http01" }}
+
+{{- $myNS := lookup "v1" "Namespace" "" .Release.Namespace }}
+{{- $host := index $myNS.metadata.annotations "namespace.cozystack.io/host" }}
+
+{{- if .Values.api }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+  name: api-{{ .Release.Namespace }}
+  namespace: default
+spec:
+  ingressClassName: {{ .Release.Namespace }}
+  rules:
+  - host: api.{{ $host }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: kubernetes
+            port:
+              number: 443
+        path: /
+        pathType: Prefix
+{{- end }}

--- a/packages/extra/ingress/templates/cdi-uploadproxy.yaml
+++ b/packages/extra/ingress/templates/cdi-uploadproxy.yaml
@@ -10,11 +10,7 @@ kind: Ingress
 metadata:
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    {{- if eq $issuerType "cloudflare" }} 
-    {{- else }}
-    acme.cert-manager.io/http01-ingress-class: {{ .Release.Namespace }}
-    {{- end }}
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
   name: cdi-uploadproxy-{{ .Release.Namespace }}
   namespace: cozy-kubevirt-cdi
 spec:
@@ -30,8 +26,4 @@ spec:
               number: 443
         path: /
         pathType: Prefix
-  tls:
-  - hosts:
-    - cdi-uploadproxy.{{ $host }}
-    secretName: cdi-uploadproxy-{{ .Release.Namespace }}-tls
 {{- end }}

--- a/packages/extra/ingress/templates/vm-exportproxy.yaml
+++ b/packages/extra/ingress/templates/vm-exportproxy.yaml
@@ -10,11 +10,7 @@ kind: Ingress
 metadata:
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    {{- if eq $issuerType "cloudflare" }} 
-    {{- else }}
-    acme.cert-manager.io/http01-ingress-class: {{ .Release.Namespace }}
-    {{- end }}
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
   name: virt-exportproxy-{{ .Release.Namespace }}
   namespace: cozy-kubevirt
 spec:
@@ -30,8 +26,4 @@ spec:
               number: 443
         path: /
         pathType: ImplementationSpecific
-  tls:
-  - hosts:
-    virt-exportproxy.{{ $host }}
-    secretName: virt-exportproxy-{{ .Release.Namespace }}-tls
 {{- end }}

--- a/packages/extra/ingress/values.schema.json
+++ b/packages/extra/ingress/values.schema.json
@@ -40,6 +40,11 @@
             "type": "boolean",
             "description": "Should ingress serve KubeVirt export proxy",
             "default": false
+        },
+        "api": {
+            "type": "boolean",
+            "description": "Should ingress serve Cozystack API",
+            "default": true
         }
     }
 }

--- a/packages/extra/ingress/values.yaml
+++ b/packages/extra/ingress/values.yaml
@@ -33,3 +33,6 @@ cdiUploadProxy: false
 
 ## @param virtExportProxy Should ingress serve KubeVirt export proxy
 virtExportProxy: false
+
+## @param api Should ingress serve Cozystack API
+api: true

--- a/packages/extra/versions_map
+++ b/packages/extra/versions_map
@@ -19,7 +19,7 @@ ingress 1.2.0 28fca4ef
 ingress 1.3.0 fde4bcfa
 ingress 1.4.0 fd240701
 ingress 1.5.0 93bdf411
-ingress 1.5.1 HEAD
+ingress 1.6.0 HEAD
 monitoring 1.0.0 d7cfa53c
 monitoring 1.1.0 25221fdc
 monitoring 1.2.0 f81be075


### PR DESCRIPTION
- [ingress] Introduce Kubernetes API proxy
- [ingress] Fix vmExportProxy ingress
- [ingress] Refactor cdiUploadProxy ingress


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable option to enable or disable serving the Cozystack API through ingress, defaulting to enabled.
  - Introduced a new ingress resource for securely routing API traffic via HTTPS passthrough.

- **Improvements**
  - Updated ingress resources to use SSL passthrough for secure connections, removing dependency on cert-manager for TLS termination.

- **Documentation**
  - Updated documentation to reflect the new API parameter and its default behavior.

- **Chores**
  - Bumped the ingress chart version to 1.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->