### PR TITLE
[dashboard] Fix FerretDB spec

### DIFF
--- a/packages/system/dashboard/values.yaml
+++ b/packages/system/dashboard/values.yaml
@@ -240,7 +240,7 @@ kubeapps:
               - application:
                   kind: FerretDB
                   singular: ferretdb
-                  plural: ferretdb
+                  plural: ferretdbs
                 release:
                   prefix: ferretdb-
                   labels:


### PR DESCRIPTION
## What this PR does

Due to a typo in the spec, the dashboard couldn't deploy or display instances of FerretDB. This patch fixes the typo.

### Release note

```release-note
[dashboard] Fix FerretDB management in the web UI.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected FerretDB resource pluralization to “ferretdbs,” aligning with Kubernetes conventions. This ensures resources display and behave correctly in the dashboard, preventing discovery issues and errors in listing, navigation, and management.
  - Improves reliability of installs and upgrades with Flux/Helm workflows by matching expected resource names. No other FerretDB settings were changed, maintaining backward compatibility for existing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->