### PR TITLE
[vm] Remove egress restrictions on non-isolated vm

### DIFF
--- a/packages/apps/tenant/templates/networkpolicy.yaml
+++ b/packages/apps/tenant/templates/networkpolicy.yaml
@@ -34,6 +34,21 @@ spec:
       - world
 ---
 apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-world-egress
+  namespace: {{ include "tenant.name" . }}
+spec:
+  endpointSelector:
+    matchExpressions:
+    - key: policy.cozystack.io/allow-world-egress
+      operator: In
+      values: ["true"]
+  egress:
+  - toEntities:
+      - world
+---
+apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
   name: {{ include "tenant.name" . }}-egress

--- a/packages/apps/virtual-machine/templates/service.yaml
+++ b/packages/apps/virtual-machine/templates/service.yaml
@@ -49,6 +49,3 @@ spec:
           - port: {{ quote . }}
           {{- end }}
     {{- end }}
-  egress:
-  - toEntities:
-      - world

--- a/packages/apps/virtual-machine/templates/vm.yaml
+++ b/packages/apps/virtual-machine/templates/vm.yaml
@@ -62,9 +62,10 @@ spec:
   template:
     metadata:
       annotations:
-        policy.cozystack.io/allow-external-communication: "false"
         kubevirt.io/allow-pod-bridge-network-live-migration: "true"
       labels:
+        policy.cozystack.io/allow-external-communication: "false"
+        policy.cozystack.io/allow-world-egress: "true"
         {{- include "virtual-machine.labels" . | nindent 8 }}
     spec:
       domain:

--- a/packages/apps/vm-instance/templates/service.yaml
+++ b/packages/apps/vm-instance/templates/service.yaml
@@ -49,6 +49,3 @@ spec:
         - port: {{ quote . }}
         {{- end }}
     {{- end }}
-  egress:
-  - toEntities:
-      - world

--- a/packages/apps/vm-instance/templates/vm.yaml
+++ b/packages/apps/vm-instance/templates/vm.yaml
@@ -26,9 +26,10 @@ spec:
   template:
     metadata:
       annotations:
-        policy.cozystack.io/allow-external-communication: "false"
         kubevirt.io/allow-pod-bridge-network-live-migration: "true"
       labels:
+        policy.cozystack.io/allow-external-communication: "false"
+        policy.cozystack.io/allow-world-egress: "true"
         {{- include "virtual-machine.labels" . | nindent 8 }}
     spec:
       domain:


### PR DESCRIPTION
## What this PR does

Virtual machines with a public IP have a network policy that explicitly allows them to communicate with the external internet. When created in a non-isolated tenant that has no network policies by default, creating such a policy, instead, **restricts** egress traffic originating from the VM from going anywhere, __except__ the outside internet. Instead of allowing VMs to communicate with the outside internet via a network policy, this patch now adds a label to the VMs by which they will be targetted by Cozystack's default network policies, if such policies exist. When no policies are present, the VM's egress traffic will no longer be policed. Resolves #1601.

### Release note

```release-note
[virtual-machine,vm-instance] Remove the egress network policy from
virtual machines and govern egress traffic by default network policies
instead, resolving the bug in #1601.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed outbound-to-world egress rules from service network policies.
  * Updated VM manifests to move external-communication metadata into labels and mark allow-world-egress.

* **New Features**
  * Added tenant-level network policies to selectively permit world egress and to allow specific control-plane egress paths between tenant and control namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->