### PR TITLE
[virtual-machine] Revert per-vm network policies

### DIFF
--- a/packages/apps/tenant/templates/networkpolicy.yaml
+++ b/packages/apps/tenant/templates/networkpolicy.yaml
@@ -20,11 +20,7 @@ metadata:
   name: allow-external-communication
   namespace: {{ include "tenant.name" . }}
 spec:
-  endpointSelector:
-    matchExpressions:
-    - key: policy.cozystack.io/allow-external-communication
-      operator: NotIn
-      values: ["false"]
+  endpointSelector: {}
   ingress:
   - fromEntities:
       - world

--- a/packages/apps/virtual-machine/templates/service.yaml
+++ b/packages/apps/virtual-machine/templates/service.yaml
@@ -28,27 +28,3 @@ spec:
     {{- end }}
     {{- end }}
 {{- end }}
----
-apiVersion: cilium.io/v2
-kind: CiliumNetworkPolicy
-metadata:
-  name: {{ include "virtual-machine.fullname" . }}
-spec:
-  endpointSelector:
-    matchLabels:
-      {{- include "virtual-machine.selectorLabels" . | nindent 6 }}
-  ingress:
-  - fromEntities:
-      - cluster
-  - fromEntities:
-      - world
-    {{- if eq .Values.externalMethod "PortList" }}
-    toPorts:
-      - ports:
-          {{- range .Values.externalPorts }}
-          - port: {{ quote . }}
-          {{- end }}
-    {{- end }}
-  egress:
-  - toEntities:
-      - world

--- a/packages/apps/virtual-machine/templates/vm.yaml
+++ b/packages/apps/virtual-machine/templates/vm.yaml
@@ -62,7 +62,6 @@ spec:
   template:
     metadata:
       annotations:
-        policy.cozystack.io/allow-external-communication: "false"
         kubevirt.io/allow-pod-bridge-network-live-migration: "true"
       labels:
         {{- include "virtual-machine.labels" . | nindent 8 }}

--- a/packages/apps/vm-instance/templates/service.yaml
+++ b/packages/apps/vm-instance/templates/service.yaml
@@ -28,27 +28,3 @@ spec:
     {{- end }}
     {{- end }}
 {{- end }}
----
-apiVersion: cilium.io/v2
-kind: CiliumNetworkPolicy
-metadata:
-  name: {{ include "virtual-machine.fullname" . }}
-spec:
-  endpointSelector:
-    matchLabels:
-      {{- include "virtual-machine.selectorLabels" . | nindent 6 }}
-  ingress:
-  - fromEntities:
-      - cluster
-  - fromEntities:
-      - world
-    {{- if eq .Values.externalMethod "PortList" }}
-    toPorts:
-      - ports:
-        {{- range .Values.externalPorts }}
-        - port: {{ quote . }}
-        {{- end }}
-    {{- end }}
-  egress:
-  - toEntities:
-      - world

--- a/packages/apps/vm-instance/templates/vm.yaml
+++ b/packages/apps/vm-instance/templates/vm.yaml
@@ -26,7 +26,6 @@ spec:
   template:
     metadata:
       annotations:
-        policy.cozystack.io/allow-external-communication: "false"
         kubevirt.io/allow-pod-bridge-network-live-migration: "true"
       labels:
         {{- include "virtual-machine.labels" . | nindent 8 }}


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Revert per-vm network policies functionality introduced by https://github.com/cozystack/cozystack/pull/1611
As it is not working as expected any way.

This is temporary solution before implementing full-fledged security groups in Cozystack

fixes https://github.com/cozystack/cozystack/issues/1601
alternative solution: https://github.com/cozystack/cozystack/pull/1602

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[virtual-machine] Revert per-vm network policies
```