### PR TITLE
[dashboard-controller] Fix static resources reconciliation and showing secrets

### DIFF
--- a/internal/controller/dashboard/static_refactored.go
+++ b/internal/controller/dashboard/static_refactored.go
@@ -178,7 +178,7 @@ func CreateAllCustomColumnsOverrides() []*dashboardv1alpha1.CustomColumnsOverrid
 			createCustomColumnWithJsonPath("Name", ".metadata.name", "Secret", "", "/openapi-ui/{2}/{reqsJsonPath[0]['.metadata.namespace']['-']}/factory/kube-secret-details/{reqsJsonPath[0]['.metadata.name']['-']}"),
 			createFlatMapColumn("Data", ".data"),
 			createStringColumn("Key", "_flatMapData_Key"),
-			createSecretBase64Column("Value", "_flatMapData_Value"),
+			createSecretBase64Column("Value", "._flatMapData_Value"),
 			createTimestampColumn("Created", ".metadata.creationTimestamp"),
 		}),
 


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[dashboard-controller] Fix static resources reconciliation and showing secrets
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cache synchronization handling in the controller manager.
  * Corrected tenant secret value retrieval path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->