### PR TITLE
[dx] Remove BUILDER and PLATFORM autodetection logic

### DIFF
--- a/packages/apps/clickhouse/Makefile
+++ b/packages/apps/clickhouse/Makefile
@@ -8,16 +8,11 @@ generate:
 
 image:
 	docker buildx build images/clickhouse-backup \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=$(PLATFORM) \
 		--tag $(REGISTRY)/clickhouse-backup:$(call settag,$(CLICKHOUSE_BACKUP_TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/clickhouse-backup:latest \
 		--cache-to type=inline \
 		--metadata-file images/clickhouse-backup.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/clickhouse-backup:$(call settag,$(CLICKHOUSE_BACKUP_TAG))@$$(yq e '."containerimage.digest"' images/clickhouse-backup.json -o json -r)" \
 		> images/clickhouse-backup.tag
 	rm -f images/clickhouse-backup.json

--- a/packages/apps/http-cache/Makefile
+++ b/packages/apps/http-cache/Makefile
@@ -7,16 +7,11 @@ image: image-nginx
 
 image-nginx:
 	docker buildx build images/nginx-cache \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=$(PLATFORM) \
 		--tag $(REGISTRY)/nginx-cache:$(call settag,$(NGINX_CACHE_TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/nginx-cache:latest \
 		--cache-to type=inline \
 		--metadata-file images/nginx-cache.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/nginx-cache:$(call settag,$(NGINX_CACHE_TAG))@$$(yq e '."containerimage.digest"' images/nginx-cache.json -o json -r)" \
 		> images/nginx-cache.tag
 	rm -f images/nginx-cache.json

--- a/packages/apps/kubernetes/Makefile
+++ b/packages/apps/kubernetes/Makefile
@@ -12,52 +12,37 @@ image: image-ubuntu-container-disk image-kubevirt-cloud-provider image-kubevirt-
 
 image-ubuntu-container-disk:
 	docker buildx build images/ubuntu-container-disk \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=$(PLATFORM) \
 		--build-arg KUBERNETES_VERSION=${KUBERNETES_VERSION} \
 		--tag $(REGISTRY)/ubuntu-container-disk:$(call settag,$(KUBERNETES_VERSION)) \
 		--tag $(REGISTRY)/ubuntu-container-disk:$(call settag,$(KUBERNETES_VERSION)-$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/ubuntu-container-disk:latest \
 		--cache-to type=inline \
 		--metadata-file images/ubuntu-container-disk.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/ubuntu-container-disk:$(call settag,$(KUBERNETES_VERSION))@$$(yq e '."containerimage.digest"' images/ubuntu-container-disk.json -o json -r)" \
 		> images/ubuntu-container-disk.tag
 	rm -f images/ubuntu-container-disk.json
 
 image-kubevirt-cloud-provider:
 	docker buildx build images/kubevirt-cloud-provider \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=$(PLATFORM) \
 		--tag $(REGISTRY)/kubevirt-cloud-provider:$(call settag,$(KUBERNETES_PKG_TAG)) \
 		--tag $(REGISTRY)/kubevirt-cloud-provider:$(call settag,$(KUBERNETES_PKG_TAG)-$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/kubevirt-cloud-provider:latest \
 		--cache-to type=inline \
 		--metadata-file images/kubevirt-cloud-provider.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/kubevirt-cloud-provider:$(call settag,$(KUBERNETES_PKG_TAG))@$$(yq e '."containerimage.digest"' images/kubevirt-cloud-provider.json -o json -r)" \
 		> images/kubevirt-cloud-provider.tag
 	rm -f images/kubevirt-cloud-provider.json
 
 image-kubevirt-csi-driver:
 	docker buildx build images/kubevirt-csi-driver \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=$(PLATFORM) \
 		--tag $(REGISTRY)/kubevirt-csi-driver:$(call settag,$(KUBERNETES_PKG_TAG)) \
 		--tag $(REGISTRY)/kubevirt-csi-driver:$(call settag,$(KUBERNETES_PKG_TAG)-$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/kubevirt-csi-driver:latest \
 		--cache-to type=inline \
 		--metadata-file images/kubevirt-csi-driver.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/kubevirt-csi-driver:$(call settag,$(KUBERNETES_PKG_TAG))@$$(yq e '."containerimage.digest"' images/kubevirt-csi-driver.json -o json -r)" \
 		> images/kubevirt-csi-driver.tag
 	IMAGE=$$(cat images/kubevirt-csi-driver.tag) \
@@ -67,17 +52,12 @@ image-kubevirt-csi-driver:
 
 image-cluster-autoscaler:
 	docker buildx build images/cluster-autoscaler \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=$(PLATFORM) \
 		--tag $(REGISTRY)/cluster-autoscaler:$(call settag,$(KUBERNETES_PKG_TAG)) \
 		--tag $(REGISTRY)/cluster-autoscaler:$(call settag,$(KUBERNETES_PKG_TAG)-$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/cluster-autoscaler:latest \
 		--cache-to type=inline \
 		--metadata-file images/cluster-autoscaler.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/cluster-autoscaler:$(call settag,$(KUBERNETES_PKG_TAG))@$$(yq e '."containerimage.digest"' images/cluster-autoscaler.json -o json -r)" \
 		> images/cluster-autoscaler.tag
 	rm -f images/cluster-autoscaler.json

--- a/packages/apps/mysql/Makefile
+++ b/packages/apps/mysql/Makefile
@@ -8,16 +8,11 @@ generate:
 
 image:
 	docker buildx build images/mariadb-backup \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=$(PLATFORM) \
 		--tag $(REGISTRY)/mariadb-backup:$(call settag,$(MARIADB_BACKUP_TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/mariadb-backup:latest \
 		--cache-to type=inline \
 		--metadata-file images/mariadb-backup.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/mariadb-backup:$(call settag,$(MARIADB_BACKUP_TAG))@$$(yq e '."containerimage.digest"' images/mariadb-backup.json -o json -r)" \
 		> images/mariadb-backup.tag
 	rm -f images/mariadb-backup.json

--- a/packages/core/installer/Makefile
+++ b/packages/core/installer/Makefile
@@ -24,15 +24,11 @@ image: pre-checks image-matchbox image-cozystack image-talos
 
 image-cozystack:
 	docker buildx build -f images/cozystack/Dockerfile ../../.. \
-		--provenance false \
 		--tag $(REGISTRY)/installer:$(call settag,$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/installer:latest \
-		--platform linux/amd64 \
 		--cache-to type=inline \
 		--metadata-file images/installer.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	IMAGE="$(REGISTRY)/installer:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/installer.json -o json -r)" \
 		yq -i '.cozystack.image = strenv(IMAGE)' values.yaml
 	rm -f images/installer.json
@@ -45,15 +41,12 @@ image-matchbox:
 	test -f ../../../_out/assets/kernel-amd64 || make talos-kernel
 	test -f ../../../_out/assets/initramfs-metal-amd64.xz || make talos-initramfs
 	docker buildx build -f images/matchbox/Dockerfile ../../.. \
-		--provenance false \
 		--tag $(REGISTRY)/matchbox:$(call settag,$(TAG)) \
 		--tag $(REGISTRY)/matchbox:$(call settag,$(TALOS_VERSION)-$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/matchbox:latest \
 		--cache-to type=inline \
 		--metadata-file images/matchbox.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/matchbox:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/matchbox.json -o json -r)" \
 		> ../../extra/bootbox/images/matchbox.tag
 	rm -f images/matchbox.json

--- a/packages/core/testing/Makefile
+++ b/packages/core/testing/Makefile
@@ -16,16 +16,11 @@ image: image-e2e-sandbox
 
 image-e2e-sandbox:
 	docker buildx build -f images/e2e-sandbox/Dockerfile images/e2e-sandbox \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=$(PLATFORM) \
 		--tag $(REGISTRY)/e2e-sandbox:$(call settag,$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/e2e-sandbox:latest \
 		--cache-to type=inline \
 		--metadata-file images/e2e-sandbox.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	IMAGE="$(REGISTRY)/e2e-sandbox:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/e2e-sandbox.json -o json -r)" \
 		yq -i '.e2e.image = strenv(IMAGE)' values.yaml
 	rm -f images/e2e-sandbox.json

--- a/packages/extra/monitoring/Makefile
+++ b/packages/extra/monitoring/Makefile
@@ -10,16 +10,11 @@ generate:
 
 image:
 	docker buildx build images/grafana \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=$(PLATFORM) \
 		--tag $(REGISTRY)/grafana:$(call settag,$(GRAFANA_TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/grafana:latest \
 		--cache-to type=inline \
 		--metadata-file images/grafana.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/grafana:$(call settag,$(GRAFANA_TAG))@$$(yq e '."containerimage.digest"' images/grafana.json -o json -r)" \
 		> images/grafana.tag
 	rm -f images/grafana.json

--- a/packages/system/bucket/Makefile
+++ b/packages/system/bucket/Makefile
@@ -12,16 +12,11 @@ image: image-s3manager
 
 image-s3manager:
 	docker buildx build images/s3manager \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=$(PLATFORM) \
 		--tag $(REGISTRY)/s3manager:$(call settag,$(S3MANAGER_TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/s3manager:latest \
 		--cache-to type=inline \
 		--metadata-file images/s3manager.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/s3manager:$(call settag,$(S3MANAGER_TAG))@$$(yq e '."containerimage.digest"' images/s3manager.json -o json -r)" \
 		> images/s3manager.tag
 	rm -f images/s3manager.json

--- a/packages/system/cilium/Makefile
+++ b/packages/system/cilium/Makefile
@@ -17,17 +17,12 @@ update:
 
 image:
 	docker buildx build images/cilium \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=$(PLATFORM) \
 		--tag $(REGISTRY)/cilium:$(call settag,$(CILIUM_TAG)) \
 		--tag $(REGISTRY)/cilium:$(call settag,$(CILIUM_TAG)-$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/cilium:latest \
 		--cache-to type=inline \
 		--metadata-file images/cilium.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/cilium" \
 		yq -i '.cilium.image.repository = strenv(REPOSITORY)' values.yaml
 	TAG=$(call settag,$(CILIUM_TAG)) \

--- a/packages/system/cozystack-api/Makefile
+++ b/packages/system/cozystack-api/Makefile
@@ -8,16 +8,11 @@ image: image-cozystack-api
 
 image-cozystack-api:
 	docker buildx build -f images/cozystack-api/Dockerfile ../../.. \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=$(PLATFORM) \
 		--tag $(REGISTRY)/cozystack-api:$(call settag,$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/cozystack-api:latest \
 		--cache-to type=inline \
 		--metadata-file images/cozystack-api.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	IMAGE="$(REGISTRY)/cozystack-api:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/cozystack-api.json -o json -r)" \
 		yq -i '.cozystackAPI.image = strenv(IMAGE)' values.yaml
 	rm -f images/cozystack-api.json

--- a/packages/system/cozystack-controller/Makefile
+++ b/packages/system/cozystack-controller/Makefile
@@ -8,16 +8,11 @@ image: image-cozystack-controller update-version
 
 image-cozystack-controller:
 	docker buildx build -f images/cozystack-controller/Dockerfile ../../.. \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=$(PLATFORM) \
 		--tag $(REGISTRY)/cozystack-controller:$(call settag,$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/cozystack-controller:latest \
 		--cache-to type=inline \
 		--metadata-file images/cozystack-controller.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	IMAGE="$(REGISTRY)/cozystack-controller:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/cozystack-controller.json -o json -r)" \
 		yq -i '.cozystackController.image = strenv(IMAGE)' values.yaml
 	rm -f images/cozystack-controller.json

--- a/packages/system/dashboard/Makefile
+++ b/packages/system/dashboard/Makefile
@@ -28,16 +28,11 @@ update-dockerfiles:
 
 image-dashboard: update-version
 	docker buildx build images/dashboard \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=$(PLATFORM) \
 		--tag $(REGISTRY)/dashboard:$(call settag,$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/dashboard:latest \
 		--cache-to type=inline \
 		--metadata-file images/dashboard.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	REGISTRY="$(REGISTRY)" \
 		yq -i '.kubeapps.dashboard.image.registry = strenv(REGISTRY)' values.yaml
 	REPOSITORY="dashboard" \
@@ -50,16 +45,11 @@ image-dashboard: update-version
 
 image-kubeapps-apis: update-version
 	docker buildx build images/kubeapps-apis \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=$(PLATFORM) \
 		--tag $(REGISTRY)/kubeapps-apis:$(call settag,$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/kubeapps-apis:latest \
 		--cache-to type=inline \
 		--metadata-file images/kubeapps-apis.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	REGISTRY="$(REGISTRY)" \
 		yq -i '.kubeapps.kubeappsapis.image.registry = strenv(REGISTRY)' values.yaml
 	REPOSITORY="kubeapps-apis" \

--- a/packages/system/kamaji/Makefile
+++ b/packages/system/kamaji/Makefile
@@ -13,16 +13,11 @@ update:
 
 image:
 	docker buildx build images/kamaji \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=$(PLATFORM) \
 		--tag $(REGISTRY)/kamaji:$(call settag,$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/kamaji:latest \
 		--cache-to type=inline \
 		--metadata-file images/kamaji.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack"
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/kamaji" \
 		yq -i '.kamaji.image.repository = strenv(REPOSITORY)' values.yaml
 	TAG=$(TAG)@$$(yq e '."containerimage.digest"' images/kamaji.json -o json -r) \

--- a/packages/system/kubeovn-webhook/Makefile
+++ b/packages/system/kubeovn-webhook/Makefile
@@ -6,16 +6,11 @@ include ../../../scripts/package.mk
 
 image:
 	docker buildx build images/kubeovn-webhook \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=$(PLATFORM) \
 		--tag $(REGISTRY)/kubeovn-webhook:$(call settag,$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/kubeovn-webhook:latest \
 		--cache-to type=inline \
 		--metadata-file images/kubeovn-webhook.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack"
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	IMAGE="$(REGISTRY)/kubeovn-webhook:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/kubeovn-webhook.json -o json -r)" \
 		yq -i '.image = strenv(IMAGE)' values.yaml
 	rm -f images/kubeovn-webhook.json

--- a/packages/system/kubeovn/Makefile
+++ b/packages/system/kubeovn/Makefile
@@ -19,17 +19,12 @@ update:
 
 image:
 	docker buildx build images/kubeovn \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=$(PLATFORM) \
 		--tag $(REGISTRY)/kubeovn:$(call settag,$(KUBEOVN_TAG)) \
 		--tag $(REGISTRY)/kubeovn:$(call settag,$(KUBEOVN_TAG)-$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/kubeovn:latest \
 		--cache-to type=inline \
 		--metadata-file images/kubeovn.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	REGISTRY="$(REGISTRY)" \
 		yq -i '.global.registry.address = strenv(REGISTRY)' values.yaml
 	REPOSITORY="kubeovn" \

--- a/packages/system/metallb/Makefile
+++ b/packages/system/metallb/Makefile
@@ -15,18 +15,13 @@ image-controller image-speaker:
 	$(eval TARGET := $(subst image-,,$@))
 	$(eval VERSION := $(shell yq '.appVersion' charts/metallb/Chart.yaml))
 	docker buildx build images/metallb \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=$(PLATFORM) \
 		--target $(TARGET) \
 		--build-arg VERSION=$(VERSION) \
 		--tag $(REGISTRY)/metallb-$(TARGET):$(VERSION) \
 		--cache-from type=registry,ref=$(REGISTRY)/metallb-$(TARGET):latest \
 		--cache-to type=inline \
 		--metadata-file images/$(TARGET).json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/metallb-$(TARGET)" \
 		yq -i '.metallb.$(TARGET).image.repository = strenv(REPOSITORY)' values.yaml
 	TAG=$(VERSION)@$$(yq e '."containerimage.digest"' images/$(TARGET).json -o json -r) \

--- a/packages/system/objectstorage-controller/Makefile
+++ b/packages/system/objectstorage-controller/Makefile
@@ -22,8 +22,7 @@ image-controller image-sidecar:
 		--cache-from type=registry,ref=$(REGISTRY)/objectstorage-$(TARGET):latest \
 		--cache-to   type=inline \
 		--metadata-file images/$(TARGET).json \
-		--push=$(PUSH) --provenance=false --load=$(LOAD) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack"
+		$(BUILDX_ARGS)
 	IMAGE="$(REGISTRY)/objectstorage-$(TARGET):$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/$(TARGET).json -r)" \
 		yq -i '$(YAML_PATH) = strenv(IMAGE)' $(VALUES_FILE)
 	rm -f images/$(TARGET).json


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

It does not work well anyway.

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[dx] Remove BUILDER and PLATFORM autodetection logic
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Consolidated Docker Buildx flags into a single configurable argument across all image build targets, keeping tagging, caching, and metadata behavior unchanged.
- Chores
  - Added configurable environment variables for builds (e.g., builder, platform, extra args, tag) to standardize and simplify configuration.
  - Removed automatic builder/platform detection; these can now be explicitly set when needed, making builds more predictable and customizable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->