### PR TITLE
[kubernetes] No default nodegroups in values

### DIFF
--- a/packages/apps/kubernetes/Chart.yaml
+++ b/packages/apps/kubernetes/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.26.0
+version: 0.26.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/kubernetes/values.yaml
+++ b/packages/apps/kubernetes/values.yaml
@@ -10,25 +10,25 @@ version: "v1.32"
 host: ""
 ## @param nodeGroups [object] Worker nodes configuration (see example)
 ##
-nodeGroups:
-  md0:
-    minReplicas: 0
-    maxReplicas: 10
-    instanceType: "u1.medium"
-    ephemeralStorage: 20Gi
-    roles:
-    - ingress-nginx
-
-    resources:
-      cpu: ""
-      memory: ""
-
-    ## List of GPUs to attach (WARN: NVIDIA driver requires at least 4 GiB of RAM)
-    ## e.g:
-    ## instanceType: "u1.xlarge"
-    ## gpus:
-    ## - name: nvidia.com/AD102GL_L40S
-    gpus: []
+nodeGroups: {}
+#   md0:
+#     minReplicas: 0
+#     maxReplicas: 10
+#     instanceType: "u1.medium"
+#     ephemeralStorage: 20Gi
+#     roles:
+#     - ingress-nginx
+# 
+#     resources:
+#       cpu: ""
+#       memory: ""
+# 
+#     ## List of GPUs to attach (WARN: NVIDIA driver requires at least 4 GiB of RAM)
+#     ## e.g:
+#     ## instanceType: "u1.xlarge"
+#     ## gpus:
+#     ## - name: nvidia.com/AD102GL_L40S
+#     gpus: []
 
 
 ## @section Cluster Addons

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -61,7 +61,8 @@ kubernetes 0.24.0 62cb694d
 kubernetes 0.25.0 70f82667
 kubernetes 0.25.1 acd4663a
 kubernetes 0.25.2 08cb7c0f
-kubernetes 0.26.0 HEAD
+kubernetes 0.26.0 68a47097
+kubernetes 0.26.1 HEAD
 mysql 0.1.0 263e47be
 mysql 0.2.0 c24a103f
 mysql 0.3.0 53f2365e


### PR DESCRIPTION
Since nodegroups are defined as key-value pairs in the values, there's no easy way to remove the example md0 nodegroup that was provided there for purposes of documentation. Commenting it out from values.yaml keeps the documentation in place, but doesn't force the node group onto users.

Release note:
[kubernetes] Remove potentially undesirable node group from default values of kubernetes chart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the chart version for the Kubernetes application to 0.26.1.
  * Updated version mappings to reflect the new release.

* **Refactor**
  * Changed the default node group configuration in Kubernetes values to be empty by default, with previous example settings now commented out. Users must now define node groups explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->