### PR TITLE
fix(cadvisor/kubelet): remove noisy labels to restore CPU metrics

### DIFF
--- a/packages/system/monitoring-agents/templates/cadvisor-scrape.yaml
+++ b/packages/system/monitoring-agents/templates/cadvisor-scrape.yaml
@@ -19,10 +19,8 @@ spec:
     - __name__
   path: /metrics/cadvisor
   relabelConfigs:
-  - action: labelmap
-    regex: __meta_kubernetes_node_label_(.+)
-  - action: labeldrop
-    regex: '.*node_kubevirt_io.*'
+  - action: labelkeep
+    regex: "__address__|instance|__scheme__|__scrape_timeout__|__scrape_interval__|metrics_path|node|job|__metrics_path__"
   - sourceLabels: [__metrics_path__]
     targetLabel: metrics_path
   - replacement: cadvisor

--- a/packages/system/monitoring-agents/templates/kubelet-scrape.yaml
+++ b/packages/system/monitoring-agents/templates/kubelet-scrape.yaml
@@ -19,10 +19,8 @@ spec:
     - __name__
   path: /metrics/probes
   relabelConfigs:
-  - action: labelmap
-    regex: __meta_kubernetes_node_label_(.+)
-  - action: labeldrop
-    regex: '.*node_kubevirt_io.*'
+  - action: labelkeep
+    regex: "__address__|instance|__scheme__|__scrape_timeout__|__scrape_interval__|metrics_path|node|job|__metrics_path__|container|pod|namespace"
   - sourceLabels: [__metrics_path__]
     targetLabel: metrics_path
   - replacement: kubelet
@@ -51,10 +49,8 @@ spec:
     regex: (rest_client_request_duration_seconds_bucket|rest_client_request_duration_seconds_sum|rest_client_request_duration_seconds_count)
     source_labels: [__name__]
   relabelConfigs:
-  - action: labelmap
-    regex: __meta_kubernetes_node_label_(.+)
-  - action: labeldrop
-    regex: '.*node_kubevirt_io.*'
+  - action: labelkeep
+    regex: "__address__|instance|__scheme__|__scrape_timeout__|__scrape_interval__|metrics_path|node|job|__metrics_path__|container|pod|namespace"
   - sourceLabels:
     - __metrics_path__
     targetLabel: metrics_path


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->
This patch introduces a whitelist-based label filtering mechanism in
cadvisor/kubelet metrics collection. By explicitly keeping only the
desired labels, we avoid noisy and high-cardinality dimensions while
retaining meaningful CPU metrics for analysis.

This improves the stability of the metrics pipeline and ensures
consistent visibility into application workloads.

```release-note
[platform] Introduce whitelist label filtering for cadvisor/kubelet
metrics to reduce noise and improve CPU metric reliability.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Monitoring scrape configs now explicitly keep a whitelist of essential telemetry labels (instance, node, job, container, pod, namespace, metrics paths, scheme, scrape timeouts) to reduce label churn and improve query consistency across node, kubelet and cadvisor scrapes.
  * Scrapes now enforce HTTPS with TLS options and a 5s timeout for more consistent and reliable node/kubelet collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->