### PR TITLE
[platform] Better migration for 0.36.2->0.37.2+

### DIFF
--- a/scripts/migrations/20
+++ b/scripts/migrations/20
@@ -26,9 +26,16 @@ cozypkg -n cozy-system -C packages/system/cozystack-resource-definition-crd appl
 cozypkg -n cozy-system -C packages/system/cozystack-resource-definitions apply cozystack-resource-definitions --plain
 cozypkg -n cozy-system -C packages/system/cozystack-api apply cozystack-api --plain
 helm upgrade --install -n cozy-system cozystack-controller ./packages/system/cozystack-controller/ --take-ownership
+helm upgrade --install -n cozy-system lineage-controller-webhook ./packages/system/lineage-controller-webhook/ --take-ownership
 
 sleep 5
-timeout 60 sh -c 'until kubectl create service clusterip lineage-webhook-test --clusterip="None" --dry-run=server; do sleep 1; done'
+kubectl delete ns cozy-lineage-webhook-test --ignore-not-found && kubectl create ns cozy-lineage-webhook-test
+cleanup_test_ns() {
+  kubectl delete ns cozy-lineage-webhook-test --ignore-not-found
+}
+trap cleanup_test_ns ERR
+timeout 60 sh -c 'until kubectl -n cozy-lineage-webhook-test create service clusterip lineage-webhook-test --clusterip="None" --dry-run=server; do sleep 1; done'
+cleanup_test_ns
 
 kubectl wait deployment/cozystack-api -n cozy-system --timeout=4m --for=condition=available || exit 1
 kubectl wait deployment/cozystack-controller -n cozy-system --timeout=4m --for=condition=available || exit 1


### PR DESCRIPTION
## What this PR does

For users upgrading from 0.36.2 directly to 0.37.2+, where the lineage-controller-webhook is broken out of the Cozystack controller into a separate daemonset, the existing migration script of 0.36->0.37.0 is insufficient. This patch ensures the presence of the new version of the lineage webhook and fixes a bug in the migration script where the readiness of the webhook was not appropriately verified.

### Release note

```release-note
[platform] Improved migration script when skipping versions 0.37.0 and
0.37.1 during upgrades.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically installs the lineage-controller webhook via Helm during setup, aligning its deployment with existing controller components.

* **Chores**
  * Adds a temporary namespace for preflight validation of the webhook service to avoid cluster-wide side effects.
  * Replaces cluster-scoped dry-run checks with namespace-scoped dry-run and ensures cleanup and timeout-based waits for predictable installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->