### PR TITLE
tenant-root-values-from-config

### DIFF
--- a/packages/core/platform/templates/apps.yaml
+++ b/packages/core/platform/templates/apps.yaml
@@ -16,6 +16,19 @@
 {{- $host = $tenantRoot.spec.values.host }}
 {{- else }}
 {{- end }}
+
+{{/* Handle tenant-root features */}}
+{{- $features := dict "ingress" false "monitoring" false "etcd" false "isolated" false }}
+{{- if and $cozyConfig.data (hasKey $cozyConfig.data "tenant-root") }}
+  {{- $enabledFeatures := splitList "," (index $cozyConfig.data "tenant-root") }}
+  {{- range $feature := $enabledFeatures }}
+    {{- $feature = trim $feature }}
+    {{- if hasKey $features $feature }}
+      {{- $_ := set $features $feature true }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
 ---
 apiVersion: v1
 kind: Namespace
@@ -54,6 +67,7 @@ spec:
         namespace: cozy-public
   values:
     host: "{{ $host }}"
+    {{- toYaml $features | nindent 4 }}
   dependsOn:
   {{- range $x := $bundle.releases }}
   {{- if has $x.name (list "cilium" "kubeovn") }}


### PR DESCRIPTION
Capability to define in cozy-system coma separated string of enabled features on tenant-root namespace
https://github.com/cozystack/cozystack/issues/1021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for dynamically enabling features such as ingress, monitoring, etcd, and isolated based on configuration settings. Enabled features are now reflected in the application deployment values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->