### PR TITLE
[feat] add Hetzner L4 Balancer

### DIFF
--- a/packages/system/hetzner-ccm/Chart.yaml
+++ b/packages/system/hetzner-ccm/Chart.yaml
@@ -1,0 +1,2 @@
+name: hetzner-ccm
+version: 1.26.0  # Placeholder, the actual version will be automatically set during the build process

--- a/packages/system/hetzner-ccm/Makefile
+++ b/packages/system/hetzner-ccm/Makefile
@@ -1,0 +1,10 @@
+export NAME=hetzner-ccm
+export NAMESPACE=kube-system
+
+include ../../../scripts/package.mk
+
+update:
+	rm -rf charts
+	helm repo add hcloud https://charts.hetzner.cloud
+	helm repo update hcloud
+	helm pull hcloud/hcloud-cloud-controller-manager --untar --untardir charts

--- a/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/.helmignore
+++ b/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/.snapshots/default.yaml
+++ b/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/.snapshots/default.yaml
@@ -1,0 +1,96 @@
+---
+# Source: hcloud-cloud-controller-manager/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hcloud-cloud-controller-manager
+  namespace: kube-system
+---
+# Source: hcloud-cloud-controller-manager/templates/clusterrolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "system:hcloud-cloud-controller-manager"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: hcloud-cloud-controller-manager
+    namespace: kube-system
+---
+# Source: hcloud-cloud-controller-manager/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hcloud-cloud-controller-manager
+  namespace: kube-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: 'hcloud-hccm'
+      app.kubernetes.io/name: 'hcloud-cloud-controller-manager'
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: 'hcloud-hccm'
+        app.kubernetes.io/name: 'hcloud-cloud-controller-manager'
+    spec:
+      serviceAccountName: hcloud-cloud-controller-manager
+      dnsPolicy: Default
+      tolerations:
+        # Allow HCCM itself to schedule on nodes that have not yet been initialized by HCCM.
+        - key: "node.cloudprovider.kubernetes.io/uninitialized"
+          value: "true"
+          effect: "NoSchedule"
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+
+        # Allow HCCM to schedule on control plane nodes.
+        - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
+          operator: Exists
+        - key: "node-role.kubernetes.io/control-plane"
+          effect: NoSchedule
+          operator: Exists
+
+        - key: "node.kubernetes.io/not-ready"
+          effect: "NoExecute"
+      containers:
+        - name: hcloud-cloud-controller-manager
+          args:
+            - "--allow-untagged-cloud"
+            - "--cloud-provider=hcloud"
+            - "--route-reconciliation-period=30s"
+            - "--webhook-secure-port=0"
+            - "--leader-elect=false"
+          env:
+            - name: HCLOUD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: token
+                  name: hcloud
+            - name: ROBOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: robot-password
+                  name: hcloud
+                  optional: true
+            - name: ROBOT_USER
+              valueFrom:
+                secretKeyRef:
+                  key: robot-user
+                  name: hcloud
+                  optional: true
+          image: docker.io/hetznercloud/hcloud-cloud-controller-manager:v1.26.0 # x-releaser-pleaser-version
+          ports:
+            - name: metrics
+              containerPort: 8233
+          resources:
+            requests:
+              cpu: 100m
+              memory: 50Mi
+      priorityClassName: "system-cluster-critical"

--- a/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/.snapshots/full.daemonset.yaml
+++ b/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/.snapshots/full.daemonset.yaml
@@ -1,0 +1,113 @@
+---
+# Source: hcloud-cloud-controller-manager/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hcloud-cloud-controller-manager
+  namespace: kube-system
+---
+# Source: hcloud-cloud-controller-manager/templates/clusterrolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "system:hcloud-cloud-controller-manager"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: hcloud-cloud-controller-manager
+    namespace: kube-system
+---
+# Source: hcloud-cloud-controller-manager/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: hcloud-cloud-controller-manager
+  namespace: kube-system
+spec:
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: 'hcloud-hccm'
+      app.kubernetes.io/name: 'hcloud-cloud-controller-manager'
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: 'hcloud-hccm'
+        app.kubernetes.io/name: 'hcloud-cloud-controller-manager'
+        pod-label: pod-label
+      annotations:
+        pod-annotation: pod-annotation
+    spec:
+      serviceAccountName: hcloud-cloud-controller-manager
+      dnsPolicy: Default
+      tolerations:
+        # Allow HCCM itself to schedule on nodes that have not yet been initialized by HCCM.
+        - key: "node.cloudprovider.kubernetes.io/uninitialized"
+          value: "true"
+          effect: "NoSchedule"
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+
+        # Allow HCCM to schedule on control plane nodes.
+        - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
+          operator: Exists
+        - key: "node-role.kubernetes.io/control-plane"
+          effect: NoSchedule
+          operator: Exists
+
+        - key: "node.kubernetes.io/not-ready"
+          effect: "NoExecute"
+        
+        - effect: NoSchedule
+          key: example-key
+          operator: Exists
+      nodeSelector:
+        
+        foo: bar
+      containers:
+        - name: hcloud-cloud-controller-manager
+          command:
+            - "/bin/hcloud-cloud-controller-manager"
+            - "--allow-untagged-cloud"
+            - "--cloud-provider=hcloud"
+            - "--route-reconciliation-period=30s"
+            - "--webhook-secure-port=0"
+          env:
+            - name: HCLOUD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: token
+                  name: hcloud
+            - name: ROBOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: robot-password
+                  name: hcloud
+                  optional: true
+            - name: ROBOT_USER
+              valueFrom:
+                secretKeyRef:
+                  key: robot-user
+                  name: hcloud
+                  optional: true
+          image: docker.io/hetznercloud/hcloud-cloud-controller-manager:v1.26.0 # x-releaser-pleaser-version
+          ports:
+            - name: metrics
+              containerPort: 8233
+          resources:
+            requests:
+              cpu: 100m
+              memory: 50Mi
+          volumeMounts:
+            - mountPath: /var/run/secrets/hcloud
+              name: token-volume
+              readOnly: true
+      priorityClassName: system-cluster-critical
+      volumes:
+        - name: token-volume
+          secret:
+            secretName: hcloud-token

--- a/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/.snapshots/full.values.daemonset.yaml
+++ b/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/.snapshots/full.values.daemonset.yaml
@@ -1,0 +1,51 @@
+kind: DaemonSet
+
+monitoring:
+  podMonitor:
+    labels:
+      environment: staging
+    annotations:
+      release: kube-prometheus-stack
+
+additionalTolerations:
+  - key: "example-key"
+    operator: "Exists"
+    effect: "NoSchedule"
+
+nodeSelector:
+  foo: bar
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+                - antarctica-east1
+                - antarctica-west1
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 1
+        preference:
+          matchExpressions:
+            - key: another-node-label-key
+              operator: In
+              values:
+                - another-node-label-value
+
+podLabels:
+  pod-label: pod-label
+
+podAnnotations:
+  pod-annotation: pod-annotation
+
+extraVolumeMounts:
+  - name: token-volume
+    readOnly: true
+    mountPath: /var/run/secrets/hcloud
+
+extraVolumes:
+  - name: token-volume
+    secret:
+      secretName: hcloud-token

--- a/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/Chart.yaml
+++ b/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: hcloud-cloud-controller-manager
+type: application
+version: 1.26.0

--- a/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/README.md
+++ b/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/README.md
@@ -1,0 +1,61 @@
+# hcloud-cloud-controller-manager Helm Chart
+
+This Helm chart is the recommended installation method for [hcloud-cloud-controller-manager](https://github.com/hetznercloud/hcloud-cloud-controller-manager).
+
+## Quickstart
+
+First, [install Helm 3](https://helm.sh/docs/intro/install/).
+
+The following snippet will deploy hcloud-cloud-controller-manager to the kube-system namespace.
+
+```sh
+# Sync the Hetzner Cloud helm chart repository to your local computer.
+helm repo add hcloud https://charts.hetzner.cloud
+helm repo update hcloud
+
+# Install the latest version of the hcloud-cloud-controller-manager chart.
+helm install hccm hcloud/hcloud-cloud-controller-manager -n kube-system
+
+# If you want to install hccm with private networking support (see main Deployment guide for more info).
+helm install hccm hcloud/hcloud-cloud-controller-manager -n kube-system --set networking.enabled=true
+```
+
+Please note that additional configuration is necessary. See the main [Deployment](https://github.com/hetznercloud/hcloud-cloud-controller-manager#deployment) guide.
+
+If you're unfamiliar with Helm it would behoove you to peep around the documentation. Perhaps start with the [Quickstart Guide](https://helm.sh/docs/intro/quickstart/)?
+
+### Upgrading from static manifests
+
+If you previously installed hcloud-cloud-controller-manager with this command:
+
+```sh
+kubectl apply -f https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm.yaml
+```
+
+You can uninstall that same deployment, by running the following command:
+
+```sh
+kubectl delete -f https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm.yaml
+```
+
+Then you can follow the Quickstart installation steps above.
+
+## Configuration
+
+This chart aims to be highly flexible. Please review the [values.yaml](./values.yaml) for a full list of configuration options.
+
+If you've already deployed hccm using the `helm install` command above, you can easily change configuration values:
+
+```sh
+helm upgrade hccm hcloud/hcloud-cloud-controller-manager -n kube-system --set monitoring.podMonitor.enabled=true
+```
+
+### Multiple replicas / DaemonSet
+
+You can choose between different deployment options. By default the chart will deploy a single replica as a Deployment.
+
+If you want to change the replica count you can adjust the value `replicaCount` inside the helm values.
+If you have more than 1 replica leader election will be turned on automatically.
+
+If you want to deploy hccm as a DaemonSet you can set `kind` to `DaemonSet` inside the values.
+To adjust on which nodes the DaemonSet should be deployed you can use the `nodeSelector` and `additionalTolerations` values.

--- a/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/templates/NOTES.txt
+++ b/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/templates/NOTES.txt
@@ -1,0 +1,5 @@
+{{ if (and $.Values.monitoring.enabled $.Values.monitoring.podMonitor.enabled) }}
+{{ if not ($.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") }}
+WARNING: monitoring.podMonitoring.enabled=true but PodMonitor could not be installed: the CRD was not detected.
+{{ end }}
+{{ end }}

--- a/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/templates/_helpers.tpl
+++ b/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "hcloud-cloud-controller-manager.name" -}}
+{{- $.Values.nameOverride | default $.Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "hcloud-cloud-controller-manager.selectorLabels" -}}
+{{- tpl (toYaml $.Values.selectorLabels) $ }}
+{{- end }}

--- a/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/templates/clusterrolebinding.yaml
+++ b/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.rbac.create }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "system:{{ include "hcloud-cloud-controller-manager.name" . }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "hcloud-cloud-controller-manager.name" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/templates/daemonset.yaml
+++ b/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/templates/daemonset.yaml
@@ -1,0 +1,108 @@
+{{- if eq $.Values.kind "DaemonSet" }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "hcloud-cloud-controller-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      {{- include "hcloud-cloud-controller-manager.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "hcloud-cloud-controller-manager.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
+    spec:
+    {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "hcloud-cloud-controller-manager.name" . }}
+      dnsPolicy: Default
+      tolerations:
+        # Allow HCCM itself to schedule on nodes that have not yet been initialized by HCCM.
+        - key: "node.cloudprovider.kubernetes.io/uninitialized"
+          value: "true"
+          effect: "NoSchedule"
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+
+        # Allow HCCM to schedule on control plane nodes.
+        - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
+          operator: Exists
+        - key: "node-role.kubernetes.io/control-plane"
+          effect: NoSchedule
+          operator: Exists
+
+        - key: "node.kubernetes.io/not-ready"
+          effect: "NoExecute"
+
+        {{- if gt (len .Values.additionalTolerations) 0 }}
+        {{ toYaml .Values.additionalTolerations | nindent 8 }}
+        {{- end }}
+
+      {{- if gt (len .Values.nodeSelector) 0 }}
+      nodeSelector:
+        {{ toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+
+      {{- if $.Values.networking.enabled }}
+      hostNetwork: true
+      {{- end }}
+      containers:
+        - name: hcloud-cloud-controller-manager
+          command:
+            - "/bin/hcloud-cloud-controller-manager"
+            {{- range $key, $value := $.Values.args }}
+            {{- if not (eq $value nil) }}
+            - "--{{ $key }}{{ if $value }}={{ $value }}{{ end }}"
+            {{- end }}
+            {{- end }}
+            {{- if $.Values.networking.enabled }}
+            - "--allocate-node-cidrs=true"
+            - "--cluster-cidr={{ $.Values.networking.clusterCIDR }}"
+            {{- end }}
+          env:
+            {{- range $key, $value := $.Values.env }}
+            - name: {{ $key }}
+              {{- tpl (toYaml $value) $ | nindent 14 }}
+            {{- end }}
+            {{- if $.Values.networking.enabled }}
+            - name: HCLOUD_NETWORK
+              {{- tpl (toYaml $.Values.networking.network) $ | nindent 14 }}
+            {{- end }}
+            {{- if not $.Values.monitoring.enabled }}
+            - name: HCLOUD_METRICS_ENABLED
+              value: "false"
+            {{- end }}
+            {{- if $.Values.robot.enabled }}
+            - name: ROBOT_ENABLED
+              value: "true"
+            {{- end }}
+          image: {{ $.Values.image.repository }}:{{ tpl $.Values.image.tag . }} # x-releaser-pleaser-version
+          ports:
+            {{- if $.Values.monitoring.enabled }}
+            - name: metrics
+              containerPort: 8233
+            {{- end }}
+          resources:
+            {{- toYaml $.Values.resources | nindent 12 }}
+          {{- with .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      priorityClassName: system-cluster-critical
+      {{- with .Values.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/templates/deployment.yaml
+++ b/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/templates/deployment.yaml
@@ -1,0 +1,118 @@
+{{- if eq $.Values.kind "Deployment" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "hcloud-cloud-controller-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      {{- include "hcloud-cloud-controller-manager.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "hcloud-cloud-controller-manager.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
+    spec:
+    {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "hcloud-cloud-controller-manager.name" . }}
+      dnsPolicy: Default
+      tolerations:
+        # Allow HCCM itself to schedule on nodes that have not yet been initialized by HCCM.
+        - key: "node.cloudprovider.kubernetes.io/uninitialized"
+          value: "true"
+          effect: "NoSchedule"
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+
+        # Allow HCCM to schedule on control plane nodes.
+        - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
+          operator: Exists
+        - key: "node-role.kubernetes.io/control-plane"
+          effect: NoSchedule
+          operator: Exists
+
+        - key: "node.kubernetes.io/not-ready"
+          effect: "NoExecute"
+
+        {{- if gt (len .Values.additionalTolerations) 0 }}
+        {{ toYaml .Values.additionalTolerations | nindent 8 }}
+        {{- end }}
+
+      {{- if gt (len .Values.nodeSelector) 0 }}
+      nodeSelector:
+        {{ toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+
+      {{- if gt (len .Values.affinity) 0 }}
+      affinity:
+        {{ toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
+
+      {{- if $.Values.networking.enabled }}
+      hostNetwork: true
+      {{- end }}
+      containers:
+        - name: hcloud-cloud-controller-manager
+          args:
+            {{- range $key, $value := $.Values.args }}
+            {{- if not (eq $value nil) }}
+            - "--{{ $key }}{{ if $value }}={{ $value }}{{ end }}"
+            {{- end }}
+            {{- end }}
+            {{- if $.Values.networking.enabled }}
+            - "--allocate-node-cidrs=true"
+            - "--cluster-cidr={{ $.Values.networking.clusterCIDR }}"
+            {{- end }}
+            {{- if (eq (int $.Values.replicaCount) 1) }}
+            - "--leader-elect=false"
+            {{- end }}
+          env:
+            {{- range $key, $value := $.Values.env }}
+            - name: {{ $key }}
+              {{- tpl (toYaml $value) $ | nindent 14 }}
+            {{- end }}
+            {{- if $.Values.networking.enabled }}
+            - name: HCLOUD_NETWORK
+              {{- tpl (toYaml $.Values.networking.network) $ | nindent 14 }}
+            {{- end }}
+            {{- if not $.Values.monitoring.enabled }}
+            - name: HCLOUD_METRICS_ENABLED
+              value: "false"
+            {{- end }}
+            {{- if $.Values.robot.enabled }}
+            - name: ROBOT_ENABLED
+              value: "true"
+            {{- end }}
+          image: {{ $.Values.image.repository }}:{{ tpl $.Values.image.tag . }} # x-releaser-pleaser-version
+          ports:
+            {{- if $.Values.monitoring.enabled }}
+            - name: metrics
+              containerPort: 8233
+            {{- end }}
+          resources:
+            {{- toYaml $.Values.resources | nindent 12 }}
+          {{- with .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- with .Values.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/templates/podmonitor.yaml
+++ b/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/templates/podmonitor.yaml
@@ -1,0 +1,22 @@
+{{ if (and $.Values.monitoring.enabled $.Values.monitoring.podMonitor.enabled) }}
+{{ if $.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor" }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "hcloud-cloud-controller-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- with $.Values.monitoring.podMonitor.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- range $key, $value := .Values.monitoring.podMonitor.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  {{- tpl (toYaml $.Values.monitoring.podMonitor.spec) $ | nindent 2 }}
+  selector:
+    matchLabels:
+      {{- include "hcloud-cloud-controller-manager.selectorLabels" . | nindent 6 }}
+{{ end }}
+{{ end }}

--- a/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/templates/serviceaccount.yaml
+++ b/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "hcloud-cloud-controller-manager.name" . }}
+  namespace: {{ .Release.Namespace }}

--- a/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/values.yaml
+++ b/packages/system/hetzner-ccm/charts/hcloud-cloud-controller-manager/values.yaml
@@ -1,0 +1,154 @@
+# hccm program command line arguments.
+# The following flags are managed by the chart and should *not* be set directly here:
+# --allocate-node-cidrs
+# --cluster-cidr
+# --leader-elect
+args:
+  cloud-provider: hcloud
+  allow-untagged-cloud: ""
+
+  # Read issue #395 to understand how changes to this value affect you.
+  # https://github.com/hetznercloud/hcloud-cloud-controller-manager/issues/395
+  route-reconciliation-period: 30s
+
+  # We do not use the webhooks feature and there is no need to bind a port that is unused.
+  # https://github.com/kubernetes/kubernetes/issues/120043
+  # https://github.com/hetznercloud/hcloud-cloud-controller-manager/issues/492
+  webhook-secure-port: "0"
+
+# Change deployment kind from "Deployment" to "DaemonSet"
+kind: Deployment
+
+# change replicaCount (only used when kind is "Deployment")
+replicaCount: 1
+
+# hccm environment variables
+env:
+  # The following variables are managed by the chart and should *not* be set here:
+  # HCLOUD_METRICS_ENABLED - see monitoring.enabled
+  # HCLOUD_NETWORK - see networking.enabled
+  # ROBOT_ENABLED - see robot.enabled
+
+  # You can also use a file to provide secrets to the hcloud-cloud-controller-manager.
+  # This is currently possible for HCLOUD_TOKEN, ROBOT_USER, and ROBOT_PASSWORD.
+  # Use the env var appended with _FILE (e.g. HCLOUD_TOKEN_FILE) and set the value to the file path that should be read
+  # The file must be provided externally (e.g. via secret injection).
+  # Example:
+  # HCLOUD_TOKEN_FILE:
+  #   value: "/etc/hetzner/token"
+  # to disable reading the token from the secret you have to disable the original env var:
+  # HCLOUD_TOKEN: null
+
+  HCLOUD_TOKEN:
+    valueFrom:
+      secretKeyRef:
+        name: hcloud
+        key: token
+
+  ROBOT_USER:
+    valueFrom:
+      secretKeyRef:
+        name: hcloud
+        key: robot-user
+        optional: true
+  ROBOT_PASSWORD:
+    valueFrom:
+      secretKeyRef:
+        name: hcloud
+        key: robot-password
+        optional: true
+
+image:
+  repository: docker.io/hetznercloud/hcloud-cloud-controller-manager
+  tag: "v{{ $.Chart.Version }}"
+  # Optionally specify an array of imagePullSecrets.
+  # Secrets must be manually created in the namespace.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  # e.g:
+  # pullSecrets:
+  #   - myRegistryKeySecretName
+  #
+  pullSecrets: []
+
+monitoring:
+  # When enabled, the hccm Pod will serve metrics on port :8233
+  enabled: true
+  podMonitor:
+    # When enabled (and metrics.enabled=true), a PodMonitor will be deployed to scrape metrics.
+    # The PodMonitor [1] CRD must already exist in the target cluster.
+    enabled: false
+    # PodMonitor Labels
+    labels: {}
+    #   release: kube-prometheus-stack
+    # PodMonitor Annotations
+    annotations: {}
+    # PodMonitorSpec to be deployed. The "selector" field is set elsewhere and should *not* be used here.
+    # https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.PodMonitorSpec
+    spec:
+      podMetricsEndpoints:
+        - port: metrics
+
+nameOverride: ~
+
+networking:
+  # If enabled, hcloud-ccm will be deployed with networking support.
+  enabled: false
+  # If networking is enabled, clusterCIDR must match the PodCIDR subnet your cluster has been configured with.
+  # The default "10.244.0.0/16" assumes you're using Flannel with default configuration.
+  clusterCIDR: 10.244.0.0/16
+  network:
+    valueFrom:
+      secretKeyRef:
+        name: hcloud
+        key: network
+
+# Resource requests for the deployed hccm Pod.
+resources:
+  requests:
+    cpu: 100m
+    memory: 50Mi
+
+selectorLabels:
+  app.kubernetes.io/name: '{{ include "hcloud-cloud-controller-manager.name" $ }}'
+  app.kubernetes.io/instance: "{{ $.Release.Name }}"
+
+additionalTolerations: []
+
+# nodeSelector:
+#   node-role.kubernetes.io/control-plane: ""
+nodeSelector: {}
+
+# Set the affinity for pods. (Only works with kind=Deployment)
+affinity: {}
+
+# pods priorityClassName
+# ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption
+priorityClassName: "system-cluster-critical"
+
+robot:
+  # Set to true to enable support for Robot (Dedicated) servers.
+  enabled: false
+
+rbac:
+  # Create a cluster role binding with admin access for the service account.
+  create: true
+
+podLabels: {}
+
+podAnnotations: {}
+
+# Mounts the specified volume to the hcloud-cloud-controller-manager container.
+extraVolumeMounts: []
+# # Example
+# extraVolumeMounts:
+#   - name: token-volume
+#     readOnly: true
+#     mountPath: /var/run/secrets/hcloud
+
+# Adds extra volumes to the pod.
+extraVolumes: []
+# # Example
+# extraVolumes:
+#   - name: token-volume
+#     secret:
+#       secretName: hcloud-token

--- a/packages/system/hetzner-ccm/values.yaml
+++ b/packages/system/hetzner-ccm/values.yaml
@@ -1,0 +1,172 @@
+# hccm program command line arguments.
+# The following flags are managed by the chart and should *not* be set directly here:
+# --allocate-node-cidrs
+# --cluster-cidr
+# --leader-elect
+args:
+  cloud-provider: hcloud
+  allow-untagged-cloud: ""
+
+  # Read issue #395 to understand how changes to this value affect you.
+  # https://github.com/hetznercloud/hcloud-cloud-controller-manager/issues/395
+  route-reconciliation-period: 30s
+
+  # We do not use the webhooks feature and there is no need to bind a port that is unused.
+  # https://github.com/kubernetes/kubernetes/issues/120043
+  # https://github.com/hetznercloud/hcloud-cloud-controller-manager/issues/492
+  webhook-secure-port: "0"
+
+
+# Change deployment kind from "Deployment" to "DaemonSet"
+kind: Deployment
+
+
+# change replicaCount (only used when kind is "Deployment")
+replicaCount: 1
+
+
+# hccm environment variables
+env:
+  # The following variables are managed by the chart and should *not* be set here:
+  # HCLOUD_METRICS_ENABLED - see monitoring.enabled
+  # HCLOUD_NETWORK - see networking.enabled
+  # ROBOT_ENABLED - see robot.enabled
+
+  # You can also use a file to provide secrets to the hcloud-cloud-controller-manager.
+  # This is currently possible for HCLOUD_TOKEN, ROBOT_USER, and ROBOT_PASSWORD.
+  # Use the env var appended with _FILE (e.g. HCLOUD_TOKEN_FILE) and set the value to the file path that should be read
+  # The file must be provided externally (e.g. via secret injection).
+  # Example:
+  # HCLOUD_TOKEN_FILE:
+  #   value: "/etc/hetzner/token"
+  # to disable reading the token from the secret you have to disable the original env var:
+  # HCLOUD_TOKEN: null
+
+  HCLOUD_TOKEN:
+    valueFrom:
+      secretKeyRef:
+        name: hcloud
+        key: token
+
+  ROBOT_USER:
+    valueFrom:
+      secretKeyRef:
+        name: hcloud
+        key: robot-user
+        optional: true
+  ROBOT_PASSWORD:
+    valueFrom:
+      secretKeyRef:
+        name: hcloud
+        key: robot-password
+        optional: true
+
+
+image:
+  repository: docker.io/hetznercloud/hcloud-cloud-controller-manager
+  tag: "v{{ $.Chart.Version }}"
+  # Optionally specify an array of imagePullSecrets.
+  # Secrets must be manually created in the namespace.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  # e.g:
+  # pullSecrets:
+  #   - myRegistryKeySecretName
+  #
+  pullSecrets: []
+
+
+monitoring:
+  # When enabled, the hccm Pod will serve metrics on port :8233
+  enabled: false
+  podMonitor:
+    # When enabled (and metrics.enabled=true), a PodMonitor will be deployed to scrape metrics.
+    # The PodMonitor [1] CRD must already exist in the target cluster.
+    enabled: false
+    # PodMonitor Labels
+    labels: {}
+    #   release: kube-prometheus-stack
+    # PodMonitor Annotations
+    annotations: {}
+    # PodMonitorSpec to be deployed. The "selector" field is set elsewhere and should *not* be used here.
+    # https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.PodMonitorSpec
+    spec:
+      podMetricsEndpoints:
+        - port: metrics
+
+
+nameOverride: "hetzner-ccm"
+
+
+networking:
+  # If enabled, hcloud-ccm will be deployed with networking support.
+  enabled: false
+  # If networking is enabled, clusterCIDR must match the PodCIDR subnet your cluster has been configured with.
+  # The default "10.244.0.0/16" assumes you're using Flannel with default configuration.
+  clusterCIDR: 10.244.0.0/16
+  network:
+    valueFrom:
+      secretKeyRef:
+        name: hcloud
+        key: network
+
+
+# Resource requests for the deployed hccm Pod.
+resources:
+  cpu: ""
+  memory: ""
+
+
+selectorLabels:
+  app.kubernetes.io/name: '{{ include "hcloud-cloud-controller-manager.name" $ }}'
+  app.kubernetes.io/instance: "{{ $.Release.Name }}"
+
+
+additionalTolerations: []
+
+
+# nodeSelector:
+#   node-role.kubernetes.io/control-plane: ""
+nodeSelector: {}
+
+
+# Set the affinity for pods. (Only works with kind=Deployment)
+affinity: {}
+
+
+# pods priorityClassName
+# ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption
+priorityClassName: "system-cluster-critical"
+
+
+robot:
+  # Set to true to enable support for Robot (Dedicated) servers.
+  enabled: false
+
+
+rbac:
+  # Create a cluster role binding with admin access for the service account.
+  create: true
+
+
+podLabels: {}
+
+
+podAnnotations: {}
+
+
+# Mounts the specified volume to the hcloud-cloud-controller-manager container.
+extraVolumeMounts: []
+# # Example
+# extraVolumeMounts:
+#   - name: token-volume
+#     readOnly: true
+#     mountPath: /var/run/secrets/hcloud
+
+
+# Adds extra volumes to the pod.
+extraVolumes: []
+# # Example
+# extraVolumes:
+#   - name: token-volume
+#     secret:
+#       secretName: hcloud-token

--- a/packages/system/hetzner-robotlb/Chart.yaml
+++ b/packages/system/hetzner-robotlb/Chart.yaml
@@ -1,0 +1,2 @@
+name: hetzner-robotlb
+version: 0.1.3  # Placeholder, the actual version will be automatically set during the build process

--- a/packages/system/hetzner-robotlb/Makefile
+++ b/packages/system/hetzner-robotlb/Makefile
@@ -1,0 +1,9 @@
+export NAME=hetzner-robotlb
+export NAMESPACE=kube-system
+
+include ../../../scripts/package.mk
+
+update:
+	rm -rf charts
+	mkdir -p charts
+	helm pull oci://ghcr.io/intreecom/charts/robotlb --untar --untardir charts

--- a/packages/system/hetzner-robotlb/charts/robotlb/.helmignore
+++ b/packages/system/hetzner-robotlb/charts/robotlb/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/packages/system/hetzner-robotlb/charts/robotlb/Chart.yaml
+++ b/packages/system/hetzner-robotlb/charts/robotlb/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 0.0.5
+description: A Helm chart for robotlb (loadbalancer on hetzner cloud).
+name: robotlb
+type: application
+version: 0.1.3

--- a/packages/system/hetzner-robotlb/charts/robotlb/templates/NOTES.txt
+++ b/packages/system/hetzner-robotlb/charts/robotlb/templates/NOTES.txt
@@ -1,0 +1,4 @@
+The RobotLB Operator was successfully installed.
+Please follow the readme to create loadbalanced services.
+
+README: https://github.com/intreecom/robotlb

--- a/packages/system/hetzner-robotlb/charts/robotlb/templates/_helpers.tpl
+++ b/packages/system/hetzner-robotlb/charts/robotlb/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "robotlb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "robotlb.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "robotlb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "robotlb.labels" -}}
+helm.sh/chart: {{ include "robotlb.chart" . }}
+{{ include "robotlb.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "robotlb.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "robotlb.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "robotlb.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "robotlb.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/packages/system/hetzner-robotlb/charts/robotlb/templates/deployment.yaml
+++ b/packages/system/hetzner-robotlb/charts/robotlb/templates/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "robotlb.fullname" . }}
+  labels:
+    {{- include "robotlb.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "robotlb.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "robotlb.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "robotlb.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /usr/local/bin/robotlb
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.envs }}
+          env:
+            {{- range $key, $val := . }}
+              - name: {{ $key | quote }}
+                value: {{ $val | quote }}
+            {{ end -}}
+          {{- end }}
+          {{- with .Values.existingSecrets }}
+          envFrom:
+            {{- range $val := . }}
+            - secretRef:
+                name: {{ $val | quote }}
+            {{ end -}}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/packages/system/hetzner-robotlb/charts/robotlb/templates/role.yaml
+++ b/packages/system/hetzner-robotlb/charts/robotlb/templates/role.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "robotlb.fullname" . }}-cr
+rules:
+ {{- toYaml .Values.serviceAccount.permissions | nindent 2 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "robotlb.fullname" . }}-crb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "robotlb.fullname" . }}-cr
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "robotlb.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/packages/system/hetzner-robotlb/charts/robotlb/templates/serviceaccount.yaml
+++ b/packages/system/hetzner-robotlb/charts/robotlb/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "robotlb.serviceAccountName" . }}
+  labels:
+    {{- include "robotlb.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/packages/system/hetzner-robotlb/charts/robotlb/values.yaml
+++ b/packages/system/hetzner-robotlb/charts/robotlb/values.yaml
@@ -1,0 +1,73 @@
+# Default values for robotlb.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: ghcr.io/intreecom/robotlb
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+envs:
+  ROBOTLB_LOG_LEVEL: "INFO"
+
+existingSecrets: []
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  # This is a list of cluster permissions to apply to the service account.
+  # By default it grants all permissions.
+  permissions:
+  - apiGroups: [""]
+    resources: [services, services/status]
+    verbs: [get, list, patch, update, watch]
+  - apiGroups: [""]
+    resources: [nodes, pods]
+    verbs: [get, list, watch]
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/packages/system/hetzner-robotlb/values.yaml
+++ b/packages/system/hetzner-robotlb/values.yaml
@@ -1,0 +1,81 @@
+image:
+  repository: ghcr.io/intreecom/robotlb
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: "hetzner-robotlb"
+
+
+envs:
+  ROBOTLB_LOG_LEVEL: "INFO"
+
+
+existingSecrets: []
+
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  # This is a list of cluster permissions to apply to the service account.
+  # By default it grants all permissions.
+  permissions:
+  - apiGroups: [""]
+    resources: [services, services/status]
+    verbs: [get, list, patch, update, watch]
+  - apiGroups: [""]
+    resources: [nodes, pods]
+    verbs: [get, list, watch]
+
+
+podAnnotations: {}
+podLabels: {}
+
+
+# fsGroup: 2000
+podSecurityContext:
+  {}
+
+
+# capabilities:
+#   drop:
+#   - ALL
+# readOnlyRootFilesystem: true
+# runAsNonRoot: true
+# runAsUser: 1000
+securityContext:
+  {}
+
+
+## Number of robotlb replicas
+replicas: 1
+
+# We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+# resources:
+#   cpu: 100m
+#   memory: 128Mi
+resources:
+  cpu: ""
+  memory: ""
+
+
+nodeSelector: {}
+
+
+tolerations: []
+
+
+affinity: {}


### PR DESCRIPTION
Add Hetzner's CCM and RobotLB to deploy / manage L4 from cozystack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Helm charts for deploying Hetzner Cloud Controller Manager (hcloud-cloud-controller-manager) and Hetzner RobotLB.
  * Added customizable configuration files, values, and templates for both controllers, supporting flexible deployment options (Deployment or DaemonSet).
  * Enabled RBAC, service account, monitoring, and networking configuration for both components.
  * Provided post-installation notes and comprehensive documentation for installation, configuration, and upgrade guidance.

* **Documentation**
  * Added detailed README files for both Helm charts, including installation and upgrade instructions, configuration options, and deployment examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->