### PR TITLE
Update LINSTOR v1.31.3

### DIFF
--- a/packages/system/piraeus-operator/charts/piraeus/templates/config.yaml
+++ b/packages/system/piraeus-operator/charts/piraeus/templates/config.yaml
@@ -17,10 +17,10 @@ data:
     #   quay.io/piraeusdatastore/piraeus-server:v1.24.2
     components:
       linstor-controller:
-        tag: v1.31.2
+        tag: v1.31.3
         image: piraeus-server
       linstor-satellite:
-        tag: v1.31.2
+        tag: v1.31.3
         image: piraeus-server
       linstor-csi:
         tag: v1.8.0


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

This version include some fixes
- https://github.com/linbit/linstor-server/

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
Update LINSTOR v1.31.3
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated LINSTOR Controller image to v1.31.3 to align with the latest upstream release.
  * Updated LINSTOR Satellite image to v1.31.3 for consistency across components.
  * No changes to other images; piraeus-server remains unchanged.
  * Users deploying or upgrading will receive the latest controller and satellite versions automatically through the chart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->