### PR TITLE
[tenant] Allow listing workloads

### DIFF
--- a/packages/apps/tenant/templates/tenant.yaml
+++ b/packages/apps/tenant/templates/tenant.yaml
@@ -28,6 +28,7 @@ rules:
   - cozystack.io
   resources:
   - workloadmonitors
+  - workloads
   verbs: ["get", "list", "watch"]
 - apiGroups:
   - core.cozystack.io
@@ -113,6 +114,7 @@ rules:
     - cozystack.io
     resources:
     - workloadmonitors
+    - workloads
     verbs: ["get", "list", "watch"]
 ---
 kind: RoleBinding
@@ -184,6 +186,7 @@ rules:
     - cozystack.io
     resources:
     - workloadmonitors
+    - workloads
     verbs: ["get", "list", "watch"]
   - apiGroups:
     - core.cozystack.io
@@ -283,6 +286,7 @@ rules:
     - cozystack.io
     resources:
     - workloadmonitors
+    - workloads
     verbs: ["get", "list", "watch"]
   - apiGroups:
     - core.cozystack.io
@@ -357,6 +361,7 @@ rules:
     - cozystack.io
     resources:
     - workloadmonitors
+    - workloads
     verbs: ["get", "list", "watch"]
   - apiGroups:
     - core.cozystack.io


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[tenant] Allow listing workload
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated access permissions to allow users across all roles (default, view, use, admin, super-admin) to access workloads in addition to workloadmonitors with get, list, and watch capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->