### PR TITLE
[kubernetes] Fix coredns tag

### DIFF
--- a/packages/system/coredns/values.yaml
+++ b/packages/system/coredns/values.yaml
@@ -1,2 +1,5 @@
 coredns:
+  image:
+    repository: registry.k8s.io/coredns/coredns
+    tag: v1.12.4
   replicaCount: 2


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

fixes https://github.com/cozystack/cozystack/issues/1468

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned CoreDNS image to registry.k8s.io/coredns/coredns:v1.12.4 for consistent, reproducible deployments.
  * Confirmed replica count remains at 2 (no scaling changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->