### PR TITLE
[dashboard] Show service LB IP

### DIFF
--- a/internal/controller/dashboard/static_refactored.go
+++ b/internal/controller/dashboard/static_refactored.go
@@ -142,7 +142,7 @@ func CreateAllCustomColumnsOverrides() []*dashboardv1alpha1.CustomColumnsOverrid
 		createCustomColumnsOverride("stock-namespace-/v1/services", []any{
 			createCustomColumnWithJsonPath("Name", ".metadata.name", "S", "service", getColorForType("service"), "/openapi-ui/{2}/{reqsJsonPath[0]['.metadata.namespace']['-']}/factory/kube-service-details/{reqsJsonPath[0]['.metadata.name']['-']}"),
 			createStringColumn("ClusterIP", ".spec.clusterIP"),
-			createStringColumn("LoadbalancerIP", ".spec.loadBalancerIP"),
+			createStringColumn("LoadbalancerIP", ".status.loadBalancer.ingress[0].ip"),
 			createTimestampColumn("Created", ".metadata.creationTimestamp"),
 		}),
 


### PR DESCRIPTION
Fix an incorrect JSON path that prevented Service LoadBalancer IPs from rendering in the table view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected LoadBalancerIP column to display the actual load balancer ingress IP from status information instead of configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->