### PR TITLE
Fix: Add missing components to `distro-full` bundle

### DIFF
--- a/packages/core/platform/bundles/distro-full.yaml
+++ b/packages/core/platform/bundles/distro-full.yaml
@@ -78,7 +78,7 @@ releases:
   releaseName: cozystack-resource-definition-crd
   chart: cozystack-resource-definition-crd
   namespace: cozy-system
-  dependsOn: [cilium,cozystack-controller]
+  dependsOn: [cilium]
 
 - name: cozystack-resource-definitions
   releaseName: cozystack-resource-definitions


### PR DESCRIPTION
  The `distro-full` bundle was missing critical components that exist in paas-full, causing multiple pod failures during installation. This PR adds the missing packages and fixes dependency issues.

  When installing cozystack with bundle-name: "distro-full", several pods failed to start:

  1. CozystackResourceDefinition CRD missing
    - cozystack-controller pod: CrashLoopBackOff
    - lineage-controller-webhook pods: CrashLoopBackOff
    - Error: no matches for kind "CozystackResourceDefinition" in version "cozystack.io/v1alpha1"

https://github.com/cozystack/cozystack/blob/a861814c241e38360f03f89ef44eb1791e4800fd/packages/system/cozystack-resource-definition-crd/definition/cozystack.io_cozystackresourcedefinitions.yaml#L1-L14

  2. selfsigned-cluster-issuer ClusterIssuer missing
    - snapshot-validation-webhook pods: ContainerCreating (waiting for TLS secret)
    - snapshot-controller HelmRelease: Failed to install (timeout)
    - Error: clusterissuer.cert-manager.io "selfsigned-cluster-issuer" not found

https://github.com/cozystack/cozystack/blob/a861814c241e38360f03f89ef44eb1791e4800fd/packages/system/cert-manager-issuers/templates/cluster-issuers.yaml#L52-L57

https://github.com/cozystack/cozystack/blob/a861814c241e38360f03f89ef44eb1791e4800fd/packages/system/snapshot-controller/template/clusterissuer.yaml#L1-L8

  3. Cascading failures
    - linstor HelmRelease: Blocked (depends on snapshot-controller)
    



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new resource-definition components to the platform distribution for enhanced configuration management.

* **Improvements**
  * Made certificate issuer components required during deployment (no longer optional).
  * Adjusted snapshot controller startup order to wait for certificate issuers, improving startup reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->