### PR TITLE
Use cozyvalues-gen with packages/apps/tenant

### DIFF
--- a/packages/apps/tenant/Makefile
+++ b/packages/apps/tenant/Makefile
@@ -1,4 +1,4 @@
 include ../../../scripts/package.mk
 
 generate:
-	readme-generator-for-helm -v values.yaml -s values.schema.json -r README.md
+	cozyvalues-gen -v values.yaml -s values.schema.json -r README.md

--- a/packages/apps/tenant/README.md
+++ b/packages/apps/tenant/README.md
@@ -69,12 +69,13 @@ tenant-u1
 
 ### Common parameters
 
-| Name             | Description                                                                                                                 | Value   |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `host`           | The hostname used to access tenant services (defaults to using the tenant name as a subdomain for it's parent tenant host). | `""`    |
-| `etcd`           | Deploy own Etcd cluster                                                                                                     | `false` |
-| `monitoring`     | Deploy own Monitoring Stack                                                                                                 | `false` |
-| `ingress`        | Deploy own Ingress Controller                                                                                               | `false` |
-| `seaweedfs`      | Deploy own SeaweedFS                                                                                                        | `false` |
-| `isolated`       | Enforce tenant namespace with network policies                                                                              | `true`  |
-| `resourceQuotas` | Define resource quotas for the tenant                                                                                       | `{}`    |
+| Name             | Description                                                                                                                 | Type      | Value   |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------- | --------- | ------- |
+| `host`           | The hostname used to access tenant services (defaults to using the tenant name as a subdomain for it's parent tenant host). | `*string` | `""`    |
+| `etcd`           | Deploy own Etcd cluster                                                                                                     | `bool`    | `false` |
+| `monitoring`     | Deploy own Monitoring Stack                                                                                                 | `bool`    | `false` |
+| `ingress`        | Deploy own Ingress Controller                                                                                               | `bool`    | `false` |
+| `seaweedfs`      | Deploy own SeaweedFS                                                                                                        | `bool`    | `false` |
+| `isolated`       | Enforce tenant namespace with network policies, `true` by default                                                           | `bool`    | `true`  |
+| `resourceQuotas` | Define resource quotas for the tenant                                                                                       | `string`  | `{}`    |
+

--- a/packages/apps/tenant/values.schema.json
+++ b/packages/apps/tenant/values.schema.json
@@ -1,41 +1,45 @@
 {
-    "properties": {
-        "etcd": {
-            "default": false,
-            "description": "Deploy own Etcd cluster",
-            "type": "boolean"
-        },
-        "host": {
-            "default": "",
-            "description": "The hostname used to access tenant services (defaults to using the tenant name as a subdomain for it's parent tenant host).",
-            "type": "string"
-        },
-        "ingress": {
-            "default": false,
-            "description": "Deploy own Ingress Controller",
-            "type": "boolean"
-        },
-        "isolated": {
-            "default": true,
-            "description": "Enforce tenant namespace with network policies",
-            "type": "boolean"
-        },
-        "monitoring": {
-            "default": false,
-            "description": "Deploy own Monitoring Stack",
-            "type": "boolean"
-        },
-        "resourceQuotas": {
-            "default": {},
-            "description": "Define resource quotas for the tenant",
-            "type": "object"
-        },
-        "seaweedfs": {
-            "default": false,
-            "description": "Deploy own SeaweedFS",
-            "type": "boolean"
-        }
+  "title": "Chart Values",
+  "type": "object",
+  "properties": {
+    "etcd": {
+      "description": "Deploy own Etcd cluster",
+      "type": "boolean",
+      "default": false
     },
-    "title": "Chart Values",
-    "type": "object"
+    "host": {
+      "description": "The hostname used to access tenant services (defaults to using the tenant name as a subdomain for it's parent tenant host).",
+      "type": "string"
+    },
+    "ingress": {
+      "description": "Deploy own Ingress Controller",
+      "type": "boolean",
+      "default": false
+    },
+    "isolated": {
+      "description": "Enforce tenant namespace with network policies, `true` by default",
+      "type": "boolean",
+      "default": true
+    },
+    "monitoring": {
+      "description": "Deploy own Monitoring Stack",
+      "type": "boolean",
+      "default": false
+    },
+    "resourceQuotas": {
+      "description": "Define resource quotas for the tenant",
+      "type": "object",
+      "default": {},
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+        "x-kubernetes-int-or-string": true
+      }
+    },
+    "seaweedfs": {
+      "description": "Deploy own SeaweedFS",
+      "type": "boolean",
+      "default": false
+    }
+  }
 }

--- a/packages/apps/tenant/values.yaml
+++ b/packages/apps/tenant/values.yaml
@@ -1,18 +1,18 @@
 ## @section Common parameters
 
-## @param host The hostname used to access tenant services (defaults to using the tenant name as a subdomain for it's parent tenant host).
-## @param etcd Deploy own Etcd cluster
-## @param monitoring Deploy own Monitoring Stack
-## @param ingress Deploy own Ingress Controller
-## @param seaweedfs Deploy own SeaweedFS
-## @param isolated Enforce tenant namespace with network policies
-## @param resourceQuotas Define resource quotas for the tenant
+## @param host {*string} The hostname used to access tenant services (defaults to using the tenant name as a subdomain for it's parent tenant host).
+## @param etcd {bool} Deploy own Etcd cluster
+## @param monitoring {bool} Deploy own Monitoring Stack
+## @param ingress {bool} Deploy own Ingress Controller
+## @param seaweedfs {bool} Deploy own SeaweedFS
+## @param isolated {bool} Enforce tenant namespace with network policies, `true` by default
 host: ""
 etcd: false
 monitoring: false
 ingress: false
 seaweedfs: false
 isolated: true
+## @param resourceQuotas {map[string]quantity} Define resource quotas for the tenant
 resourceQuotas: {}
 # resourceQuotas:
 #   cpu: "1"


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * All application parameter documentation was enhanced with explicit type annotations and structured field descriptions for improved clarity.
  * README files now include detailed parameter tables with type columns and refined default values.
  * Helm values.yaml files feature consistent type annotations and hierarchical field documentation.

* **Schema Enhancements**
  * JSON schemas for Postgres, Tenant, Virtual Machine, and Monitoring apps were comprehensively restructured with explicit types, defaults, validation patterns, and richer nested configuration options.

* **Chores**
  * Switched documentation and schema generation tools to a unified command (`cozyvalues-gen`) across all relevant Makefiles and CI workflows for consistency and simplification.

* **Bug Fixes**
  * Updated resource specifications in virtual machine tests for improved accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->