### PR TITLE
Use global scope for .Release object

### DIFF
--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -211,14 +211,14 @@ spec:
       - ["LABEL=ephemeral", "/ephemeral"]
       - ["/ephemeral/kubelet", "/var/lib/kubelet", "none", "bind,nofail"]
       - ["/ephemeral/containerd", "/var/lib/containerd", "none", "bind,nofail"]
-      {{- $sec := lookup "v1" "Secret" .Release.Namespace (printf "%s-patch-containerd" .Release.Name) }}
+      {{- $sec := lookup "v1" "Secret" $.Release.Namespace (printf "%s-patch-containerd" $.Release.Name) }}
       {{- if $sec }}
       files:
         {{- range $key, $_ := $sec.data }}
         - path: /etc/containerd/certs.d/{{ trimSuffix ".toml" $key }}/hosts.toml
           contentFrom:
             secret:
-              name: {{ .Release.Name }}-patch-containerd
+              name: {{ $.Release.Name }}-patch-containerd
               key: {{ $key }}
           permissions: "0400"
         {{- end }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of secret references in Kubernetes cluster templates to ensure correct retrieval and usage of release-specific secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->