### PR TITLE
[cozystack-api] Fix singular name for cozystack resources

### DIFF
--- a/pkg/registry/apps/application/rest.go
+++ b/pkg/registry/apps/application/rest.go
@@ -76,6 +76,7 @@ type REST struct {
 	gvr           schema.GroupVersionResource
 	gvk           schema.GroupVersionKind
 	kindName      string
+	singularName  string
 	releaseConfig config.ReleaseConfig
 }
 
@@ -93,6 +94,7 @@ func NewREST(dynamicClient dynamic.Interface, config *config.Resource) *REST {
 			Version: "v1alpha1",
 		}.WithKind(config.Application.Kind),
 		kindName:      config.Application.Kind,
+		singularName:  config.Application.Singular,
 		releaseConfig: config.Release,
 	}
 }
@@ -104,7 +106,7 @@ func (r *REST) NamespaceScoped() bool {
 
 // GetSingularName returns the singular name of the resource
 func (r *REST) GetSingularName() string {
-	return r.gvr.Resource
+	return r.singularName
 }
 
 // Create handles the creation of a new Application by converting it to a HelmRelease


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[cozystack-api] Fix singular name for cozystack resources
```