### PR TITLE
[oidc] Check APIVersions before deploying

### DIFF
--- a/packages/apps/tenant/templates/keycloakgroups.yaml
+++ b/packages/apps/tenant/templates/keycloakgroups.yaml
@@ -1,6 +1,7 @@
 {{- $cozyConfig := lookup "v1" "ConfigMap" "cozy-system" "cozystack" }}
 {{- $oidcEnabled := index $cozyConfig.data "oidc-enabled" }}
 {{- if eq $oidcEnabled "true" }}
+{{- if .Capabilities.APIVersions.Has "v1.edp.epam.com/v1" }}
 apiVersion: v1.edp.epam.com/v1
 kind: KeycloakRealmGroup
 metadata:
@@ -50,4 +51,5 @@ spec:
   realmRef:
     name: keycloakrealm-cozy
     kind: ClusterKeycloakRealm
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## What this PR does

When enabling OIDC, the Tenant applications may try to deploy KeycloakRealmGroups before the Keycloak operator is live. This may lead to a race where neither HelmRelease is able to progress. This patch addresses this.

### Release note

```release-note
[oidc] Do not deploy KeycloakRealmGroup resources as part of the Tenant
application if the v1.edp.epam.com API is not yet available.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improves deployment reliability by conditionally creating the initial Keycloak realm group only when the required API version is available. This prevents install/upgrade failures in environments lacking the corresponding CRD.
  * Other Keycloak realm groups continue to be created as before, ensuring no change to existing group provisioning where supported.
  * Enhances cross-environment compatibility for tenant deployments without impacting users on fully supported clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->