### PR TITLE
[vpc] Install Multus by default

### DIFF
--- a/packages/core/platform/bundles/paas-full.yaml
+++ b/packages/core/platform/bundles/paas-full.yaml
@@ -76,6 +76,13 @@ releases:
   namespace: cozy-kubeovn
   dependsOn: [cilium,kubeovn]
 
+- name: multus
+  releaseName: multus
+  chart: cozy-multus
+  namespace: cozy-multus
+  privileged: true
+  dependsOn: [cilium,kubeovn]
+
 - name: cozy-proxy
   releaseName: cozystack
   chart: cozy-cozy-proxy


### PR DESCRIPTION
## What this PR does

The recent patch introducing VPCs in Cozystack did not include enabling Multus, which is a dependency for this feature. This patch enables Multus by default in the paas-full bundle.

### Release-note

```release-note
[vpc] Enable Multus by default as a necessary dependency for VPCs.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new networking component to the platform bundles to enhance network orchestration and management capabilities across infrastructure deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->