### PR TITLE
[apps] Add enum of allowed values to `resourcePreset` in all applications

### DIFF
--- a/packages/apps/clickhouse/Makefile
+++ b/packages/apps/clickhouse/Makefile
@@ -5,6 +5,7 @@ include ../../../scripts/package.mk
 
 generate:
 	readme-generator -v values.yaml -s values.schema.json -r README.md
+	yq -i -o json --indent 4 '.properties.resourcesPreset.enum = ["none", "nano", "micro", "small", "medium", "large", "xlarge", "2xlarge"]' values.schema.json
 
 image:
 	docker buildx build images/clickhouse-backup \

--- a/packages/apps/clickhouse/values.schema.json
+++ b/packages/apps/clickhouse/values.schema.json
@@ -85,7 +85,17 @@
         "resourcesPreset": {
             "type": "string",
             "description": "Use a common resources preset when `resources` is not set explicitly.",
-            "default": "small"
+            "default": "small",
+            "enum": [
+                "none",
+                "nano",
+                "micro",
+                "small",
+                "medium",
+                "large",
+                "xlarge",
+                "2xlarge"
+            ]
         }
     }
 }

--- a/packages/apps/ferretdb/Makefile
+++ b/packages/apps/ferretdb/Makefile
@@ -2,3 +2,4 @@ include ../../../scripts/package.mk
 
 generate:
 	readme-generator -v values.yaml -s values.schema.json -r README.md
+	yq -i -o json --indent 4 '.properties.resourcesPreset.enum = ["none", "nano", "micro", "small", "medium", "large", "xlarge", "2xlarge"]' values.schema.json

--- a/packages/apps/ferretdb/values.schema.json
+++ b/packages/apps/ferretdb/values.schema.json
@@ -90,7 +90,17 @@
         "resourcesPreset": {
             "type": "string",
             "description": "Use a common resources preset when `resources` is not set explicitly. (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge)",
-            "default": "nano"
+            "default": "nano",
+            "enum": [
+                "none",
+                "nano",
+                "micro",
+                "small",
+                "medium",
+                "large",
+                "xlarge",
+                "2xlarge"
+            ]
         }
     }
 }

--- a/packages/apps/http-cache/Makefile
+++ b/packages/apps/http-cache/Makefile
@@ -23,6 +23,8 @@ image-nginx:
 
 generate:
 	readme-generator -v values.yaml -s values.schema.json -r README.md
+	yq -i -o json --indent 4 '.properties.haproxy.properties.resourcesPreset.enum = ["none", "nano", "micro", "small", "medium", "large", "xlarge", "2xlarge"]' values.schema.json
+	yq -i -o json --indent 4 '.properties.nginx.properties.resourcesPreset.enum = ["none", "nano", "micro", "small", "medium", "large", "xlarge", "2xlarge"]' values.schema.json
 
 update:
 	tag=$$(git ls-remote --tags --sort="v:refname" https://github.com/chrislim2888/IP2Location-C-Library | awk -F'[/^]' 'END{print $$3}') && \

--- a/packages/apps/http-cache/values.schema.json
+++ b/packages/apps/http-cache/values.schema.json
@@ -33,7 +33,17 @@
                 "resourcesPreset": {
                     "type": "string",
                     "description": "Use a common resources preset when `resources` is not set explicitly. (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge)",
-                    "default": "nano"
+                    "default": "nano",
+                    "enum": [
+                        "none",
+                        "nano",
+                        "micro",
+                        "small",
+                        "medium",
+                        "large",
+                        "xlarge",
+                        "2xlarge"
+                    ]
                 }
             }
         },
@@ -53,7 +63,17 @@
                 "resourcesPreset": {
                     "type": "string",
                     "description": "Use a common resources preset when `resources` is not set explicitly. (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge)",
-                    "default": "nano"
+                    "default": "nano",
+                    "enum": [
+                        "none",
+                        "nano",
+                        "micro",
+                        "small",
+                        "medium",
+                        "large",
+                        "xlarge",
+                        "2xlarge"
+                    ]
                 }
             }
         },

--- a/packages/apps/kafka/Makefile
+++ b/packages/apps/kafka/Makefile
@@ -2,3 +2,5 @@ include ../../../scripts/package.mk
 
 generate:
 	readme-generator -v values.yaml -s values.schema.json -r README.md
+	yq -i -o json --indent 4 '.properties.kafka.properties.resourcesPreset.enum = ["none", "nano", "micro", "small", "medium", "large", "xlarge", "2xlarge"]' values.schema.json
+	yq -i -o json --indent 4 '.properties.zookeeper.properties.resourcesPreset.enum = ["none", "nano", "micro", "small", "medium", "large", "xlarge", "2xlarge"]' values.schema.json

--- a/packages/apps/kafka/values.schema.json
+++ b/packages/apps/kafka/values.schema.json
@@ -33,7 +33,17 @@
                 "resourcesPreset": {
                     "type": "string",
                     "description": "Use a common resources preset when `resources` is not set explicitly. (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge)",
-                    "default": "small"
+                    "default": "small",
+                    "enum": [
+                        "none",
+                        "nano",
+                        "micro",
+                        "small",
+                        "medium",
+                        "large",
+                        "xlarge",
+                        "2xlarge"
+                    ]
                 }
             }
         },
@@ -63,7 +73,17 @@
                 "resourcesPreset": {
                     "type": "string",
                     "description": "Use a common resources preset when `resources` is not set explicitly. (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge)",
-                    "default": "small"
+                    "default": "small",
+                    "enum": [
+                        "none",
+                        "nano",
+                        "micro",
+                        "small",
+                        "medium",
+                        "large",
+                        "xlarge",
+                        "2xlarge"
+                    ]
                 }
             }
         },

--- a/packages/apps/mysql/Makefile
+++ b/packages/apps/mysql/Makefile
@@ -5,6 +5,7 @@ include ../../../scripts/package.mk
 
 generate:
 	readme-generator -v values.yaml -s values.schema.json -r README.md
+	yq -i -o json --indent 4 '.properties.resourcesPreset.enum = ["none", "nano", "micro", "small", "medium", "large", "xlarge", "2xlarge"]' values.schema.json
 
 image:
 	docker buildx build images/mariadb-backup \

--- a/packages/apps/mysql/values.schema.json
+++ b/packages/apps/mysql/values.schema.json
@@ -75,7 +75,17 @@
         "resourcesPreset": {
             "type": "string",
             "description": "Use a common resources preset when `resources` is not set explicitly. (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge)",
-            "default": "nano"
+            "default": "nano",
+            "enum": [
+                "none",
+                "nano",
+                "micro",
+                "small",
+                "medium",
+                "large",
+                "xlarge",
+                "2xlarge"
+            ]
         }
     }
 }

--- a/packages/apps/nats/Makefile
+++ b/packages/apps/nats/Makefile
@@ -2,3 +2,4 @@ include ../../../scripts/package.mk
 
 generate:
 	readme-generator -v values.yaml -s values.schema.json -r README.md
+	yq -i -o json --indent 4 '.properties.resourcesPreset.enum = ["none", "nano", "micro", "small", "medium", "large", "xlarge", "2xlarge"]' values.schema.json

--- a/packages/apps/nats/values.schema.json
+++ b/packages/apps/nats/values.schema.json
@@ -55,7 +55,17 @@
         "resourcesPreset": {
             "type": "string",
             "description": "Use a common resources preset when `resources` is not set explicitly. (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge)",
-            "default": "nano"
+            "default": "nano",
+            "enum": [
+                "none",
+                "nano",
+                "micro",
+                "small",
+                "medium",
+                "large",
+                "xlarge",
+                "2xlarge"
+            ]
         }
     }
 }

--- a/packages/apps/postgres/Makefile
+++ b/packages/apps/postgres/Makefile
@@ -2,3 +2,4 @@ include ../../../scripts/package.mk
 
 generate:
 	readme-generator -v values.yaml -s values.schema.json -r README.md
+	yq -i -o json --indent 4 '.properties.resourcesPreset.enum = ["none", "nano", "micro", "small", "medium", "large", "xlarge", "2xlarge"]' values.schema.json

--- a/packages/apps/postgres/values.schema.json
+++ b/packages/apps/postgres/values.schema.json
@@ -125,7 +125,17 @@
         "resourcesPreset": {
             "type": "string",
             "description": "Use a common resources preset when `resources` is not set explicitly. (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge)",
-            "default": "micro"
+            "default": "micro",
+            "enum": [
+                "none",
+                "nano",
+                "micro",
+                "small",
+                "medium",
+                "large",
+                "xlarge",
+                "2xlarge"
+            ]
         }
     }
 }

--- a/packages/apps/rabbitmq/Makefile
+++ b/packages/apps/rabbitmq/Makefile
@@ -2,3 +2,4 @@ include ../../../scripts/package.mk
 
 generate:
 	readme-generator -v values.yaml -s values.schema.json -r README.md
+	yq -i -o json --indent 4 '.properties.resourcesPreset.enum = ["none", "nano", "micro", "small", "medium", "large", "xlarge", "2xlarge"]' values.schema.json

--- a/packages/apps/rabbitmq/values.schema.json
+++ b/packages/apps/rabbitmq/values.schema.json
@@ -35,7 +35,17 @@
         "resourcesPreset": {
             "type": "string",
             "description": "Use a common resources preset when `resources` is not set explicitly. (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge)",
-            "default": "nano"
+            "default": "nano",
+            "enum": [
+                "none",
+                "nano",
+                "micro",
+                "small",
+                "medium",
+                "large",
+                "xlarge",
+                "2xlarge"
+            ]
         }
     }
 }

--- a/packages/apps/redis/Makefile
+++ b/packages/apps/redis/Makefile
@@ -2,3 +2,4 @@ include ../../../scripts/package.mk
 
 generate:
 	readme-generator -v values.yaml -s values.schema.json -r README.md
+	yq -i -o json --indent 4 '.properties.resourcesPreset.enum = ["none", "nano", "micro", "small", "medium", "large", "xlarge", "2xlarge"]' values.schema.json

--- a/packages/apps/redis/values.schema.json
+++ b/packages/apps/redis/values.schema.json
@@ -35,7 +35,17 @@
         "resourcesPreset": {
             "type": "string",
             "description": "Use a common resources preset when `resources` is not set explicitly. (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge)",
-            "default": "nano"
+            "default": "nano",
+            "enum": [
+                "none",
+                "nano",
+                "micro",
+                "small",
+                "medium",
+                "large",
+                "xlarge",
+                "2xlarge"
+            ]
         }
     }
 }

--- a/packages/apps/tcp-balancer/Makefile
+++ b/packages/apps/tcp-balancer/Makefile
@@ -1,6 +1,7 @@
 include ../../../scripts/package.mk
 
 generate:
-	readme-generator -v values.yaml -s values.schema.json.tmp -r README.md
-	cat values.schema.json.tmp | jq '.properties.httpAndHttps.properties.mode.enum = ["tcp","tcp-with-proxy"]' > values.schema.json
+	readme-generator -v values.yaml -s values.schema.json -r README.md
+	yq -i -o json --indent 2 '.properties.httpAndHttps.properties.mode.enum = ["tcp","tcp-with-proxy"]' values.schema.json
+	yq -i -o json --indent 2 '.properties.resourcesPreset.enum = ["none", "nano", "micro", "small", "medium", "large", "xlarge", "2xlarge"]' values.schema.json
 	rm -f values.schema.json.tmp

--- a/packages/apps/tcp-balancer/values.schema.json
+++ b/packages/apps/tcp-balancer/values.schema.json
@@ -66,7 +66,17 @@
     "resourcesPreset": {
       "type": "string",
       "description": "Use a common resources preset when `resources` is not set explicitly. (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge)",
-      "default": "nano"
+      "default": "nano",
+      "enum": [
+        "none",
+        "nano",
+        "micro",
+        "small",
+        "medium",
+        "large",
+        "xlarge",
+        "2xlarge"
+      ]
     }
   }
 }

--- a/packages/apps/vpn/Makefile
+++ b/packages/apps/vpn/Makefile
@@ -2,3 +2,4 @@ include ../../../scripts/package.mk
 
 generate:
 	readme-generator -v values.yaml -s values.schema.json -r README.md
+	yq -i -o json --indent 4 '.properties.resourcesPreset.enum = ["none", "nano", "micro", "small", "medium", "large", "xlarge", "2xlarge"]' values.schema.json

--- a/packages/apps/vpn/values.schema.json
+++ b/packages/apps/vpn/values.schema.json
@@ -33,7 +33,17 @@
         "resourcesPreset": {
             "type": "string",
             "description": "Use a common resources preset when `resources` is not set explicitly. (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge)",
-            "default": "nano"
+            "default": "nano",
+            "enum": [
+                "none",
+                "nano",
+                "micro",
+                "small",
+                "medium",
+                "large",
+                "xlarge",
+                "2xlarge"
+            ]
         }
     }
 }


### PR DESCRIPTION
It was present in some apps, such as managed kubernetes, but was missing in others.

bitnami/readme-generator removes enums after re-generating README, so now we patch them back using `yq` in Makefiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Resource preset options are now strictly limited to a predefined set of values across multiple apps, ensuring only valid selections such as "none", "nano", "micro", "small", "medium", "large", "xlarge", and "2xlarge" can be used.
- **Bug Fixes**
	- Improved validation for resource presets to prevent invalid entries and enhance consistency in configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->