### PR TITLE
[kubernetes] Change settings coredns replicas and image

### DIFF
--- a/packages/system/coredns/Makefile
+++ b/packages/system/coredns/Makefile
@@ -1,5 +1,5 @@
 export NAME=coredns
-export NAMESPACE=coredns
+export NAMESPACE=kube-system
 
 include ../../../scripts/package.mk
 

--- a/packages/system/coredns/values.yaml
+++ b/packages/system/coredns/values.yaml
@@ -1,0 +1,4 @@
+coredns:
+  image:
+    repository: registry.k8s.io/coredns/coredns
+  replicaCount: 2


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Exposed configuration for CoreDNS: you can now set the image repository and replica count via values.
- Changes
  - CoreDNS now deploys in the kube-system namespace for better alignment with cluster services.
  - Default CoreDNS replica count increased to 2 to improve availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->