### PR TITLE
[dashboard] Fix listing modules

### DIFF
--- a/internal/controller/dashboard/static_helpers.go
+++ b/internal/controller/dashboard/static_helpers.go
@@ -998,6 +998,15 @@ func createBoolColumn(name, jsonPath string) map[string]any {
 	}
 }
 
+// createReadyColumn creates a Ready column with Boolean type and condition check
+func createReadyColumn() map[string]any {
+	return map[string]any{
+		"name":     "Ready",
+		"type":     "Boolean",
+		"jsonPath": `.status.conditions[?(@.type=="Ready")].status`,
+	}
+}
+
 // createConverterBytesColumn creates a column with ConverterBytes component
 func createConverterBytesColumn(name, jsonPath string) map[string]any {
 	return map[string]any{

--- a/internal/controller/dashboard/static_refactored.go
+++ b/internal/controller/dashboard/static_refactored.go
@@ -149,9 +149,9 @@ func CreateAllCustomColumnsOverrides() []*dashboardv1alpha1.CustomColumnsOverrid
 		// Stock namespace core cozystack io v1alpha1 tenantmodules
 		createCustomColumnsOverride("stock-namespace-/core.cozystack.io/v1alpha1/tenantmodules", []any{
 			createCustomColumnWithJsonPath("Name", ".metadata.name", "M", "module", getColorForType("module"), "/openapi-ui/{2}/{reqsJsonPath[0]['.metadata.namespace']['-']}/factory/{reqsJsonPath[0]['.metadata.name']['-']}-details/{reqsJsonPath[0]['.metadata.name']['-']}"),
-			createStringColumn("Version", ".spec.version"),
-			createStringColumn("Status", ".status.phase"),
+			createReadyColumn(),
 			createTimestampColumn("Created", ".metadata.creationTimestamp"),
+			createStringColumn("Version", ".status.version"),
 		}),
 
 		// Factory service details port mapping


### PR DESCRIPTION

<img width="2620" height="1970" alt="image" src="https://github.com/user-attachments/assets/a8d0417b-214f-4c6c-8cab-2539043c62e8" />

Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Tenant Modules dashboard now shows a Ready status column, providing a clear readiness indicator at a glance.
  - Column layout updated for clarity: Ready appears before Created; Version remains visible and now reflects the reported runtime version.
  - Removed the previous Status column and legacy Version source to reduce confusion and highlight current operational state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->