### PR TITLE
[lineage] Check for nil chart in HelmRelease

### DIFF
--- a/internal/lineagecontrollerwebhook/config.go
+++ b/internal/lineagecontrollerwebhook/config.go
@@ -38,6 +38,9 @@ func (l *LineageControllerWebhook) Map(hr *helmv2.HelmRelease) (string, string, 
 	if !ok {
 		return "", "", "", fmt.Errorf("failed to load chart-app mapping from config")
 	}
+	if hr.Spec.Chart == nil {
+		return "", "", "", fmt.Errorf("cannot map helm release %s/%s to dynamic app", hr.Namespace, hr.Name)
+	}
 	s := hr.Spec.Chart.Spec
 	val, ok := cfg.chartAppMap[chartRef{s.SourceRef.Name, s.Chart}]
 	if !ok {


### PR DESCRIPTION
## What this PR does

Some HelmReleases use `chartRef` instead of `chart`. If the lineage webhook finds such a HelmRelease, a nil pointer dereference happens. This patch adds a nil check to guard against this.

### Release note

```release-note
[lineage] Add a nil check to guard against HelmReleases with a nil
.spec.chart field when traversing the ownership tree.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced error handling for Helm release processing. The system now gracefully handles Helm releases that are missing a Chart specification, providing informative error messages instead of causing unexpected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->