### PR TITLE
(air gapped): disable fluxcd artifact by default

### DIFF
--- a/packages/system/fluxcd/values.yaml
+++ b/packages/system/fluxcd/values.yaml
@@ -4,6 +4,7 @@ flux-instance:
       networkPolicy: true
       domain: cozy.local # -- default value is overriden in patches
     distribution:
+      artifact: ""
       version: 2.5.x
       registry: ghcr.io/fluxcd
     components:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a new configuration option for artifact specification in the distribution settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->