### PR TITLE
[kubevirt] Fix: kubevirt metrics rule

### DIFF
--- a/packages/system/kubevirt-operator/alerts/PrometheusRule.yaml
+++ b/packages/system/kubevirt-operator/alerts/PrometheusRule.yaml
@@ -10,7 +10,7 @@ spec:
       expr: |
         max_over_time(
           kubevirt_vm_info{
-            status!="Running",
+            status!="running",
             exported_namespace=~".+",
             name=~".+"
           }[10m]
@@ -27,7 +27,7 @@ spec:
       expr: |
         max_over_time(
           kubevirt_vmi_info{
-            phase!="running",
+            phase!="Running",
             exported_namespace=~".+",
             name=~".+"
           }[10m]


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[kubevirt] Fix: kubevirt metrics rule
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Prometheus alert rule expressions for virtual machine monitoring. Corrected status and phase condition comparisons to accurately identify when virtual machines are not running, ensuring alerts trigger reliably in such scenarios. These improvements enhance the accuracy of monitoring notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->