### PR TITLE
[vpc] Entry per subnet in the subnets configmap

### DIFF
--- a/packages/apps/vpc/templates/vpc.yaml
+++ b/packages/apps/vpc/templates/vpc.yaml
@@ -63,10 +63,10 @@ metadata:
     cozystack.io/vpcId: {{ $vpcId }}
     cozystack.io/tenantName: {{ $.Release.Namespace }}
 data:
-  subnets: |
-    {{- range $subnetName, $subnetConfig := .Values.subnets }}
-    - subnetName: {{ $subnetName }}
-      subnetId: {{ print "subnet-" (print $.Release.Namespace "/" $vpcId "/" $subnetName | sha256sum | trunc 8) }}
-      subnetCIDR: {{ $subnetConfig.cidr }}
-    {{- end }}
+  {{- range $subnetName, $subnetConfig := .Values.subnets }}
+  {{ $subnetName }}: |-
+    subnetName: {{ $subnetName }}
+    subnetId: {{ print "subnet-" (print $.Release.Namespace "/" $vpcId "/" $subnetName | sha256sum | trunc 8) }}
+    subnetCIDR: {{ $subnetConfig.cidr }}
+  {{- end }}
 


### PR DESCRIPTION
### Release note

```release-note
[vpc] Change the subnets configmap structure from
.data.subnets==[]Subnet to .data==map[SubnetName]Subnet for simpler
representation in the dashboard.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured VPC subnet data organization in configuration from a static list format to a dynamic map structure, where each subnet is now stored with its own key containing subnet name, ID, and CIDR information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->