### PR TITLE
[build] system/metallb: multiarch support

### DIFF
--- a/packages/system/metallb/Makefile
+++ b/packages/system/metallb/Makefile
@@ -16,6 +16,8 @@ image-controller image-speaker:
 	$(eval VERSION := $(shell yq '.appVersion' charts/metallb/Chart.yaml))
 	docker buildx build images/metallb \
 		--provenance false \
+		--builder=$(BUILDER) \
+		--platform=$(PLATFORM) \
 		--target $(TARGET) \
 		--build-arg VERSION=$(VERSION) \
 		--tag $(REGISTRY)/metallb-$(TARGET):$(VERSION) \
@@ -23,8 +25,8 @@ image-controller image-speaker:
 		--cache-to type=inline \
 		--metadata-file images/$(TARGET).json \
 		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack"
-		--load=1
+		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
+		--load=$(LOAD)
 	REPOSITORY="$(REGISTRY)/metallb-$(TARGET)" \
 		yq -i '.metallb.$(TARGET).image.repository = strenv(REPOSITORY)' values.yaml
 	TAG=$(VERSION)@$$(yq e '."containerimage.digest"' images/$(TARGET).json -o json -r) \


### PR DESCRIPTION
Add support for metallb multiarch build.

Part of #519 and a follow-up to PR #945 (issue #909)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved Docker build process for image-controller and image-speaker to allow dynamic control over image loading and enhanced build configuration consistency. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->