### PR TITLE
[k8s] add expanding persistent volumes in tenant clusters

### DIFF
--- a/packages/apps/kubernetes/Chart.yaml
+++ b/packages/apps/kubernetes/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.29.1
+version: 0.29.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/kubernetes/images/kubevirt-csi-driver.tag
+++ b/packages/apps/kubernetes/images/kubevirt-csi-driver.tag
@@ -1,1 +1,1 @@
-ghcr.io/cozystack/cozystack/kubevirt-csi-driver:0.29.1@sha256:cae43eae09fc39e5f2140d30ef55253f871cc565b8b7a564a54077b7cbd92212
+kklinch0/kubevirt-csi-driver:0.37.0@sha256:d334ba727f0974b085f6e44ee52a61fa0c507063875b52006665dbacfa332cbd

--- a/packages/apps/kubernetes/templates/csi/deploy.yaml
+++ b/packages/apps/kubernetes/templates/csi/deploy.yaml
@@ -205,6 +205,29 @@ spec:
           - mountPath: /etc/kubernetes/kubeconfig
             name: kubeconfig
             readOnly: true
+        - name: csi-resizer
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.13.1
+          args:
+            - "-csi-address=/csi/csi.sock"
+            - "-kubeconfig=/etc/kubernetes/kubeconfig/super-admin.svc"
+            - "-v=5"
+            - "-timeout=3m"
+            - '-handle-volume-inuse-error=false'
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /etc/kubernetes/kubeconfig
+              name: kubeconfig
+              readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 20Mi
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/packages/apps/kubernetes/templates/csi/infra-cluster-service-account.yaml
+++ b/packages/apps/kubernetes/templates/csi/infra-cluster-service-account.yaml
@@ -36,3 +36,25 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Release.Name }}-kcsi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-kcsi
+rules:
+- apiGroups: [""]
+  resources: ["persistentvolumes"]
+  verbs: ["get"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-kcsi-binding
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-kcsi
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-kcsi
+  namespace: {{ .Release.Namespace }}

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -72,7 +72,8 @@ kubernetes 0.26.3 c02a3818
 kubernetes 0.27.0 6cd5e746
 kubernetes 0.28.0 7f477eec
 kubernetes 0.29.0 87b23161
-kubernetes 0.29.1 HEAD
+kubernetes 0.29.1 53fbe7c2
+kubernetes 0.29.2 HEAD
 mysql 0.1.0 263e47be
 mysql 0.2.0 c24a103f
 mysql 0.3.0 53f2365e

--- a/packages/system/coredns/values.yaml
+++ b/packages/system/coredns/values.yaml
@@ -1,4 +1,2 @@
 coredns:
-  image:
-    repository: registry.k8s.io/coredns/coredns
   replicaCount: 2

--- a/packages/system/kubevirt-csi-node/templates/deploy.yaml
+++ b/packages/system/kubevirt-csi-node/templates/deploy.yaml
@@ -273,6 +273,7 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: csi.kubevirt.io
+allowVolumeExpansion: true
 parameters:
   infraStorageClassName: {{ .Values.storageClass }}
   bus: scsi

--- a/packages/system/kubevirt-csi-node/values.yaml
+++ b/packages/system/kubevirt-csi-node/values.yaml
@@ -1,3 +1,3 @@
 storageClass: replicated
 csiDriver:
-  image: ghcr.io/cozystack/cozystack/kubevirt-csi-driver:0.29.1@sha256:cae43eae09fc39e5f2140d30ef55253f871cc565b8b7a564a54077b7cbd92212
+  image: kklinch0/kubevirt-csi-driver:0.37.0@sha256:d334ba727f0974b085f6e44ee52a61fa0c507063875b52006665dbacfa332cbd


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
- add expanding persistent volumes in tenant clusters
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled PersistentVolumeClaim expansion in the KubeVirt CSI StorageClass.
  - Added CSI resizer sidecar to the controller for online volume resizing.
  - Introduced cluster-scoped RBAC to allow required access to PersistentVolumes.

- Chores
  - Updated Kubernetes app chart to 0.29.2 and set app version to 1.32.6.
  - Upgraded KubeVirt CSI driver image to 0.37.0.
  - Refreshed versions map entries for the new release.
  - Simplified CoreDNS configuration to use the default image repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->