### PR TITLE
[velero] Set defaultItemOperationTimeout=24h

### DIFF
--- a/packages/system/velero/values.yaml
+++ b/packages/system/velero/values.yaml
@@ -13,3 +13,6 @@ velero:
     volumeSnapshotLocation: null
     namespace: cozy-velero
     features: EnableCSI
+    # Increase timeout for item operations to 24 hours to prevent timeouts
+    # during backups of very large volumes. The Velero default is 4 hours.
+    defaultItemOperationTimeout: 24h


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

This PR changes default timeout for Velero to copy single item. Default value 4h is not enough for copying large block volumes of virtual machines. 

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[velero] Set defaultItemOperationTimeout=24h
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended default operation timeout to 24 hours to provide increased time for operations to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->