### PR TITLE
k8s make volumesnapshot crd name shorter

### DIFF
--- a/packages/apps/kubernetes/Chart.yaml
+++ b/packages/apps/kubernetes/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.26.1
+version: 0.26.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/kubernetes/templates/helmreleases/csi.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/csi.yaml
@@ -35,7 +35,7 @@ spec:
     storageClass: "{{ . }}"
   {{- end }}
   dependsOn:
-  - name: {{ .Release.Name }}-volumesnapshot-crd-for-tenant-k8s
+  - name: {{ .Release.Name }}-vsnap-crd
     namespace: {{ .Release.Namespace }}
   {{- if lookup "helm.toolkit.fluxcd.io/v2" "HelmRelease" .Release.Namespace .Release.Name }}
   - name: {{ .Release.Name }}

--- a/packages/apps/kubernetes/templates/helmreleases/volumesnapshot_crd.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/volumesnapshot_crd.yaml
@@ -1,16 +1,16 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: {{ .Release.Name }}-volumesnapshot-crd-for-tenant-k8s
+  name: {{ .Release.Name }}-vsnap-crd
   labels:
     cozystack.io/repository: system
     cozystack.io/target-cluster-name: {{ .Release.Name }}
 spec:
   interval: 5m
-  releaseName: volumesnapshot-crd-for-tenant-k8s
+  releaseName: vsnap-crd
   chart:
     spec:
-      chart: cozy-volumesnapshot-crd-for-tenant-k8s
+      chart: cozy-vsnap-crd
       reconcileStrategy: Revision
       sourceRef:
         kind: HelmRepository
@@ -21,8 +21,8 @@ spec:
     secretRef:
       name: {{ .Release.Name }}-admin-kubeconfig
       key: super-admin.svc
-  targetNamespace: cozy-volumesnapshot-crd-for-tenant-k8s
-  storageNamespace: cozy-volumesnapshot-crd-for-tenant-k8s
+  targetNamespace: cozy-vsnap-crd
+  storageNamespace: cozy-vsnap-crd
   install:
     createNamespace: true
     remediation:

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -62,7 +62,8 @@ kubernetes 0.25.0 70f82667
 kubernetes 0.25.1 acd4663a
 kubernetes 0.25.2 08cb7c0f
 kubernetes 0.26.0 9584e5f5
-kubernetes 0.26.1 HEAD
+kubernetes 0.26.1 0e47e1e8
+kubernetes 0.26.2 HEAD
 mysql 0.1.0 263e47be
 mysql 0.2.0 c24a103f
 mysql 0.3.0 53f2365e

--- a/packages/system/volumesnapshot-crd-for-tenant-k8s/Chart.yaml
+++ b/packages/system/volumesnapshot-crd-for-tenant-k8s/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
-name: cozy-volumesnapshot-crd-for-tenant-k8s
+name: cozy-vsnap-crd
 version: 0.0.0 # Placeholder, the actual version will be automatically set during the build process

--- a/packages/system/volumesnapshot-crd-for-tenant-k8s/Makefile
+++ b/packages/system/volumesnapshot-crd-for-tenant-k8s/Makefile
@@ -1,4 +1,4 @@
-export NAME=volumesnapshot-crd-for-tenant-k8s
+export NAME=vsnap-crd
 export NAMESPACE=cozy-$(NAME)
 
 include ../../../scripts/package.mk


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
- k8s make volumesnapshot crd name shorter
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated chart version for the Kubernetes application.
  * Changed Helm chart and namespace references to use a new, shorter name.
  * Updated version mapping to reflect the latest Kubernetes package version.
  * Renamed the Helm chart for volume snapshot resources to a shorter name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->