### PR TITLE
[nats] Merge container spec, not podTemplate

### DIFF
--- a/packages/apps/nats/templates/nats.yaml
+++ b/packages/apps/nats/templates/nats.yaml
@@ -47,13 +47,9 @@ spec:
       retries: -1
   values:
     nats:
-      podTemplate:
+      container:
         merge:
-          spec:
-            containers:
-              - name: nats
-                image: nats:2.10.17-alpine
-                resources: {{- include "cozy-lib.resources.defaultingSanitize" (list .Values.resourcesPreset .Values.resources $) | nindent 22 }}
+          resources: {{- include "cozy-lib.resources.defaultingSanitize" (list .Values.resourcesPreset .Values.resources $) | nindent 12 }}
       fullnameOverride: {{ .Release.Name }}
       config:
         {{- if or (gt (len $passwords) 0) (gt (len .Values.config.merge) 0) }}


### PR DESCRIPTION
## What this PR does

The NATS chart incorrectly used podTemplate+merge instead of container+merge to add resource requests and limits to the NATS container in the statefulset, but as a result it just completely wiped out the default container spec. By moving the overrides under the container key, the upstream chart now correctly merges the resource requests, instead of overwriting the container spec.

### Release note

```release-note
[nats] Fix incorrect path to container resources in the NATS chart.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restructured NATS deployment configuration while maintaining existing functionality and resource settings; templates were reorganized to streamline how container and resource definitions are represented. No functional or behavioral changes are expected for deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->