### PR TITLE
[kubernetes] Use controlPlane.replicas field

### DIFF
--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -147,7 +147,7 @@ spec:
     podAdditionalMetadata:
       labels:
         policy.cozystack.io/allow-to-etcd: "true"
-  replicas: 2
+  replicas: {{ .Values.controlPlane.replicas }}
   version: {{ include "kubernetes.versionMap" $ }}
 ---
 apiVersion: cozystack.io/v1alpha1


### PR DESCRIPTION
## What this PR does

The managed Kubernetes app accepts a .controPlane.replicas field, but this value was never used, instead being hardcoded in the KamajiControlPlane template to 2. This patch fixes this.

### Release note

```release-note
[kubernetes] Pass the .controlPlane.replicas field into the
KamajiControlPlane template, making the replica count of the
controlplane pods user-configurable.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Control plane replica count is now configurable via Helm values, allowing flexible deployment scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->