### PR TITLE
[kafka] Disable noisy alerts

### DIFF
--- a/packages/system/kafka-operator/templates/alerts.yaml
+++ b/packages/system/kafka-operator/templates/alerts.yaml
@@ -1,7 +1,11 @@
-{{- $files := .Files.Glob "alerts/*.yaml" -}}
-{{- range $path, $file := $files }}
----
-# from: {{ $path }}
-{{ toString $file }}
-
-{{- end -}}
+{{- /*
+# Disabled due to https://github.com/cozystack/cozystack/issues/790
+# {{- $files := .Files.Glob "alerts/*.yaml" -}}
+# {{- range $path, $file := $files }}
+# ---
+# # from: {{ $path }}
+# {{ toString $file }}
+# 
+# {{- end -}}
+#
+*/ -}}


### PR DESCRIPTION
## What this PR does

The alerts deployed with the Kafka Strimzi operator are noisy and not useful, when a given namespace does not deploy any kafka clusters. This patch removes them.

### Release note

```release-note
[kafka] Disable useless alerts for Kafka which fire when not called for,
e.g. when Kafka isn't deployed.
```

fixes https://github.com/cozystack/cozystack/issues/790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Temporarily disabled rendering of monitoring alert snippets for the Kafka Operator, resulting in no alerts being generated from this component.
  * Keeps existing deployments unaffected beyond the absence of these alerts; no configuration changes required by users.
  * Preserves previous alert definitions internally for potential reactivation in a future update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->