### PR TITLE
[core] rm talos lldp extension

### DIFF
--- a/hack/e2e-prepare-cluster.bats
+++ b/hack/e2e-prepare-cluster.bats
@@ -132,7 +132,6 @@ machine:
         - usermode_helper=disabled
     - name: zfs
     - name: spl
-    - name: lldpd
   registries:
     mirrors:
       docker.io:

--- a/packages/core/installer/hack/gen-profiles.sh
+++ b/packages/core/installer/hack/gen-profiles.sh
@@ -5,7 +5,7 @@ set -u
 TMPDIR=$(mktemp -d)
 PROFILES="initramfs kernel iso installer nocloud metal"
 FIRMWARES="amd-ucode amdgpu bnx2-bnx2x i915 intel-ice-firmware intel-ucode qlogic-firmware"
-EXTENSIONS="drbd zfs lldpd"
+EXTENSIONS="drbd zfs"
 
 mkdir -p images/talos/profiles
 
@@ -90,7 +90,6 @@ input:
     - imageRef: ${QLOGIC_FIRMWARE_IMAGE}
     - imageRef: ${DRBD_IMAGE}
     - imageRef: ${ZFS_IMAGE}
-    - imageRef: ${LLDPD_IMAGE}
 output:
   kind: ${kind}
   imageOptions: ${image_options}

--- a/packages/core/installer/images/talos/profiles/initramfs.yaml
+++ b/packages/core/installer/images/talos/profiles/initramfs.yaml
@@ -21,7 +21,6 @@ input:
     - imageRef: ghcr.io/siderolabs/qlogic-firmware:20250917@sha256:7094e5db6931a1b68240416b65ddc0f3b546bd9b8520e3cfb1ddebcbfc83e890
     - imageRef: ghcr.io/siderolabs/drbd:9.2.14-v1.11.3@sha256:4393756875751e2664a04e96c1ccff84c99958ca819dd93b46b82ad8f3b4be67
     - imageRef: ghcr.io/siderolabs/zfs:2.3.3-v1.11.3@sha256:3c0b34a760914980ac234e66f130d829e428018e46420b7bca33219b1cc2dd87
-    - imageRef: ghcr.io/siderolabs/lldpd:1.0.20@sha256:4c6370518f5b2e1f03214a6ed54778eaea663fda8850e3f4da174ed69b636172
 output:
   kind: initramfs
   imageOptions: {}

--- a/packages/core/installer/images/talos/profiles/installer.yaml
+++ b/packages/core/installer/images/talos/profiles/installer.yaml
@@ -21,7 +21,6 @@ input:
     - imageRef: ghcr.io/siderolabs/qlogic-firmware:20250917@sha256:7094e5db6931a1b68240416b65ddc0f3b546bd9b8520e3cfb1ddebcbfc83e890
     - imageRef: ghcr.io/siderolabs/drbd:9.2.14-v1.11.3@sha256:4393756875751e2664a04e96c1ccff84c99958ca819dd93b46b82ad8f3b4be67
     - imageRef: ghcr.io/siderolabs/zfs:2.3.3-v1.11.3@sha256:3c0b34a760914980ac234e66f130d829e428018e46420b7bca33219b1cc2dd87
-    - imageRef: ghcr.io/siderolabs/lldpd:1.0.20@sha256:4c6370518f5b2e1f03214a6ed54778eaea663fda8850e3f4da174ed69b636172
 output:
   kind: installer
   imageOptions: {}

--- a/packages/core/installer/images/talos/profiles/iso.yaml
+++ b/packages/core/installer/images/talos/profiles/iso.yaml
@@ -21,7 +21,6 @@ input:
     - imageRef: ghcr.io/siderolabs/qlogic-firmware:20250917@sha256:7094e5db6931a1b68240416b65ddc0f3b546bd9b8520e3cfb1ddebcbfc83e890
     - imageRef: ghcr.io/siderolabs/drbd:9.2.14-v1.11.3@sha256:4393756875751e2664a04e96c1ccff84c99958ca819dd93b46b82ad8f3b4be67
     - imageRef: ghcr.io/siderolabs/zfs:2.3.3-v1.11.3@sha256:3c0b34a760914980ac234e66f130d829e428018e46420b7bca33219b1cc2dd87
-    - imageRef: ghcr.io/siderolabs/lldpd:1.0.20@sha256:4c6370518f5b2e1f03214a6ed54778eaea663fda8850e3f4da174ed69b636172
 output:
   kind: iso
   imageOptions: {}

--- a/packages/core/installer/images/talos/profiles/kernel.yaml
+++ b/packages/core/installer/images/talos/profiles/kernel.yaml
@@ -21,7 +21,6 @@ input:
     - imageRef: ghcr.io/siderolabs/qlogic-firmware:20250917@sha256:7094e5db6931a1b68240416b65ddc0f3b546bd9b8520e3cfb1ddebcbfc83e890
     - imageRef: ghcr.io/siderolabs/drbd:9.2.14-v1.11.3@sha256:4393756875751e2664a04e96c1ccff84c99958ca819dd93b46b82ad8f3b4be67
     - imageRef: ghcr.io/siderolabs/zfs:2.3.3-v1.11.3@sha256:3c0b34a760914980ac234e66f130d829e428018e46420b7bca33219b1cc2dd87
-    - imageRef: ghcr.io/siderolabs/lldpd:1.0.20@sha256:4c6370518f5b2e1f03214a6ed54778eaea663fda8850e3f4da174ed69b636172
 output:
   kind: kernel
   imageOptions: {}

--- a/packages/core/installer/images/talos/profiles/metal.yaml
+++ b/packages/core/installer/images/talos/profiles/metal.yaml
@@ -21,7 +21,6 @@ input:
     - imageRef: ghcr.io/siderolabs/qlogic-firmware:20250917@sha256:7094e5db6931a1b68240416b65ddc0f3b546bd9b8520e3cfb1ddebcbfc83e890
     - imageRef: ghcr.io/siderolabs/drbd:9.2.14-v1.11.3@sha256:4393756875751e2664a04e96c1ccff84c99958ca819dd93b46b82ad8f3b4be67
     - imageRef: ghcr.io/siderolabs/zfs:2.3.3-v1.11.3@sha256:3c0b34a760914980ac234e66f130d829e428018e46420b7bca33219b1cc2dd87
-    - imageRef: ghcr.io/siderolabs/lldpd:1.0.20@sha256:4c6370518f5b2e1f03214a6ed54778eaea663fda8850e3f4da174ed69b636172
 output:
   kind: image
   imageOptions: { diskSize: 1306525696, diskFormat: raw }

--- a/packages/core/installer/images/talos/profiles/nocloud.yaml
+++ b/packages/core/installer/images/talos/profiles/nocloud.yaml
@@ -21,7 +21,6 @@ input:
     - imageRef: ghcr.io/siderolabs/qlogic-firmware:20250917@sha256:7094e5db6931a1b68240416b65ddc0f3b546bd9b8520e3cfb1ddebcbfc83e890
     - imageRef: ghcr.io/siderolabs/drbd:9.2.14-v1.11.3@sha256:4393756875751e2664a04e96c1ccff84c99958ca819dd93b46b82ad8f3b4be67
     - imageRef: ghcr.io/siderolabs/zfs:2.3.3-v1.11.3@sha256:3c0b34a760914980ac234e66f130d829e428018e46420b7bca33219b1cc2dd87
-    - imageRef: ghcr.io/siderolabs/lldpd:1.0.20@sha256:4c6370518f5b2e1f03214a6ed54778eaea663fda8850e3f4da174ed69b636172
 output:
   kind: image
   imageOptions: { diskSize: 1306525696, diskFormat: raw }


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does
Removes Talos lldp extension.

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
Talos lldp extension removed.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed LLDPD (Link Layer Discovery Protocol Daemon) system extension from cluster configuration. This eliminates the LLDPD kernel module from cluster setups, removes LLDPD references from build processes, and updates installation profiles across all supported deployment methods including bare metal, cloud environments, and ISO installations, resulting in a reduced system footprint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->