### PR TITLE
[nats] Fixes for NATS App Helm chart, fix template issues with config.merge

### DIFF
--- a/packages/apps/nats/templates/nats.yaml
+++ b/packages/apps/nats/templates/nats.yaml
@@ -52,9 +52,9 @@ spec:
           resources: {{- include "cozy-lib.resources.defaultingSanitize" (list .Values.resourcesPreset .Values.resources $) | nindent 12 }}
       fullnameOverride: {{ .Release.Name }}
       config:
-        {{- if or (gt (len $passwords) 0) (and .Values.config (hasKey .Values.config "merge") (gt (len .Values.config.merge) 0)) }}
+        {{- if or $passwords .Values.config.merge }}
         merge:
-          {{- if gt (len $passwords) 0 }}
+          {{- if $passwords }}
           accounts:
             A:
               users:
@@ -63,13 +63,13 @@ spec:
                   password: "{{ $password }}"
                 {{- end }}
           {{- end }}
-          {{- if and .Values.config (hasKey .Values.config "merge") (gt (len .Values.config.merge) 0) }}
-          {{ toYaml .Values.config.merge | nindent 10 }}
+          {{- with .Values.config.merge }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- end }}
-        {{- if and .Values.config (hasKey .Values.config "resolver") }}
+        {{- with .Values.config.resolver }}
         resolver:
-          {{ toYaml .Values.config.resolver | nindent 12 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         cluster:
           enabled: true


### PR DESCRIPTION
[nats] Fixes for NATS App Helm chart, fix template issues with config.merge value

## What this PR does

This PR fixes two critical bugs in the NATS application chart (`packages/apps/nats`) that prevented successful deployment when using user authentication with custom configuration:

**Bug #1: YAML Parse Error with Empty config.merge**
- When users were defined but `config.merge` was empty (`{}`), the Helm template would fail with YAML parse errors
- Fixed by adding safe existence checks before accessing `.Values.config.merge` and preventing rendering of empty merge blocks

**Bug #2: Incorrect Config Nesting**
- When both `users` and `config.merge` were defined, custom NATS config values (e.g., `max_payload`, `max_connections`) were incorrectly nested as children of the `accounts` object instead of being placed at the root NATS configuration level
- This caused NATS pods to crash with "Expected map entries for accounts" errors
- Fixed by correcting the indentation from `nindent 12` to `nindent 10` in the template

The related issue is #1354 

### Changes Made

**File**: `packages/apps/nats/templates/nats.yaml`

1. Line 55: Added safe existence checks for `.Values.config.merge`
2. Line 66: Added length validation to prevent rendering empty merge objects
3. Line 67: Fixed indentation to ensure config values merge at root level

### Impact

- Enables NATS deployments with user authentication and custom configuration
- Fixes Stalwart mail server clustering scenarios that require NATS with authentication
- Resolves HelmRelease failures in multi-tenant environments

### Testing

Can be tested with:
```yaml
apiVersion: apps.cozystack.io/v1alpha1
kind: NATS
metadata:
  name: test-nats
spec:
  replicas: 2
  users:
    testuser: {}
  config:
    merge:
      max_payload: 2097152
      max_connections: 500
```

Expected result: HelmRelease succeeds, NATS pods start successfully, and configuration is valid.

---

### Release note

```release-note
[nats] Fix NATS application chart template bugs that prevented deployments with user authentication and custom configuration.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broader detection for including merge configuration so embedded merge blocks appear more reliably.
  * Credentials/accounts sections now render whenever any password is present, fixing cases where credentials were omitted.
  * Resolver and merged config rendering made more consistent, reducing unexpected omissions in exported manifests.

* **Chores**
  * Simplified internal config handling to reduce nesting and improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->