### PR TITLE
Update Kube-OVN v1.14.11

### DIFF
--- a/packages/system/kubeovn/charts/kube-ovn/Chart.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v1.14.5
+version: v1.14.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.14.5"
+appVersion: "1.14.11"
 
 kubeVersion: ">= 1.29.0-0"

--- a/packages/system/kubeovn/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -257,8 +257,9 @@ spec:
                                     type: array
                                 type: object
                               weight:
-                                format: int32
                                 type: integer
+                                minimum: 1
+                                maximum: 100
                             required:
                               - preference
                               - weight
@@ -349,8 +350,9 @@ spec:
                                   - topologyKey
                                 type: object
                               weight:
-                                format: int32
                                 type: integer
+                                minimum: 1
+                                maximum: 100
                             required:
                               - podAffinityTerm
                               - weight
@@ -437,8 +439,9 @@ spec:
                                   - topologyKey
                                 type: object
                               weight:
-                                format: int32
                                 type: integer
+                                minimum: 1
+                                maximum: 100
                             required:
                               - podAffinityTerm
                               - weight
@@ -593,8 +596,9 @@ spec:
                                     type: array
                                 type: object
                               weight:
-                                format: int32
                                 type: integer
+                                minimum: 1
+                                maximum: 100
                             required:
                               - preference
                               - weight
@@ -685,8 +689,9 @@ spec:
                                   - topologyKey
                                 type: object
                               weight:
-                                format: int32
                                 type: integer
+                                minimum: 1
+                                maximum: 100
                             required:
                               - podAffinityTerm
                               - weight
@@ -773,8 +778,9 @@ spec:
                                   - topologyKey
                                 type: object
                               weight:
-                                format: int32
                                 type: integer
+                                minimum: 1
+                                maximum: 100
                             required:
                               - podAffinityTerm
                               - weight
@@ -891,7 +897,8 @@ spec:
               properties:
                 replicas:
                   type: integer
-                  format: int32
+                  minimum: 0
+                  maximum: 10
                 labelSelector:
                   type: string
                 conditions:
@@ -907,7 +914,6 @@ spec:
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        format: int64
                         minimum: 0
                         type: integer
                       reason:
@@ -988,7 +994,6 @@ spec:
               properties:
                 replicas:
                   type: integer
-                  format: int32
                   default: 1
                   minimum: 0
                   maximum: 10
@@ -1036,16 +1041,19 @@ spec:
                       default: false
                     minRX:
                       type: integer
-                      format: int32
                       default: 1000
+                      minimum: 1
+                      maximum: 3600000
                     minTX:
                       type: integer
-                      format: int32
                       default: 1000
+                      minimum: 1
+                      maximum: 3600000
                     multiplier:
                       type: integer
-                      format: int32
                       default: 3
+                      minimum: 1
+                      maximum: 3600000
                 selectors:
                   type: array
                   items:

--- a/packages/system/kubeovn/charts/kube-ovn/templates/ovncni-ds.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/ovncni-ds.yaml
@@ -272,5 +272,5 @@ spec:
         {{- if .Values.func.ENABLE_OVN_IPSEC }}
         - name: ovs-ipsec-keys
           hostPath:
-            path: {{ .Values.OPENVSWITCH_DIR }}
+            path: {{ .Values.OVN_IPSEC_KEY_DIR }}
         {{- end }}

--- a/packages/system/kubeovn/charts/kube-ovn/values.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/values.yaml
@@ -9,7 +9,7 @@ global:
     kubeovn:
       repository: kube-ovn
       vpcRepository: vpc-nat-gateway
-      tag: v1.14.5
+      tag: v1.14.11
       support_arm: true
       thirdparty: true
 
@@ -123,6 +123,7 @@ log_conf:
   LOG_DIR: "/var/log"
 
 OPENVSWITCH_DIR: "/etc/origin/openvswitch"
+OVN_IPSEC_KEY_DIR: "/etc/origin/ovs_ipsec_keys"
 OVN_DIR: "/etc/origin/ovn"
 DISABLE_MODULES_MANAGEMENT: false
 

--- a/packages/system/kubeovn/images/kubeovn/Dockerfile
+++ b/packages/system/kubeovn/images/kubeovn/Dockerfile
@@ -1,10 +1,10 @@
 # syntax = docker/dockerfile:experimental
-ARG VERSION=v1.14.5
+ARG VERSION=v1.14.11
 ARG BASE_TAG=$VERSION
 
-FROM golang:1.24-bookworm as builder
+FROM golang:1.25-bookworm as builder
 
-ARG TAG=v1.14.5
+ARG TAG=v1.14.11
 RUN git clone --branch ${TAG} --depth 1 https://github.com/kubeovn/kube-ovn /source
 
 WORKDIR /source


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added configurable OVN IPsec key directory and updated deployments to mount keys from this path.
  - Tightened CRD validation with explicit numeric min/max bounds to prevent invalid configurations.

- Chores
  - Updated kube-ovn chart and container image to v1.14.11 (build environment updated).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->