### PR TITLE
[bucket] Expose bucket name in secrets

### DIFF
--- a/packages/system/bucket/templates/secret.yaml
+++ b/packages/system/bucket/templates/secret.yaml
@@ -3,6 +3,7 @@
 {{- $accessKeyID := index $bucketInfo.spec.secretS3 "accessKeyID" }}
 {{- $accessSecretKey := index $bucketInfo.spec.secretS3 "accessSecretKey" }}
 {{- $endpoint := index $bucketInfo.spec.secretS3 "endpoint" }}
+{{- $bucketName := index $bucketInfo.spec "bucketName" }}
 
 apiVersion: v1
 kind: Secret
@@ -13,6 +14,7 @@ stringData:
   accessKey: {{ $accessKeyID | quote }}
   secretKey: {{ $accessSecretKey | quote }}
   endpoint: {{ trimPrefix "https://" $endpoint }}
+  bucketName: {{ $bucketName | quote }}
 ---
 apiVersion: v1
 kind: Secret

--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -120,7 +120,7 @@ seaweedfs:
     bucketClassName: "seaweedfs"
     region: ""
     sidecar:
-      image: "ghcr.io/cozystack/cozystack/objectstorage-sidecar:v0.37.0@sha256:f166f09cdc9cdbb758209883819ab8261a3793bc1d7a6b6685efd5a2b2930847"
+      image: "ghcr.io/cozystack/cozystack/objectstorage-sidecar:latest@sha256:f4ec2b5ec8183870e710b32fa11b3af5d97fa664572df5edcff4b593b00f9a7b"
   certificates:
     commonName: "SeaweedFS CA"
     ipAddresses: []


### PR DESCRIPTION
## What this PR does

The object storage controller creates secrets with bucket credentials that have no reference to the parent BucketAccess object. Because of this they cannot be linked to the managing app (buckets.apps.cozystack.io) and are not displayed in the new dashboard. This change patches the auxiliary helm release <bucket_name>-system to include the bucket name in __its__ secret, so that the necessary secret values is still presented to the user.

### Release note

```release-note
[bucket] Expose bucket name in tenant secret.
```