### PR TITLE
[keycloak, cozy-lib] Calculate Java heap params

### DIFF
--- a/packages/system/keycloak/charts/cozy-lib
+++ b/packages/system/keycloak/charts/cozy-lib
@@ -1,0 +1,1 @@
+../../../library/cozy-lib/

--- a/packages/system/keycloak/templates/sts.yaml
+++ b/packages/system/keycloak/templates/sts.yaml
@@ -68,6 +68,12 @@ spec:
           args:
             - start
           env:
+            {{- with (fromYaml (include "cozy-lib.resources.defaultingSanitize" (list "small" (default dict .Values.resources.limits) $))) }}
+            {{- with (mergeOverwrite . $.Values.resources ) }}
+            - name: JAVA_OPTS_KC_HEAP
+              value: {{ include "cozy-lib.resources.javaHeap" . }}
+            {{- end }}
+            {{- end }}
             - name: KC_METRICS_ENABLED
               value: "true"
             - name: KC_LOG_LEVEL


### PR DESCRIPTION
## What this PR does

This patch passes Java heap parameters to Keycloak to prevent OOM errors when the JVM lacks compatibility with cgroups v2 and fails to recognize container memory requests and limits. A new function is introduced in cozy-lib to calculate the heap parameters from requests and limits, setting Xmx to 75% of the memory limit and Xms to the lesser of the memory request or 25% of the memory limits.

## Release note

```release-note
[keycloak] Calculate and pass Java heap parameters explicitly to prevent OOM errors.
[cozy-lib] Introduce helper function to calculate Java heap params based on memory requests and limits.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic calculation and injection of Java heap size settings for the Keycloak container, based on resource requests and limits.
* **Improvements**
  * Enhanced resource handling to ensure all resource values are consistently formatted and sanitized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->