### PR TITLE
Save a list of observed images after workflow

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -290,8 +290,8 @@ jobs:
           done
           echo "✅ The task completed successfully after $attempt attempts"
 
-  collect_report:
-    name: Collect report
+  collect_debug_information:
+    name: Collect debug information
     runs-on: [self-hosted]
     needs: [test_apps]
     if: ${{ always() }}
@@ -313,10 +313,21 @@ jobs:
           name: cozyreport
           path: /tmp/${{ env.SANDBOX_NAME }}/_out/cozyreport.tgz
 
+      - name: Collect images list
+        run: |
+          cd /tmp/$SANDBOX_NAME
+          make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME collect-images
+
+      - name: Upload image list
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-list
+          path: /tmp/${{ env.SANDBOX_NAME }}/_out/images.txt
+
   cleanup:
     name: Tear down environment
     runs-on: [self-hosted]
-    needs: [collect_report]
+    needs: [collect_debug_information]
     if: ${{ always() && needs.test_apps.result == 'success' }}
 
     steps:
@@ -329,15 +340,6 @@ jobs:
       - name: Set sandbox ID
         run: echo "SANDBOX_NAME=cozy-e2e-sandbox-$(echo "${GITHUB_REPOSITORY}:${GITHUB_WORKFLOW}:${GITHUB_REF}" | sha256sum | cut -c1-10)" >> $GITHUB_ENV
 
-      - name: List images used
-        run: make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME list-images
-
-      - name: Upload image list
-        uses: actions/upload-artifact@v4
-        with:
-          name: image-list
-          path: images.txt
- 
       - name: Tear down sandbox
         run: make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME delete
 

--- a/hack/collect-images.sh
+++ b/hack/collect-images.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+for node in 11 12 13; do
+  talosctl -n 192.168.123.${node} -e 192.168.123.${node} images ls >> images.tmp
+  talosctl -n 192.168.123.${node} -e 192.168.123.${node} images --namespace system ls >> images.tmp
+done
+
+while read _ name sha _ ; do echo $sha $name ; done < images.tmp | sort -u > images.txt

--- a/hack/list-images.sh
+++ b/hack/list-images.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-for node in 11 12 13; do
-  talosctl -n 192.168.123.${node} -e 192.168.123.${node} images ls >> /workspace/images.tmp
-  talosctl -n 192.168.123.${node} -e 192.168.123.${node} images --namespace system ls >> /workspace/images.tmp
-done
-
-while read _ name sha _ ; do echo $sha $name ; done < /workspace/images.tmp | sort -u > /workspace/images.txt

--- a/packages/core/testing/Makefile
+++ b/packages/core/testing/Makefile
@@ -55,6 +55,11 @@ collect-report: ## Collect the test report from the sandbox.
 	mkdir -p ../../../_out
 	docker cp "${SANDBOX_NAME}:/workspace/cozyreport.tgz" ../../../_out/cozyreport.tgz
 
+collect-images: ## Collect the list of images used in the sandbox.
+	docker exec "${SANDBOX_NAME}" sh -c 'cd /workspace && hack/collect-images.sh'
+	mkdir -p ../../../_out
+	docker cp "${SANDBOX_NAME}":/workspace/images.txt ../../../_out/images.txt
+
 delete: ## Remove sandbox from existing Kubernetes cluster.
 	docker rm -f "${SANDBOX_NAME}" || true
 
@@ -72,7 +77,3 @@ apply: delete
 		"$$(yq .e2e.image values.yaml)" \
 		--timeout 30m
 	docker cp "${ROOT_DIR}/." "${SANDBOX_NAME}":/workspace
-
-list-images:
-	docker exec "${SANDBOX_NAME}" sh -c 'cd /workspace && hack/list-images.sh'
-	docker cp "${SANDBOX_NAME}":/workspace/images.txt ../../../images.txt


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a process to list images used in the environment before deletion during cleanup operations.
- **Chores**
  - Enhanced environment cleanup workflow with improved visibility into used images.
  - Introduced a shared writable directory between host and container for better file management during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->