### PR TITLE
Add addtional check to wait for lineage-webhook

### DIFF
--- a/scripts/migrations/20
+++ b/scripts/migrations/20
@@ -28,6 +28,8 @@ cozypkg -n cozy-system -C packages/system/cozystack-api apply cozystack-api --pl
 helm upgrade --install -n cozy-system cozystack-controller ./packages/system/cozystack-controller/ --take-ownership
 
 sleep 5
+timeout 60 sh -c 'until kubectl create service clusterip lineage-webhook-test --clusterip="None" --dry-run=server; do sleep 1; done'
+
 kubectl wait deployment/cozystack-api -n cozy-system --timeout=4m --for=condition=available || exit 1
 kubectl wait deployment/cozystack-controller -n cozy-system --timeout=4m --for=condition=available || exit 1
 


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a timeout-based step that repeatedly attempts server-side dry-run creation of a Kubernetes Service (headless) between controller upgrade and subsequent waits.
  * Inserts this validation step without altering existing flow or other behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->