### PR TITLE
Re-update kamaji to latest version

### DIFF
--- a/packages/system/kamaji/images/kamaji/Dockerfile
+++ b/packages/system/kamaji/images/kamaji/Dockerfile
@@ -1,7 +1,7 @@
 # Build the manager binary
 FROM golang:1.24 as builder
 
-ARG VERSION=edge-25.3.2
+ARG VERSION=edge-25.4.1
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
It was updated: https://github.com/cozystack/cozystack/commit/4ecf492cd4fa8f74e63b24f69842e3df9e73f59b

Then partially reverted during merge: https://github.com/cozystack/cozystack/commit/d550a67f1933eeaa4484ad773186b919c8afc704

Please take a look if it should be updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Kamaji component to use version edge-25.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->