### PR TITLE
Add me to MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,3 +10,4 @@
 | Andrei Gumilev | [@chumkaska](https://github.com/chumkaska) | Ænix | Platform Documentation |
 | Timur Tukaev | [@tym83](https://github.com/tym83) | Ænix | Cozystack Website, Marketing, Community Management |
 | Kirill Klinchenkov | [@klinch0](https://github.com/klinch0) | Ænix | Core Maintainer |
+| Nikita Bykov | [@nbykov0](https://github.com/nbykov0) | Ænix | Maintainer of ARM and stuff |


### PR DESCRIPTION
Add me to MAINTAINERS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Nikita Bykov to the public maintainers list, including name, GitHub handle, company, and area of responsibility.
  * Ensures the maintainer roster is current and transparent for contributors and users seeking points of contact.
  * No product functionality, UI, or API behavior changes.
  * Helps improve project governance visibility and support routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->