### PR TITLE
[cozy-lib, bug] divf by cpu ratio, not mulf

### DIFF
--- a/packages/library/cozy-lib/templates/_resourcepresets.tpl
+++ b/packages/library/cozy-lib/templates/_resourcepresets.tpl
@@ -13,32 +13,26 @@ These presets are for basic testing and not meant to be used in production
 {{- define "cozy-lib.resources.preset" -}}
 {{-   $cpuAllocationRatio := include "cozy-lib.resources.cpuAllocationRatio" . | float64 }}
 {{-   $args := index . 0 }}
+{{-   $global := index . 1 }}
 
 {{-   $baseCPU := dict
-        "nano"    (dict "requests" (dict "cpu" "100m" ))
-        "micro"   (dict "requests" (dict "cpu" "250m" ))
-        "small"   (dict "requests" (dict "cpu" "500m" ))
-        "medium"  (dict "requests" (dict "cpu" "500m" ))
-        "large"   (dict "requests" (dict "cpu" "1"    ))
-        "xlarge"  (dict "requests" (dict "cpu" "2"    ))
-        "2xlarge" (dict "requests" (dict "cpu" "4"    ))
+        "nano"    (dict "cpu" "100m" )
+        "micro"   (dict "cpu" "250m" )
+        "small"   (dict "cpu" "500m" )
+        "medium"  (dict "cpu" "500m" )
+        "large"   (dict "cpu" "1"    )
+        "xlarge"  (dict "cpu" "2"    )
+        "2xlarge" (dict "cpu" "4"    )
 }}
 {{-   $baseMemory := dict
-        "nano"    (dict "requests" (dict "memory" "128Mi" ))
-        "micro"   (dict "requests" (dict "memory" "256Mi" ))
-        "small"   (dict "requests" (dict "memory" "512Mi" ))
-        "medium"  (dict "requests" (dict "memory" "1Gi"   ))
-        "large"   (dict "requests" (dict "memory" "2Gi"   ))
-        "xlarge"  (dict "requests" (dict "memory" "4Gi"   ))
-        "2xlarge" (dict "requests" (dict "memory" "8Gi"   ))
+        "nano"    (dict "memory" "128Mi" )
+        "micro"   (dict "memory" "256Mi" )
+        "small"   (dict "memory" "512Mi" )
+        "medium"  (dict "memory" "1Gi"   )
+        "large"   (dict "memory" "2Gi"   )
+        "xlarge"  (dict "memory" "4Gi"   )
+        "2xlarge" (dict "memory" "8Gi"   )
 }}
-
-{{-   range $baseCPU }}
-{{-     $_ := set . "limits" (dict "cpu" (include "cozy-lib.resources.toFloat" .requests.cpu | float64 | mulf $cpuAllocationRatio | toString)) }}
-{{-   end }}
-{{-   range $baseMemory }}
-{{-     $_ := set . "limits" (dict "memory" .requests.memory) }}
-{{-   end }}
 
 {{- $presets := dict 
   "nano" (dict 
@@ -72,7 +66,8 @@ These presets are for basic testing and not meant to be used in production
  }}
 {{- $_ := merge $presets $baseCPU $baseMemory }}
 {{- if hasKey $presets $args -}}
-{{- index $presets $args | toYaml -}}
+{{- $flatDict := index $presets $args }}
+{{- include "cozy-lib.resources.sanitize" (list $flatDict $global) }}
 {{- else -}}
 {{- printf "ERROR: Preset key '%s' invalid. Allowed values are %s" . (join "," (keys $presets)) | fail -}}
 {{- end -}}

--- a/packages/library/cozy-lib/templates/_resources.tpl
+++ b/packages/library/cozy-lib/templates/_resources.tpl
@@ -34,7 +34,7 @@
   to have equal requests and limits, except CPU, where the limit is increased
   by a factor of the CPU allocation ratio. The template expects to receive a
   dict {"requests":{...}, "limits":{...}} as input, e.g.
-  {{ include "cozy-lib.resources.sanitize" .Values.resources }}.
+  {{ include "cozy-lib.resources.sanitize" list (.Values.resources $) }}.
   Example input:
   ==============
   limits:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the structure of resource presets for improved clarity and processing.
  * Adjusted template logic to streamline resource handling and removed previous resource limit calculations.
  * Modified template parameters to enhance flexibility in resource processing.
* **Chores**
  * Improved internal template invocation for better compatibility with resource data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->