### PR TITLE
[Tests] Add Kafka, Redis

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -155,7 +155,7 @@ jobs:
   test_apps:
     strategy:
       matrix:
-        app: [clickhouse,kubernetes,mysql,postgres,virtualmachine,vminstance]
+        app: [clickhouse,kafka,kubernetes,mysql,postgres,redis,virtualmachine,vminstance]
     name: Test ${{ matrix.app }}
     runs-on: [self-hosted]
     needs: setup_tenant

--- a/hack/e2e-apps/kafka.bats
+++ b/hack/e2e-apps/kafka.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+
+@test "Create Kafka" {
+  name='test'
+  kubectl create -f- <<EOF
+apiVersion: apps.cozystack.io/v1alpha1
+kind: Kafka
+metadata:
+  name: $name
+  namespace: tenant-test
+spec:
+  external: false
+  kafka:
+    size: 10Gi
+    replicas: 2
+    storageClass: ""
+    resources: {}
+    resourcesPreset: "nano"
+  zookeeper:
+    size: 5Gi
+    replicas: 2
+    storageClass: ""
+    resources:
+    resourcesPreset: "nano"
+  topics:
+    - name: testResults
+      partitions: 1
+      replicas: 2
+      config:
+        min.insync.replicas: 2
+    - name: testOrders
+      config:
+        cleanup.policy: compact
+        segment.ms: 3600000
+        max.compaction.lag.ms: 5400000
+        min.insync.replicas: 2
+      partitions: 1
+      replicas: 2
+EOF
+  sleep 5
+  kubectl -n tenant-test wait hr kafka-$name --timeout=30s --for=condition=ready
+  kubectl wait kafkas -n tenant-test test --timeout=60s --for=condition=ready
+  timeout 60 sh -ec "until kubectl -n tenant-test get pvc data-kafka-$name-zookeeper-0; do sleep 10; done"
+  kubectl -n tenant-test wait pvc data-kafka-$name-zookeeper-0 --timeout=50s --for=jsonpath='{.status.phase}'=Bound
+  timeout 40 sh -ec "until kubectl -n tenant-test get svc kafka-$name-zookeeper-client -o jsonpath='{.spec.ports[0].port}' | grep -q '2181'; do sleep 10; done"
+  timeout 40 sh -ec "until kubectl -n tenant-test get svc kafka-$name-zookeeper-nodes -o jsonpath='{.spec.ports[*].port}' | grep -q '2181 2888 3888'; do sleep 10; done"
+  timeout 80 sh -ec "until kubectl -n tenant-test get endpoints kafka-$name-zookeeper-nodes -o jsonpath='{.subsets[*].addresses[0].ip}' | grep -q '[0-9]'; do sleep 10; done"
+  kubectl -n tenant-test delete kafka.apps.cozystack.io $name
+  kubectl -n tenant-test delete pvc data-kafka-$name-zookeeper-0
+  kubectl -n tenant-test delete pvc data-kafka-$name-zookeeper-1
+}

--- a/hack/e2e-apps/postgres.bats
+++ b/hack/e2e-apps/postgres.bats
@@ -50,4 +50,5 @@ EOF
   timeout 120 sh -ec "until kubectl -n tenant-test get endpoints postgres-$name-ro -o jsonpath='{.subsets[*].addresses[*].ip}' | grep -q '[0-9]'; do sleep 10; done"
   timeout 120 sh -ec "until kubectl -n tenant-test get endpoints postgres-$name-rw -o jsonpath='{.subsets[*].addresses[*].ip}' | grep -q '[0-9]'; do sleep 10; done"
   kubectl -n tenant-test delete postgreses.apps.cozystack.io $name
+  kubectl -n tenant-test delete job.batch/postgres-$name-init-job
 }

--- a/hack/e2e-apps/redis.bats
+++ b/hack/e2e-apps/redis.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+@test "Create Redis" {
+  name='test'
+  kubectl create -f- <<EOF
+apiVersion: apps.cozystack.io/v1alpha1
+kind: Redis
+metadata:
+  name: $name
+  namespace: tenant-test
+spec:
+  external: false
+  size: 1Gi
+  replicas: 2
+  storageClass: ""
+  authEnabled: true
+  resources: {}
+  resourcesPreset: "nano"
+EOF
+  sleep 5
+  kubectl -n tenant-test wait hr redis-$name --timeout=20s --for=condition=ready
+  kubectl -n tenant-test wait pvc redisfailover-persistent-data-rfr-redis-$name-0 --timeout=50s --for=jsonpath='{.status.phase}'=Bound
+  kubectl -n tenant-test wait deploy rfs-redis-$name --timeout=90s --for=condition=available
+  kubectl -n tenant-test wait sts rfr-redis-$name --timeout=90s --for=jsonpath='{.status.replicas}'=2
+  kubectl -n tenant-test delete redis.apps.cozystack.io $name
+}


### PR DESCRIPTION
Add extra tests into e2e apps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added automated end-to-end tests for Kafka and Redis resources in Kubernetes, including creation, readiness verification, and cleanup. These tests ensure that the Kafka and Redis clusters are properly deployed and their components are functioning as expected.
	- Updated PostgreSQL test to improve cleanup by removing initialization jobs after resource deletion.
- **Chores**
	- Expanded the pull request testing workflow to include Kafka and Redis applications in the test matrix for broader coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->