### PR TITLE
[e2e] Increase Kubernetes connection timeouts

### DIFF
--- a/hack/e2e-apps/run-kubernetes.sh
+++ b/hack/e2e-apps/run-kubernetes.sh
@@ -87,14 +87,14 @@ EOF
 
 
   # Set up port forwarding to the Kubernetes API server for a 200 second timeout
-  bash -c 'timeout 200s kubectl port-forward service/kubernetes-'"${test_name}"' -n tenant-test '"${port}"':6443 > /dev/null 2>&1 &'
+  bash -c 'timeout 300s kubectl port-forward service/kubernetes-'"${test_name}"' -n tenant-test '"${port}"':6443 > /dev/null 2>&1 &'
   # Verify the Kubernetes version matches what we expect (retry for up to 20 seconds)
   timeout 20 sh -ec 'until kubectl --kubeconfig tenantkubeconfig version 2>/dev/null | grep -Fq "Server Version: ${k8s_version}"; do sleep 5; done'
 
   # Wait for the nodes to be ready (timeout after 2 minutes)
-  timeout 2m bash -c '
+  timeout 3m bash -c '
     until [ "$(kubectl --kubeconfig tenantkubeconfig get nodes -o jsonpath="{.items[*].metadata.name}" | wc -w)" -eq 2 ]; do
-      sleep 3
+      sleep 2
     done
   '
   # Verify the nodes are ready


### PR DESCRIPTION
This patch increases the connection and request timeouts used in the E2E tests when communicating with the Kubernetes API. The change improves test stability under high load and slow cluster response conditions.

```release-note
[e2e] Increase connection and request timeouts for Kubernetes API calls in E2E tests to improve stability.
```

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized infrastructure timeout and polling configurations to improve deployment reliability and test execution efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->