### PR TITLE
Added a setting for sending alerts to Slack

### DIFF
--- a/internal/lineagecontrollerwebhook/config.go
+++ b/internal/lineagecontrollerwebhook/config.go
@@ -38,6 +38,9 @@ func (l *LineageControllerWebhook) Map(hr *helmv2.HelmRelease) (string, string, 
 	if !ok {
 		return "", "", "", fmt.Errorf("failed to load chart-app mapping from config")
 	}
+	if hr.Spec.Chart == nil {
+		return "", "", "", fmt.Errorf("cannot map helm release %s/%s to dynamic app", hr.Namespace, hr.Name)
+	}
 	s := hr.Spec.Chart.Spec
 	val, ok := cfg.chartAppMap[chartRef{s.SourceRef.Name, s.Chart}]
 	if !ok {

--- a/packages/extra/monitoring/README.md
+++ b/packages/extra/monitoring/README.md
@@ -72,7 +72,8 @@
 | `alerta.alerts.telegram.token`            | Telegram token for your bot                                                         | `string`    | `""`    |
 | `alerta.alerts.telegram.chatID`           | Specify multiple ID's separated by comma. Get yours in https://t.me/chatid_echo_bot | `string`    | `""`    |
 | `alerta.alerts.telegram.disabledSeverity` | List of severity without alerts, separated by comma like: "informational,warning"   | `string`    | `""`    |
-
+| `alerta.alerts.slack`                     | Configuration for Slack alerts                                                      | `*object`   | `null`  |
+| `alerta.alerts.slack.url`                 | Slack webhook URL                                                                   | `string`    | `""`    |
 
 ### Grafana configuration
 

--- a/packages/extra/monitoring/templates/alerta/alerta.yaml
+++ b/packages/extra/monitoring/templates/alerta/alerta.yaml
@@ -122,6 +122,13 @@ spec:
               value: "{{ .Values.alerta.alerts.telegram.disabledSeverity }}"
             {{- end }}
 
+            {{- if .Values.alerta.alerts.slack.url }}
+            - name: "PLUGINS"
+              value: "slack"
+            - name: "SLACK_WEBHOOK_URL"
+              value: "{{ .Values.alerta.alerts.slack.url }}"
+            {{- end }}
+
           ports:
             - name: http
               containerPort: 8080

--- a/packages/extra/monitoring/values.schema.json
+++ b/packages/extra/monitoring/values.schema.json
@@ -12,6 +12,20 @@
           "type": "object",
           "default": {},
           "properties": {
+            "slack": {
+              "description": "Configuration for Slack alerts",
+              "type": "object",
+              "default": {},
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "url": {
+                  "description": "Slack webhook URL",
+                  "type": "string"
+                }
+              }
+            },
             "telegram": {
               "description": "Configuration for Telegram alerts",
               "type": "object",

--- a/packages/extra/monitoring/values.yaml
+++ b/packages/extra/monitoring/values.yaml
@@ -90,6 +90,8 @@ logsStorages:
 ## @field telegramAlerts.token {string} Telegram token for your bot
 ## @field telegramAlerts.chatID {string} Specify multiple ID's separated by comma. Get yours in https://t.me/chatid_echo_bot
 ## @field telegramAlerts.disabledSeverity {string} List of severity without alerts, separated by comma like: "informational,warning"
+## @field alerts.slack {*slackAlerts} Configuration for Slack alerts
+## @field slackAlerts.url {string} Slack webhook URL
 alerta:
   storage: 10Gi
   storageClassName: ""
@@ -111,6 +113,9 @@ alerta:
       token: ""
       chatID: ""
       disabledSeverity: ""
+
+    slack:
+      url: ""
 
 ## @section Grafana configuration
 


### PR DESCRIPTION
The ability to send alerts to Slack has been added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Slack webhook support for alerta so alerts can be sent to Slack when a URL is provided.
  * Alerta now builds active notification integrations at runtime and enables only configured providers (Slack alongside existing Telegram).

* **Bug Fixes**
  * Improved stability when processing certain release metadata to prevent unexpected failures.

* **Documentation**
  * Updated configuration docs and schema to include Slack alerting options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->