### PR TITLE
[bugfix] up pgdump version

### DIFF
--- a/packages/apps/postgres/Chart.yaml
+++ b/packages/apps/postgres/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0
+version: 0.14.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/postgres/images/postgres-backup/Dockerfile
+++ b/packages/apps/postgres/images/postgres-backup/Dockerfile
@@ -1,2 +1,2 @@
-FROM alpine:3.20
-RUN apk add --no-cache postgresql16-client uuidgen restic
+FROM alpine:3.22
+RUN apk add --no-cache postgresql17-client uuidgen restic

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -87,7 +87,8 @@ postgres 0.10.1 93bdf411
 postgres 0.11.0 f9f8bb2f
 postgres 0.12.0 6130f43d
 postgres 0.12.1 632224a3
-postgres 0.14.0 HEAD
+postgres 0.14.0 62cb694d
+postgres 0.14.1 HEAD
 rabbitmq 0.1.0 263e47be
 rabbitmq 0.2.0 53f2365e
 rabbitmq 0.3.0 6c5cf5bf


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the PostgreSQL client version in the backup image from 16 to 17.
  - Incremented the postgres application chart version to 0.14.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->