### PR TITLE
[kamaji] Pass in-tree image as migrate-image

### DIFF
--- a/packages/system/kamaji/Makefile
+++ b/packages/system/kamaji/Makefile
@@ -27,4 +27,5 @@ image:
 		yq -i '.kamaji.image.repository = strenv(REPOSITORY)' values.yaml
 	TAG=$(TAG)@$$(yq e '."containerimage.digest"' images/kamaji.json -o json -r) \
 		yq -i '.kamaji.image.tag = strenv(TAG)' values.yaml
+	yq -i '.kamaji.extraArgs[0] = "--migrate-image=" + .kamaji.image.repository + ":" + .kamaji.image.tag' values.yaml
 	rm -f images/kamaji.json


### PR DESCRIPTION
## What this PR does

The in-tree build of the Kamaji image lacks the appropriate ldflags, resulting in invalid flags of the Kamaji controller manager binary. When a migration job starts, it tries to pull an image with an explicit empty string as a tag, which is invalid. This patch sets the in-tree image as the image for the migration job, both working around this issue, as well as being consistent in the image used.

### Release note

```release-note
[kamaji] Fix broken migration jobs originating from missing environment variables in the in-tree build.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automatically sets the Kamaji migrate image argument during builds to match the configured registry, tag, and digest.
  * Updates deployment values to include the migrate image reference so all Kamaji images are consistently pinned.
  * Reduces manual configuration and improves reliability of deployments and upgrades by ensuring migrate image is kept in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->