### PR TITLE
[api] Efficient listing of TenantNamespaces

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -138,8 +138,7 @@ func (c completedConfig) New() (*CozyServer, error) {
 	coreV1alpha1Storage["tenantnamespaces"] = cozyregistry.RESTInPeace(
 		tenantnamespacestorage.NewREST(
 			clientset.CoreV1(),
-			clientset.AuthorizationV1(),
-			20,
+			clientset.RbacV1(),
 		),
 	)
 	coreV1alpha1Storage["tenantsecrets"] = cozyregistry.RESTInPeace(


### PR DESCRIPTION
## What this PR does

The Cozystack API server lists TenantNamespaces by running a SubjectAccessReview against every single requested namespace to see if the user can create a WorkloadMonitor there. Will this is robust in terms of permissions, delegating the authorization decision to the k8s API, this is incredibly inefficient and has caused high latency to the API. This patch simplifies the logic by instead getting the user's groups and checking if the namespace contains a rolebinding for that group. That way listing TenantNamespaces is reduced to a list call to the k8s API for namespaces and another list call for rolebindings across all namespaces, while authorization is done on the Cozystack API server instead of making further calls to the k8s API.

### Release note

```release-note
[api] Optimize listing of TenantNamespaces, fixes a bug causing very
high latency to the k8s API.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - TenantNamespace visibility now consistently reflects RBAC role bindings. Cluster administrators see all namespaces; users only see namespaces they’re permitted to access.

- Refactor
  - Access evaluation simplified to rely on role/rolebinding membership, removing per-namespace authorization calls and improving listing performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->