### PR TITLE
[seaweedfs] Allow users to discover their buckets

### DIFF
--- a/packages/system/seaweedfs/Makefile
+++ b/packages/system/seaweedfs/Makefile
@@ -1,12 +1,30 @@
-NAME=seaweedfs-system
+export NAME=seaweedfs-system
 
+include ../../../scripts/common-envs.mk
 include ../../../scripts/package.mk
 
 update:
 	rm -rf charts
 	mkdir -p charts
-	curl -sSL https://github.com/seaweedfs/seaweedfs/archive/refs/heads/master.tar.gz | \
-	tar xzvf - --strip 3 -C charts seaweedfs-master/k8s/charts/seaweedfs
+	version=$$(git ls-remote --tags --sort="v:refname" https://github.com/seaweedfs/seaweedfs | grep -v '\^{}' | grep 'refs/tags/[0-9]' | awk -F'/' 'END{print $$3}') && \
+	curl -sSL https://github.com/seaweedfs/seaweedfs/archive/refs/tags/$${version}.tar.gz | \
+	tar xzvf - --strip 3 -C charts seaweedfs-$${version}/k8s/charts/seaweedfs && \
+	sed -i.bak "/ARG VERSION/ s|=.*|=$${version}|g" images/seaweedfs/Dockerfile && \
+	rm -f images/seaweedfs/Dockerfile.bak
 	patch --no-backup-if-mismatch -p4 < patches/resize-api-server-annotation.diff
 	patch --no-backup-if-mismatch -p4 < patches/fix-volume-servicemonitor.patch
 	#patch --no-backup-if-mismatch -p4 < patches/retention-policy-delete.yaml
+
+image:
+	docker buildx build images/seaweedfs \
+		--tag $(REGISTRY)/seaweedfs:$(call settag,$(TAG)) \
+		--cache-from type=registry,ref=$(REGISTRY)/seaweedfs:latest \
+		--cache-to type=inline \
+		--metadata-file images/seaweedfs.json \
+		$(BUILDX_ARGS)
+	REGISTRY="$(REGISTRY)" \
+		yq -i '.seaweedfs.image.registry = strenv(REGISTRY)' values.yaml
+	TAG=$(TAG)@$$(yq e '."containerimage.digest"' images/seaweedfs.json -o json -r) \
+		yq -i '.seaweedfs.image.tag = strenv(TAG)' values.yaml
+	yq -i '.global.imageName = "seaweedfs"' values.yaml
+	rm -f images/seaweedfs.json

--- a/packages/system/seaweedfs/images/seaweedfs/Dockerfile
+++ b/packages/system/seaweedfs/images/seaweedfs/Dockerfile
@@ -1,0 +1,58 @@
+FROM golang:1.24-alpine as builder
+
+ARG VERSION=3.97
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN apk add --no-cache git g++ fuse
+
+WORKDIR /workspace
+
+RUN git clone --depth 1 --branch ${VERSION} https://github.com/seaweedfs/seaweedfs.git .
+
+COPY patches /patches
+RUN git apply /patches/*.diff
+
+RUN cd weed && \
+    export LDFLAGS="-X github.com/seaweedfs/seaweedfs/weed/util/version.COMMIT=$(git rev-parse --short HEAD)" && \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build \
+    -tags "full" \
+    -ldflags "-extldflags -static ${LDFLAGS}" \
+    -o /usr/bin/weed
+
+FROM alpine AS final
+
+LABEL author="Chris Lu"
+
+COPY --from=builder /usr/bin/weed /usr/bin/
+RUN mkdir -p /etc/seaweedfs
+COPY --from=builder /workspace/docker/filer.toml /etc/seaweedfs/filer.toml
+COPY --from=builder /workspace/docker/entrypoint.sh /entrypoint.sh
+RUN apk add --no-cache fuse
+
+# volume server gprc port
+EXPOSE 18080
+# volume server http port
+EXPOSE 8080
+# filer server gprc port
+EXPOSE 18888
+# filer server http port
+EXPOSE 8888
+# master server shared gprc port
+EXPOSE 19333
+# master server shared http port
+EXPOSE 9333
+# s3 server http port
+EXPOSE 8333
+# webdav server http port
+EXPOSE 7333
+
+RUN mkdir -p /data/filerldb2
+
+VOLUME /data
+WORKDIR /data
+
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+

--- a/packages/system/seaweedfs/images/seaweedfs/patches/fix-signature-permission-check.diff
+++ b/packages/system/seaweedfs/images/seaweedfs/patches/fix-signature-permission-check.diff
@@ -1,0 +1,58 @@
+diff --git a/weed/s3api/auth_signature_v2.go b/weed/s3api/auth_signature_v2.go
+index 4cdc07df0..b31c37a27 100644
+--- a/weed/s3api/auth_signature_v2.go
++++ b/weed/s3api/auth_signature_v2.go
+@@ -116,11 +116,6 @@ func (iam *IdentityAccessManagement) doesSignV2Match(r *http.Request) (*Identity
+ 		return nil, s3err.ErrInvalidAccessKeyID
+ 	}
+ 
+-	bucket, object := s3_constants.GetBucketAndObject(r)
+-	if !identity.canDo(s3_constants.ACTION_WRITE, bucket, object) {
+-		return nil, s3err.ErrAccessDenied
+-	}
+-
+ 	expectedAuth := signatureV2(cred, r.Method, r.URL.Path, r.URL.Query().Encode(), r.Header)
+ 	if !compareSignatureV2(v2Auth, expectedAuth) {
+ 		return nil, s3err.ErrSignatureDoesNotMatch
+@@ -163,11 +158,6 @@ func (iam *IdentityAccessManagement) doesPresignV2SignatureMatch(r *http.Request
+ 		return nil, s3err.ErrInvalidAccessKeyID
+ 	}
+ 
+-	bucket, object := s3_constants.GetBucketAndObject(r)
+-	if !identity.canDo(s3_constants.ACTION_READ, bucket, object) {
+-		return nil, s3err.ErrAccessDenied
+-	}
+-
+ 	expectedSignature := preSignatureV2(cred, r.Method, r.URL.Path, r.URL.Query().Encode(), r.Header, expires)
+ 	if !compareSignatureV2(signature, expectedSignature) {
+ 		return nil, s3err.ErrSignatureDoesNotMatch
+diff --git a/weed/s3api/auth_signature_v4.go b/weed/s3api/auth_signature_v4.go
+index a0417a922..c512f70cc 100644
+--- a/weed/s3api/auth_signature_v4.go
++++ b/weed/s3api/auth_signature_v4.go
+@@ -190,12 +190,6 @@ func (iam *IdentityAccessManagement) doesSignatureMatch(hashedPayload string, r
+ 		return nil, s3err.ErrInvalidAccessKeyID
+ 	}
+ 
+-	bucket, object := s3_constants.GetBucketAndObject(r)
+-	canDoResult := identity.canDo(s3_constants.ACTION_WRITE, bucket, object)
+-	if !canDoResult {
+-		return nil, s3err.ErrAccessDenied
+-	}
+-
+ 	// Extract date, if not present throw error.
+ 	var dateStr string
+ 	if dateStr = req.Header.Get("x-amz-date"); dateStr == "" {
+@@ -318,12 +312,6 @@ func (iam *IdentityAccessManagement) doesPresignedSignatureMatch(hashedPayload s
+ 		return nil, s3err.ErrInvalidAccessKeyID
+ 	}
+ 
+-	// Check permissions
+-	bucket, object := s3_constants.GetBucketAndObject(r)
+-	if !identity.canDo(s3_constants.ACTION_READ, bucket, object) {
+-		return nil, s3err.ErrAccessDenied
+-	}
+-
+ 	// Parse date
+ 	t, e := time.Parse(iso8601Format, dateStr)
+ 	if e != nil {

--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -1,12 +1,15 @@
 global:
   enableSecurity: true
   serviceAccountName: "tenant-foo-seaweedfs"
+  imageName: "ghcr.io/cozystack/cozystack/seaweedfs"
   extraEnvironmentVars:
     WEED_CLUSTER_SW_MASTER: "seaweedfs-master:9333"
     WEED_CLUSTER_SW_FILER: "seaweedfs-filer-client:8888"
   monitoring:
     enabled: true
 seaweedfs:
+  image:
+    tag: "latest@sha256:5ab64da9a0bc33c555f18d86a9664fe63617d48e5ea5192ef34822c24dcc5771"
   master:
     volumeSizeLimitMB: 30000
     replicas: 3


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

This PR enables building of `seaweedfs` image.
Also backports patch from upstream https://github.com/seaweedfs/seaweedfs/pull/7335 

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[seaweedfs] Allow users to discover their buckets
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * S3 signature handling adjusted so signature verification focuses on authentication; permission checks are evaluated afterward.

* **Chores**
  * Build process now discovers and uses remote release versions dynamically.
  * Introduced an optimized multi-stage container build with improved tagging and registry caching.
  * Added configurable image settings (global image name and image tag) for deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->