### PR TITLE
[cozy-lib] Fix: handling resources=nil

### DIFF
--- a/packages/library/cozy-lib/templates/_resources.tpl
+++ b/packages/library/cozy-lib/templates/_resources.tpl
@@ -154,7 +154,7 @@
 {{-   $resources := index . 1 }}
 {{-   $global := index . 2 }}
 {{-   $presetMap := include "cozy-lib.resources.unsanitizedPreset" $preset | fromYaml }}
-{{-   $mergedMap := deepCopy $resources | mergeOverwrite $presetMap }}
+{{-   $mergedMap := deepCopy (default (dict) $resources) | mergeOverwrite $presetMap }}
 {{-   include "cozy-lib.resources.sanitize" (list $mergedMap $global) }}
 {{- end }}
 


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


Fixes issue:

```
error: template: tcp-balancer/templates/deployment.yaml:37:23: executing "tcp-balancer/templates/deployment.yaml" at <include "cozy-lib.resources.defaultingSanitize" (list .Values.resourcesP
reset .Values.resources $)>: error calling include: template: tcp-balancer/charts/cozy-lib/templates/_resources.tpl:157:20: executing "cozy-lib.resources.defaultingSanitize" at <deepCopy $re
sources>: error calling deepCopy: reflect: call of reflect.Value.Type on zero Value
```

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[cozy-lib] Fix: handling resources=nil
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured resource merging behaves predictably when resources are missing by introducing a guarded default, improving reliability and preventing errors during resource composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->