### PR TITLE
[vpc] Give predictable name to subnet configmap

### DIFF
--- a/packages/apps/vpc/templates/vpc.yaml
+++ b/packages/apps/vpc/templates/vpc.yaml
@@ -58,9 +58,9 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ $vpcId }}-subnets
+  name: {{ $.Release.Name }}-subnets
   labels:
-    cozystack.io/vpcName: {{ $.Release.Name }}
+    cozystack.io/vpcId: {{ $vpcId }}
     cozystack.io/tenantName: {{ $.Release.Namespace }}
 data:
   subnets: |


### PR DESCRIPTION
## What this PR does

The new VPC feature creates a configmap, containing the list of subnets under the VPC. However, the configmap has the VPC ID in its name, rather than the name of the VPC, making it harder to target inside the dashboard, as the helper functions from Helm (e.g. sha256sum) may not be available in the dashboard's custom resources. This patch renames the configmap to use the VPC's name.

### Release note

```release-note
[vpc] Change the subnet configmap name to a human-friendly value
(matching the VPC name), instead of being derived via a sha256sum,
making it easier to reference in the dashboard.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VPC resource naming and labeling conventions for improved identification and management consistency across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->