### PR TITLE
[cozystack-api] Fix updaing lists

### DIFF
--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -236,6 +236,15 @@ func (o *AppsServerOptions) Config() (*apiserver.Config, error) {
 				},
 			}
 
+			// make `.spec` schemaless so any keys are accepted
+			if specProp, ok := newDef.Properties["spec"]; ok {
+				specProp.AdditionalProperties = &spec.SchemaOrBool{
+					Allows: true,
+					Schema: &spec.Schema{},
+				}
+				newDef.Properties["spec"] = specProp
+			}
+
 			// 3. Save the new resource definition under the correct name
 			defs[resourceName] = *newDef
 			klog.V(6).Infof("PostProcessSpec: Added OpenAPI definition for %s\n", resourceName)


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

When you update lists in cozystack objects, you might face with the error:

```
Warning: resource vminstances/mikrotik-demo is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used o
n resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
warning: error calculating patch from openapi v3 spec: unable to find api field "disks"
Error from server: error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"apps.cozystack.io/v1alpha1\",\"kind\":\"VMInstance\",\"metadata\":{\"annotations\":{},\"name
\":\"mikrotik-demo\",\"namespace\":\"tenant-vasya\"},\"spec\":{\"disks\":[{\"bus\":\"sata\",\"name\":\"mikrotik-system\"},{\"name\":\"mikrotik-iso\"}],\"instanceProfile\":\"ubuntu\",\"instan
ceType\":\"u1.medium\",\"running\":true}}\n"}},"spec":{"disks":[{"bus":"sata","name":"mikrotik-system"},{"name":"mikrotik-iso"}]}}
to:
Resource: "apps.cozystack.io/v1alpha1, Resource=vminstances", GroupVersionKind: "apps.cozystack.io/v1alpha1, Kind=VMInstance"
Name: "mikrotik-demo", Namespace: "tenant-vasya"
for: "/tmp/2": error when patching "/tmp/2": unable to find api field in struct JSON for the json field "disks"
```

This PR workarounds this.

Related to https://github.com/cozystack/cozystack/pull/1168

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[cozystack-api] Fix updaing lists on cozystack objects
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Made resource specifications more flexible by allowing any content under the specification property for dynamically registered resource kinds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->