### PR TITLE
[fluxcd] Upgrade to Flux Operator 0.28.0

### DIFF
--- a/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.27.0
+appVersion: v0.28.0
 description: 'A Helm chart for deploying the Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.27.0
+version: 0.28.0

--- a/packages/system/fluxcd-operator/charts/flux-operator/README.md
+++ b/packages/system/fluxcd-operator/charts/flux-operator/README.md
@@ -1,6 +1,6 @@
 # flux-operator
 
-![Version: 0.27.0](https://img.shields.io/badge/Version-0.27.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.27.0](https://img.shields.io/badge/AppVersion-v0.27.0-informational?style=flat-square)
+![Version: 0.28.0](https://img.shields.io/badge/Version-0.28.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.28.0](https://img.shields.io/badge/AppVersion-v0.28.0-informational?style=flat-square)
 
 The [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator) provides a
 declarative API for the installation and upgrade of CNCF [Flux](https://fluxcd.io) and the

--- a/packages/system/fluxcd-operator/charts/flux-operator/templates/crds.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/templates/crds.yaml
@@ -458,6 +458,57 @@ spec:
                   - type
                   type: object
                 type: array
+              history:
+                description: |-
+                  History contains the reconciliation history of the FluxInstance
+                  as a list of snapshots ordered by the last reconciled time.
+                items:
+                  description: |-
+                    Snapshot represents a point-in-time record of a group of resources reconciliation,
+                    including timing information, status, and a unique digest identifier.
+                  properties:
+                    digest:
+                      description: Digest is the checksum in the format `<algo>:<hex>`
+                        of the resources in this snapshot.
+                      type: string
+                    firstReconciled:
+                      description: FirstReconciled is the time when this revision
+                        was first reconciled to the cluster.
+                      format: date-time
+                      type: string
+                    lastReconciled:
+                      description: LastReconciled is the time when this revision was
+                        last reconciled to the cluster.
+                      format: date-time
+                      type: string
+                    lastReconciledDuration:
+                      description: LastReconciledDuration is time it took to reconcile
+                        the resources in this revision.
+                      type: string
+                    lastReconciledStatus:
+                      description: LastReconciledStatus is the status of the last
+                        reconciliation.
+                      type: string
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      description: Metadata contains additional information about
+                        the snapshot.
+                      type: object
+                    totalReconciliations:
+                      description: TotalReconciliations is the total number of reconciliations
+                        that have occurred for this snapshot.
+                      format: int64
+                      type: integer
+                  required:
+                  - digest
+                  - firstReconciled
+                  - lastReconciled
+                  - lastReconciledDuration
+                  - lastReconciledStatus
+                  - totalReconciliations
+                  type: object
+                type: array
               inventory:
                 description: |-
                   Inventory contains a list of Kubernetes resource object references
@@ -1476,6 +1527,57 @@ spec:
                   - reason
                   - status
                   - type
+                  type: object
+                type: array
+              history:
+                description: |-
+                  History contains the reconciliation history of the ResourceSet
+                  as a list of snapshots ordered by the last reconciled time.
+                items:
+                  description: |-
+                    Snapshot represents a point-in-time record of a group of resources reconciliation,
+                    including timing information, status, and a unique digest identifier.
+                  properties:
+                    digest:
+                      description: Digest is the checksum in the format `<algo>:<hex>`
+                        of the resources in this snapshot.
+                      type: string
+                    firstReconciled:
+                      description: FirstReconciled is the time when this revision
+                        was first reconciled to the cluster.
+                      format: date-time
+                      type: string
+                    lastReconciled:
+                      description: LastReconciled is the time when this revision was
+                        last reconciled to the cluster.
+                      format: date-time
+                      type: string
+                    lastReconciledDuration:
+                      description: LastReconciledDuration is time it took to reconcile
+                        the resources in this revision.
+                      type: string
+                    lastReconciledStatus:
+                      description: LastReconciledStatus is the status of the last
+                        reconciliation.
+                      type: string
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      description: Metadata contains additional information about
+                        the snapshot.
+                      type: object
+                    totalReconciliations:
+                      description: TotalReconciliations is the total number of reconciliations
+                        that have occurred for this snapshot.
+                      format: int64
+                      type: integer
+                  required:
+                  - digest
+                  - firstReconciled
+                  - lastReconciled
+                  - lastReconciledDuration
+                  - lastReconciledStatus
+                  - totalReconciliations
                   type: object
                 type: array
               inventory:

--- a/packages/system/fluxcd/charts/flux-instance/Chart.yaml
+++ b/packages/system/fluxcd/charts/flux-instance/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.27.0
+appVersion: v0.28.0
 description: 'A Helm chart for deploying a Flux instance managed by Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.27.0
+version: 0.28.0

--- a/packages/system/fluxcd/charts/flux-instance/README.md
+++ b/packages/system/fluxcd/charts/flux-instance/README.md
@@ -1,6 +1,6 @@
 # flux-instance
 
-![Version: 0.27.0](https://img.shields.io/badge/Version-0.27.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.27.0](https://img.shields.io/badge/AppVersion-v0.27.0-informational?style=flat-square)
+![Version: 0.28.0](https://img.shields.io/badge/Version-0.28.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.28.0](https://img.shields.io/badge/AppVersion-v0.28.0-informational?style=flat-square)
 
 This chart is a thin wrapper around the `FluxInstance` custom resource, which is
 used by the [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator)


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does
Bump the Flux Operator to 0.28.0
Details at https://github.com/controlplaneio-fluxcd/flux-operator/releases/tag/v0.28.0

### Release note



```release-note
Bump the Flux Operator to 0.28.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added reconciliation history to Flux resources, exposing per-run snapshots (digest, timestamps, duration, status, metadata, total runs) for FluxInstance, FluxReport, ResourceSet, and ResourceSetInputProvider.
  - Clarified description of lastAppliedRevision for ResourceSet.
- Chores
  - Bumped chart versions to 0.28.0 (AppVersion v0.28.0).
- Documentation
  - Updated README badges to reflect Version 0.28.0 and AppVersion v0.28.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->