### PR TITLE
feature make force upgrade for ingress controller chart

### DIFF
--- a/packages/apps/tenant/Chart.yaml
+++ b/packages/apps/tenant/Chart.yaml
@@ -4,4 +4,4 @@ description: Separated tenant namespace
 icon: /logos/tenant.svg
 
 type: application
-version: 1.13.0
+version: 1.14.0

--- a/packages/apps/tenant/templates/ingress.yaml
+++ b/packages/apps/tenant/templates/ingress.yaml
@@ -20,5 +20,7 @@ spec:
       version: "*"
   interval: 1m0s
   timeout: 5m0s
+  upgrade:
+    force: true
   values: {}
 {{- end }}

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -165,7 +165,8 @@ tcp-balancer 0.4.2 4369b031
 tcp-balancer 0.5.0 08cb7c0f
 tcp-balancer 0.5.1 c02a3818
 tcp-balancer 0.6.0 HEAD
-tenant 1.13.0 HEAD
+tenant 1.13.0 8f1975d1
+tenant 1.14.0 HEAD
 virtual-machine 0.14.0 HEAD
 vm-disk 0.1.0 d971f2ff
 vm-disk 0.1.1 6130f43d


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped tenant chart version to 1.14.0; no user-visible changes.
  - Updated deployment configuration to force ingress upgrades (no impact on app behavior).
  - Refreshed version mappings to reflect the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->