### PR TITLE
[ingress] make nginx resources configurable

### DIFF
--- a/packages/extra/ingress/Chart.yaml
+++ b/packages/extra/ingress/Chart.yaml
@@ -3,4 +3,4 @@ name: ingress
 description: NGINX Ingress Controller
 icon: /logos/ingress-nginx.svg
 type: application
-version: 1.8.0
+version: 1.9.0

--- a/packages/extra/ingress/README.md
+++ b/packages/extra/ingress/README.md
@@ -4,9 +4,13 @@
 
 ### Common parameters
 
-| Name             | Description                                                       | Type        | Value   |
-| ---------------- | ----------------------------------------------------------------- | ----------- | ------- |
-| `replicas`       | Number of ingress-nginx replicas                                  | `int`       | `2`     |
-| `whitelist`      | List of client networks                                           | `[]*string` | `[]`    |
-| `clouflareProxy` | Restoring original visitor IPs when Cloudflare proxied is enabled | `bool`      | `false` |
+| Name               | Description                                                                                                                                | Type        | Value   |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ | ----------- | ------- |
+| `replicas`         | Number of ingress-nginx replicas                                                                                                           | `int`       | `2`     |
+| `whitelist`        | List of client networks                                                                                                                    | `[]*string` | `[]`    |
+| `cloudflareProxy`  | Restoring original visitor IPs when Cloudflare proxied is enabled                                                                          | `bool`      | `false` |
+| `resources`        | Explicit CPU and memory configuration for each ingress-nginx replica. When left empty, the preset defined in `resourcesPreset` is applied. | `*object`   | `{}`    |
+| `resources.cpu`    | CPU available to each replica                                                                                                              | `*quantity` | `null`  |
+| `resources.memory` | Memory (RAM) available to each replica                                                                                                     | `*quantity` | `null`  |
+| `resourcesPreset`  | Default sizing preset used when `resources` is omitted. Allowed values: `nano`, `micro`, `small`, `medium`, `large`, `xlarge`, `2xlarge`.  | `string`    | `micro` |
 

--- a/packages/extra/ingress/templates/nginx-ingress.yaml
+++ b/packages/extra/ingress/templates/nginx-ingress.yaml
@@ -29,6 +29,7 @@ spec:
       controller:
         replicaCount: {{ .Values.replicas }}
         ingressClass: {{ .Release.Namespace }}
+        resources: {{- include "cozy-lib.resources.defaultingSanitize" (list .Values.resourcesPreset .Values.resources $) | nindent 10 }}
         ingressClassResource:
           name: {{ .Release.Namespace }}
           controllerValue: k8s.io/ingress-nginx-{{ .Release.Namespace }}
@@ -49,12 +50,12 @@ spec:
           type: LoadBalancer
           externalTrafficPolicy: Local
           {{- end }}
-        {{- if or .Values.whitelist .Values.clouflareProxy }}
+        {{- if or .Values.whitelist .Values.cloudflareProxy }}
         config:
           {{- with .Values.whitelist }}
           whitelist-source-range: "{{ join "," . }}"
           {{- end }}
-          {{- if .Values.clouflareProxy }}
+          {{- if .Values.cloudflareProxy }}
           set_real_ip_from: "{{ include "ingress.cloudflare-ips" . }}"
           use-forwarded-headers: "true"
           server-snippet: "real_ip_header CF-Connecting-IP;"

--- a/packages/extra/ingress/values.schema.json
+++ b/packages/extra/ingress/values.schema.json
@@ -2,7 +2,7 @@
   "title": "Chart Values",
   "type": "object",
   "properties": {
-    "clouflareProxy": {
+    "cloudflareProxy": {
       "description": "Restoring original visitor IPs when Cloudflare proxied is enabled",
       "type": "boolean",
       "default": false
@@ -11,6 +11,53 @@
       "description": "Number of ingress-nginx replicas",
       "type": "integer",
       "default": 2
+    },
+    "resources": {
+      "description": "Explicit CPU and memory configuration for each ingress-nginx replica. When left empty, the preset defined in `resourcesPreset` is applied.",
+      "type": "object",
+      "default": {},
+      "properties": {
+        "cpu": {
+          "description": "CPU available to each replica",
+          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "x-kubernetes-int-or-string": true
+        },
+        "memory": {
+          "description": "Memory (RAM) available to each replica",
+          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "x-kubernetes-int-or-string": true
+        }
+      }
+    },
+    "resourcesPreset": {
+      "description": "Default sizing preset used when `resources` is omitted. Allowed values: `nano`, `micro`, `small`, `medium`, `large`, `xlarge`, `2xlarge`.",
+      "type": "string",
+      "default": "micro",
+      "enum": [
+        "nano",
+        "micro",
+        "small",
+        "medium",
+        "large",
+        "xlarge",
+        "2xlarge"
+      ]
     },
     "whitelist": {
       "description": "List of client networks",

--- a/packages/extra/ingress/values.yaml
+++ b/packages/extra/ingress/values.yaml
@@ -11,5 +11,16 @@ replicas: 2
 ## - "10.100.0.0/16"
 whitelist: []
 
-## @param clouflareProxy {bool} Restoring original visitor IPs when Cloudflare proxied is enabled
-clouflareProxy: false
+## @param cloudflareProxy {bool} Restoring original visitor IPs when Cloudflare proxied is enabled
+cloudflareProxy: false
+
+## @param resources {*resources} Explicit CPU and memory configuration for each ingress-nginx replica. When left empty, the preset defined in `resourcesPreset` is applied.
+## @field resources.cpu {*quantity} CPU available to each replica
+## @field resources.memory {*quantity} Memory (RAM) available to each replica
+## Example:
+## resources:
+##   cpu: 4000m
+##   memory: 4Gi
+resources: {}
+## @param resourcesPreset {string enum:"nano,micro,small,medium,large,xlarge,2xlarge"} Default sizing preset used when `resources` is omitted. Allowed values: `nano`, `micro`, `small`, `medium`, `large`, `xlarge`, `2xlarge`.
+resourcesPreset: "micro"

--- a/packages/extra/versions_map
+++ b/packages/extra/versions_map
@@ -30,7 +30,8 @@ ingress 1.4.0 fd240701
 ingress 1.5.0 93bdf411
 ingress 1.6.0 632224a3
 ingress 1.7.0 c02a3818
-ingress 1.8.0 HEAD
+ingress 1.8.0 8f1975d1
+ingress 1.9.0 HEAD
 monitoring 1.0.0 d7cfa53c
 monitoring 1.1.0 25221fdc
 monitoring 1.2.0 f81be075

--- a/packages/system/monitoring-agents/templates/kube-ovn-plunger-scrape.yaml
+++ b/packages/system/monitoring-agents/templates/kube-ovn-plunger-scrape.yaml
@@ -1,42 +1,23 @@
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: coredns
-  namespace: kube-system
-  labels:
-    app: coredns
-spec:
-  clusterIP: None
-  ports:
-    - name: http-metrics
-      port: 9153
-      protocol: TCP
-      targetPort: 9153
-  selector:
-    k8s-app: kube-dns
----
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMServiceScrape
 metadata:
-  name: coredns
+  name: kubeovn-plunger
   namespace: cozy-monitoring
 spec:
   selector:
     matchLabels:
-      app: coredns
+      app.kubernetes.io/name: kube-ovn-plunger
+      app.kubernetes.io/instance: kubeovn-plunger
   namespaceSelector:
     matchNames:
-      - "kube-system"
+    - "cozy-kubeovn"
   endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    port: http-metrics
+  - port: metrics
     relabelConfigs:
     - action: labeldrop
-      regex: (endpoint|namespace|pod|container)
-    - replacement: kube-dns
+      regex: (endpoint|pod|container)
+    - replacement: kubeovn-plunger
       targetLabel: job
-    - sourceLabels: [__meta_kubernetes_pod_node_name]
-      targetLabel: node
     - targetLabel: tier
       replacement: cluster


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added per-replica CPU and memory configuration for the ingress controller.
  - Introduced resource presets (nano, micro, small, medium, large, xlarge, 2xlarge) with a default of micro.
- Documentation
  - Updated parameters guide to document new resource settings and presets.
- Chores
  - Bumped ingress chart version to 1.9.0.
  - Updated version mapping to include the new chart version and pin the previous one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->