### PR TITLE
[cozystack-controller] Add workloadmonitors to lineage webhook; track UPDATE operations

### DIFF
--- a/packages/system/cozystack-controller/templates/mutatingwebhookconfiguration.yaml
+++ b/packages/system/cozystack-controller/templates/mutatingwebhookconfiguration.yaml
@@ -16,10 +16,14 @@ webhooks:
         namespace: {{ .Release.Namespace }}
         path: /mutate-lineage
     rules:
-      - operations: ["CREATE"]
+      - operations: ["CREATE", "UPDATE"]
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["pods","secrets", "services", "persistentvolumeclaims"]
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["cozystack.io"]
+        apiVersions: ["v1alpha1"]
+        resources: ["workloadmonitors"]
     failurePolicy: Fail
     namespaceSelector:
       matchExpressions:


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

Workloadmonitors are shown in the dashboard, we need to label them as well

Enable UPDATE method to ensure that labels were not removed or changed, also to ensure migrations for older resources

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The mutating webhook now applies on both creation and updates of core Kubernetes resources (Pods, Secrets, Services, PersistentVolumeClaims), ensuring consistent defaults and policies when resources change.
  - Added mutation support for the WorkloadMonitor custom resource (v1alpha1), covering both creation and updates for consistent configuration across its lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->