### PR TITLE
[controller] Remove crdmem, handle DaemonSet

### DIFF
--- a/packages/system/cozystack-controller/templates/deployment.yaml
+++ b/packages/system/cozystack-controller/templates/deployment.yaml
@@ -28,3 +28,6 @@ spec:
         {{- if .Values.cozystackController.disableTelemetry }}
         - --disable-telemetry
         {{- end }}
+        {{- if eq .Values.cozystackController.cozystackAPIKind "Deployment" }}
+        - --reconcile-deployment
+        {{- end }}

--- a/packages/system/cozystack-controller/templates/role.yaml
+++ b/packages/system/cozystack-controller/templates/role.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: cozy-system
 rules:
 - apiGroups: ["apps"]
-  resources: ["deployments"]
+  resources: ["deployments", "daemonsets"]
   resourceNames: ["cozystack-api"]
   verbs: ["patch", "update"]
 

--- a/packages/system/cozystack-controller/values.yaml
+++ b/packages/system/cozystack-controller/values.yaml
@@ -3,3 +3,4 @@ cozystackController:
   debug: false
   disableTelemetry: false
   cozystackVersion: "v0.37.0"
+  cozystackAPIKind: "DaemonSet"


### PR DESCRIPTION
## What this PR does

This patch drops the custom caching of the Cozystack resource definitions in favor of the informer cache and adds a flag to the Cozystack controller to select, whether it restarts the cozystack-api deployment or the cozystack-api daemonset.

### BREAKING CHANGES

As with the new default behavior of using a local endpoint for the k8s API by the lineage webhook and the Cozystack API, the Cozystack controller now also defaults to restarting a Cozystack API DaemonSet instead of a Deployment. To revert to the old behavior, disable the local k8s API endpoint on the webhook and cozystack API and set the `cozystackController.cozystackAPIKind` value in the Cozystack controller system Helm chart to "Deployment".

### Release note

```release-note
[controller] Use informer cache instead of the older bespoke
implementation and add support for running the Cozystack API as a
DaemonSet.
```