### PR TITLE
[seaweedfs] Fix migration to v3.99

### DIFF
--- a/packages/system/seaweedfs/templates/hook.yaml
+++ b/packages/system/seaweedfs/templates/hook.yaml
@@ -2,7 +2,7 @@
 {{- $configMap := lookup "v1" "ConfigMap" .Release.Namespace "seaweedfs-deployed-version" }}
 {{- if $configMap }}
   {{- $deployedVersion := dig "data" "version" "0" $configMap }}
-  {{- if ge $deployedVersion "2" }}
+  {{- if ge $deployedVersion "3" }}
     {{- $shouldRunUpdateHook = false }}
   {{- end }}
 {{- end }}

--- a/packages/system/seaweedfs/templates/version.yaml
+++ b/packages/system/seaweedfs/templates/version.yaml
@@ -3,4 +3,4 @@ kind: ConfigMap
 metadata:
   name: seaweedfs-deployed-version
 data:
-  version: "2"
+  version: "3"


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[seaweedfs] Fix migration to v3.99
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded seaweedfs configuration to version 3.
  * Updated pre-upgrade hook execution conditions to ensure proper upgrade procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->