### PR TITLE
[dashboard] Fix /docs redirect

### DIFF
--- a/packages/system/dashboard/templates/nginx-config.yaml
+++ b/packages/system/dashboard/templates/nginx-config.yaml
@@ -55,12 +55,12 @@ data:
           proxy_pass http://incloud-web-web.{{ .Release.Namespace }}.svc:64231;
       }
 
-      location = / {
-          return 301 https://dashboard.{{ $host }}/openapi-ui;
-      }
-
       location = /docs {
           return 301 https://cozystack.io/docs/;
+      }
+
+      location = / {
+          return 301 https://dashboard.{{ $host }}/openapi-ui;
       }
 
       location / {


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Reordered the Nginx routing for the root path to follow the /docs block, keeping the existing redirect to the OpenAPI UI unchanged.
  - No user-facing behavior changes expected; request routing remains consistent.
  - Aimed at maintaining configuration clarity and alignment, with minimal risk and low review complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->