### PR TITLE
[apps] vpc: more docs

### DIFF
--- a/packages/apps/vpc/README.md
+++ b/packages/apps/vpc/README.md
@@ -5,12 +5,12 @@ As the service evolves, it will provide more ways to isolate your workloads.
 
 ## Service details
 
-The service utilizes kube-ovn VPC and Subnet resources, which use ovn logical routers and logical switches under the hood.
-Currently every workload will have a connection to a default management network which will also have a default gateway, and the majority of traffic will be going through it.
-VPC subnets are for now an additional dedicated networking spaces.
+To function, the service requires kube-ovn and multus CNI to be present, so by default it will only work on `paas-full` bundle.
+Kube-ovn provides VPC and Subnet resources and performs isolation and networking maintenance such as DHCP. Under the hood it uses ovn virtual routers and virtual switches.
+Multus enables a multi-nic capability, so a pod or a VM could have two or more network interfaces.
 
-A VM or a pod may be connected to multiple secondary Subnets at once.
-Each secondary connection will be represented as an additional network interface.
+Currently every workload will have a connection to a default management network which will also have a default gateway, and the majority of traffic will go through it.
+VPC subnets are for now an additional dedicated networking spaces.
 
 ## Deployment notes
 
@@ -20,6 +20,8 @@ Subnet ip address space must not overlap with the default management network ip 
 Currently there are no fail-safe checks, however they are planned for the future.
 
 Different VPCs may have subnets with ovelapping ip address ranges.
+
+A VM or a pod may be connected to multiple secondary Subnets at once. Each secondary connection will be represented as an additional network interface.
 
 ## Parameters
 


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does
Adds VPC details about bundles and required components for it to work.

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
More docs for VPC
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified infrastructure dependencies and networking requirements for VPC service operation.
  * Improved guidance on multi‑NIC support, explaining that VMs and pods can attach to multiple secondary subnets as separate network interfaces.
  * Added explicit deployment notes for configuring and connecting secondary subnets, and clarified current behavior of default management networks and VPC subnets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->