### PR TITLE
[tests] cleanup state before repeat e2e-apps

### DIFF
--- a/hack/e2e-apps/bucket.bats
+++ b/hack/e2e-apps/bucket.bats
@@ -3,6 +3,7 @@
 @test "Create and Verify Seeweedfs Bucket" {
   # Create the bucket resource
   name='test'
+  kubectl -n tenant-test delete buckets.apps.cozystack.io "$name" --ignore-not-found
   kubectl apply -f - <<EOF
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Bucket

--- a/hack/e2e-apps/clickhouse.bats
+++ b/hack/e2e-apps/clickhouse.bats
@@ -2,6 +2,7 @@
 
 @test "Create DB ClickHouse" {
   name='test'
+  kubectl -n tenant-test delete clickhouses.apps.cozystack.io $name --ignore-not-found
   kubectl apply -f- <<EOF
 apiVersion: apps.cozystack.io/v1alpha1
 kind: ClickHouse

--- a/hack/e2e-apps/kafka.bats
+++ b/hack/e2e-apps/kafka.bats
@@ -2,6 +2,7 @@
 
 @test "Create Kafka" {
   name='test'
+  kubectl -n tenant-test delete kafkas.apps.cozystack.io "$name" --ignore-not-found
   kubectl apply -f- <<EOF
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Kafka

--- a/hack/e2e-apps/mysql.bats
+++ b/hack/e2e-apps/mysql.bats
@@ -2,6 +2,7 @@
 
 @test "Create DB MySQL" {
   name='test'
+  kubectl -n tenant-test delete mysqls.apps.cozystack.io $name --ignore-not-found
   kubectl apply -f- <<EOF
 apiVersion: apps.cozystack.io/v1alpha1
 kind: MySQL

--- a/hack/e2e-apps/postgres.bats
+++ b/hack/e2e-apps/postgres.bats
@@ -2,6 +2,7 @@
 
 @test "Create DB PostgreSQL" {
   name='test'
+  kubectl -n tenant-test delete postgreses.apps.cozystack.io $name --ignore-not-found
   kubectl apply -f - <<EOF
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Postgres

--- a/hack/e2e-apps/redis.bats
+++ b/hack/e2e-apps/redis.bats
@@ -2,6 +2,7 @@
 
 @test "Create Redis" {
   name='test'
+  kubectl -n tenant-test delete redises.apps.cozystack.io $name --ignore-not-found
   kubectl apply -f- <<EOF
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Redis

--- a/hack/e2e-apps/run-kubernetes.sh
+++ b/hack/e2e-apps/run-kubernetes.sh
@@ -4,6 +4,7 @@ run_kubernetes_test() {
     local port="$3"
     local k8s_version=$(yq "$version_expr" packages/apps/kubernetes/files/versions.yaml)
 
+  kubectl -n tenant-test delete kuberneteses.apps.cozystack.io $test_name --ignore-not-found
   kubectl apply -f - <<EOF
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Kubernetes

--- a/hack/e2e-apps/virtualmachine.bats
+++ b/hack/e2e-apps/virtualmachine.bats
@@ -2,6 +2,7 @@
 
 @test "Create a Virtual Machine" {
   name='test'
+  kubectl -n tenant-test delete virtualmachines.apps.cozystack.io $name --ignore-not-found
   kubectl apply -f - <<EOF
 apiVersion: apps.cozystack.io/v1alpha1
 kind: VirtualMachine

--- a/hack/e2e-apps/vminstance.bats
+++ b/hack/e2e-apps/vminstance.bats
@@ -1,5 +1,12 @@
 #!/usr/bin/env bats
 
+@test "Cleanup" {
+  name='test'
+  diskName='test'
+  kubectl -n tenant-test delete vmdisks.apps.cozystack.io $diskName --ignore-not-found
+  kubectl -n tenant-test delete vminstances.apps.cozystack.io $name --ignore-not-found
+}
+
 @test "Create a VM Disk" {
   name='test'
   kubectl apply -f - <<EOF


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability by ensuring existing resources are deleted before creating new ones in end-to-end tests for Bucket, ClickHouse, Kafka, MySQL, Postgres, Redis, Virtual Machine, and Kubernetes resources.
  * Added a cleanup step to the vminstance test suite for improved test isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->