### PR TITLE
[nats] Fix NATS app chart to use existing secret credentials when present

### DIFF
--- a/packages/apps/nats/templates/nats.yaml
+++ b/packages/apps/nats/templates/nats.yaml
@@ -3,7 +3,7 @@
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (printf "%s-credentials" .Release.Name) }}
 {{- $passwords := dict }}
 
-{{- with (index $existingSecret "data") }}
+{{- with (dig "data" (dict) $existingSecret) }}
   {{- range $k, $v := . }}
     {{- $_ := set $passwords $k (b64dec $v) }}
   {{- end }}


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

This PR fixes an issue where NATS user credentials were being regenerated on every helm release update, rather than reusing existing secrets. The fix implements the same secret reuse pattern that is already used in the postgres app.

### Changes:
- Added `lookup` call to fetch existing credentials secret before generating passwords
- Pre-populate passwords from existing secret data (base64 decoded)
- Only generate new random passwords for users that don't have existing credentials

### Behavior:
- **Before**: Every helm upgrade would regenerate credentials for users without explicit passwords, breaking existing connections
- **After**: Existing credentials are preserved across helm upgrades, matching postgres app behavior

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[nats] Fix credential regeneration on helm release updates by implementing existing secret lookup pattern
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NATS deployments can now read and reuse existing release credentials, reducing unnecessary credential rotation and keeping logins consistent across updates.
  * When credentials are missing, the system still auto-generates passwords; when users are defined it emits the computed credentials for use by the deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->