### PR TITLE
[ingress] Enforce HTTPS-only for API

### DIFF
--- a/packages/system/cozystack-api/templates/api-ingress.yaml
+++ b/packages/system/cozystack-api/templates/api-ingress.yaml
@@ -10,6 +10,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
   name: kubernetes
   namespace: default
 spec:


### PR DESCRIPTION
This patch updates the default API Ingress to add the nginx.ingress.kubernetes.io/force-ssl-redirect annotation, ensuring all HTTP traffic (port 80) is redirected to HTTPS (port 443). This prevents unencrypted external access and improves security.

```release-note
[ingress] Force HTTPS access for api.dev3.infra.aenix.org and block direct HTTP.
```

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enforced SSL/TLS redirect for API ingress connections to enhance security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->