### PR TITLE
[dashboard] fix: FerretDBs plural

### DIFF
--- a/packages/system/dashboard/values.yaml
+++ b/packages/system/dashboard/values.yaml
@@ -240,7 +240,7 @@ kubeapps:
               - application:
                   kind: FerretDB
                   singular: ferretdb
-                  plural: ferretdb
+                  plural: ferretdbs
                 release:
                   prefix: ferretdb-
                   labels:


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected the pluralized name for FerretDB resources in the dashboard configuration.
  - Improves consistency of how FerretDB resources appear across plugin-driven views.
  - No other changes to application behavior or configuration were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->