### PR TITLE
[seaweedfs] Fix seaweedfs volumes configuration

### DIFF
--- a/packages/extra/seaweedfs/templates/seaweedfs.yaml
+++ b/packages/extra/seaweedfs/templates/seaweedfs.yaml
@@ -110,6 +110,7 @@ spec:
             {{- else if $.Values.storageClass }}
             storageClass: {{ $.Values.storageClass }}
             {{- end }}
+            maxVolumes: 0
           nodeSelector: |
             topology.kubernetes.io/zone: {{ $zoneName }}
           dataCenter: {{ $zone.dataCenter | default $zoneName }}

--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -8,8 +8,8 @@ global:
     enabled: true
 seaweedfs:
   master:
+    volumeSizeLimitMB: 30000
     replicas: 3
-    volumeSizeLimitMB: 100
     #  replication type is XYZ:
     # X number of replica in other data centers
     # Y number of replica in other racks in the same data center


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Fix seaweedfs volumes configuration

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[seaweedfs] Fix seaweedfs volumes configuration
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option for setting the maximum number of volumes per data directory in the SeaweedFS Helm chart.

* **Chores**
  * Increased the default volume size limit for SeaweedFS master from 100 MB to 30,000 MB.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->