### PR TITLE
[ci] Stop using personal domain for CI

### DIFF
--- a/hack/e2e-prepare-cluster.bats
+++ b/hack/e2e-prepare-cluster.bats
@@ -136,25 +136,25 @@ machine:
     mirrors:
       docker.io:
         endpoints:
-        - https://dockerio.nexus.lllamnyp.su
+        - https://dockerio.nexus.aenix.org
       cr.fluentbit.io:
         endpoints:
-        - https://fluentbit.nexus.lllamnyp.su
+        - https://fluentbit.nexus.aenix.org
       docker-registry3.mariadb.com:
         endpoints:
-        - https://mariadb.nexus.lllamnyp.su
+        - https://mariadb.nexus.aenix.org
       gcr.io:
         endpoints:
-        - https://gcr.nexus.lllamnyp.su
+        - https://gcr.nexus.aenix.org
       ghcr.io:
         endpoints:
-        - https://ghcr.nexus.lllamnyp.su
+        - https://ghcr.nexus.aenix.org
       quay.io:
         endpoints:
-        - https://quay.nexus.lllamnyp.su
+        - https://quay.nexus.aenix.org
       registry.k8s.io:
         endpoints:
-        - https://k8s.nexus.lllamnyp.su
+        - https://k8s.nexus.aenix.org
   files:
   - content: |
       [plugins]


### PR DESCRIPTION
Migrate away from using a private domain for build infra.

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image registry mirror URLs in the cluster configuration to use a new domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->