### PR TITLE
[redis-operator] Build patched operator in-tree

### DIFF
--- a/packages/system/redis-operator/Makefile
+++ b/packages/system/redis-operator/Makefile
@@ -1,6 +1,8 @@
+REDIS_OPERATOR_TAG=$(shell grep -F 'ARG VERSION=' images/redis-operator/Dockerfile | cut -f2 -d=)
 export NAME=redis-operator
 export NAMESPACE=cozy-$(NAME)
 
+include ../../../scripts/common-envs.mk
 include ../../../scripts/package.mk
 
 update:
@@ -9,3 +11,16 @@ update:
 	helm repo update redis-operator
 	helm pull redis-operator/redis-operator --untar --untardir charts
 	sed -i '/{{/d' charts/redis-operator/crds/databases.spotahome.com_redisfailovers.yaml
+
+image:
+	docker buildx build images/redis-operator \
+		--tag $(REGISTRY)/redis-operator:$(REDIS_OPERATOR_TAG) \
+		--cache-from type=registry,ref=$(REGISTRY)/redis-operator:latest \
+		--cache-to type=inline \
+		--metadata-file images/redis-operator.json \
+		$(BUILDX_ARGS)
+	REPOSITORY="$(REGISTRY)/redis-operator" \
+		yq -i '.redis-operator.image.repository = strenv(REPOSITORY)' values.yaml
+	TAG=$(REDIS_OPERATOR_TAG)@$$(yq e '."containerimage.digest"' images/redis-operator.json -o json -r) \
+		yq -i '.redis-operator.image.tag = strenv(TAG)' values.yaml
+	rm -f images/redis-operator.json

--- a/packages/system/redis-operator/images/redis-operator/Dockerfile
+++ b/packages/system/redis-operator/images/redis-operator/Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:1.20 AS builder
+
+ARG VERSION=v1.3.0-rc1
+
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+
+RUN curl -sSL https://github.com/spotahome/redis-operator/archive/refs/tags/${VERSION}.tar.gz | tar -xzvf- --strip=1
+
+COPY patches /patches
+RUN git apply /patches/*.diff
+
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH VERSION=$VERSION ./scripts/build.sh
+
+FROM alpine:latest
+RUN apk --no-cache add \
+  ca-certificates
+COPY --from=builder /workspace/bin/redis-operator /usr/local/bin
+RUN addgroup -g 1000 rf && \
+  adduser -D -u 1000 -G rf rf && \
+  chown rf:rf /usr/local/bin/redis-operator
+USER rf
+
+ENTRYPOINT ["/usr/local/bin/redis-operator"]
+

--- a/packages/system/redis-operator/images/redis-operator/patches/labels.diff
+++ b/packages/system/redis-operator/images/redis-operator/patches/labels.diff
@@ -1,0 +1,23 @@
+diff --git a/service/k8s/service.go b/service/k8s/service.go
+index 712cc4c0..e84afc92 100644
+--- a/service/k8s/service.go
++++ b/service/k8s/service.go
+@@ -10,6 +10,7 @@ import (
+ 
+ 	"github.com/spotahome/redis-operator/log"
+ 	"github.com/spotahome/redis-operator/metrics"
++	"github.com/spotahome/redis-operator/operator/redisfailover/util"
+ )
+ 
+ // Service the ServiceAccount service that knows how to interact with k8s to manage them
+@@ -95,6 +96,10 @@ func (s *ServiceService) CreateOrUpdateService(namespace string, service *corev1
+ 	// namespace is our spec(https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#concurrency-control-and-consistency),
+ 	// we will replace the current namespace state.
+ 	service.ResourceVersion = storedService.ResourceVersion
++	newLabels := util.MergeLabels(storedService.GetLabels(), service.GetLabels())
++	newAnnotations := util.MergeAnnotations(storedService.GetAnnotations(), service.GetAnnotations())
++	service.SetLabels(newLabels)
++	service.SetAnnotations(newAnnotations)
+ 	return s.UpdateService(namespace, service)
+ }
+ 

--- a/packages/system/redis-operator/values.yaml
+++ b/packages/system/redis-operator/values.yaml
@@ -1,3 +1,4 @@
 redis-operator:
   image:
-    tag: v1.3.0-rc1
+    repository: ghcr.io/cozystack/cozystack/redis-operator
+    tag: v1.3.0-rc1@sha256:a4012e6a1b5daaedb57cc27edfdbff52124de4164b5ec0ee53c5ce5710ef4c25


### PR DESCRIPTION
## What this PR does

This patch moves the build of the Redis operator into the Cozystack organization and patches it to prevent overwriting third-party labels on owned resources.

### Release note

```release-note
[redis-operator] Move operator into tree and patch it to retain
third-party labels on owned resources, reducing noisy traffic to the API
server.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated Docker image build pipeline with version tracking and caching.
  * Updated image configuration to include repository reference and digest for reproducibility.

* **Bug Fixes**
  * Improved label and annotation handling to preserve existing Kubernetes resource metadata instead of overwriting it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->