### PR TITLE
[vpc,dashboard] Print subnet details as table

### DIFF
--- a/internal/controller/dashboard/factory.go
+++ b/internal/controller/dashboard/factory.go
@@ -150,6 +150,27 @@ func detailsTab(kind, endpoint, schemaJSON string, keysOrder [][]string) map[str
 		}),
 		paramsList,
 	}
+	if kind == "VirtualPrivateCloud" {
+		rightColStack = append(rightColStack,
+			antdFlexVertical("vpc-subnets-block", 4, []any{
+				antdText("vpc-subnets-label", true, "Subnets", nil),
+				map[string]any{
+					"type": "EnrichedTable",
+					"data": map[string]any{
+						"id":                   "vpc-subnets-table",
+						"baseprefix":           "/openapi-ui",
+						"clusterNamePartOfUrl": "{2}",
+						"customizationId":      "virtualprivatecloud-subnets",
+						"fetchUrl":             "/api/clusters/{2}/k8s/api/v1/namespaces/{3}/configmaps",
+						"fieldSelector": map[string]any{
+							"metadata.name": "virtualprivatecloud-{6}-subnets",
+						},
+						"pathToItems": []any{"items"},
+					},
+				},
+			}),
+		)
+	}
 
 	return map[string]any{
 		"key":   "details",

--- a/internal/controller/dashboard/static_refactored.go
+++ b/internal/controller/dashboard/static_refactored.go
@@ -182,6 +182,13 @@ func CreateAllCustomColumnsOverrides() []*dashboardv1alpha1.CustomColumnsOverrid
 			createTimestampColumn("Created", ".metadata.creationTimestamp"),
 		}),
 
+		// Virtual private cloud subnets
+		createCustomColumnsOverride("virtualprivatecloud-subnets", []any{
+			createFlatMapColumn("Data", ".data"),
+			createStringColumn("Subnet Parameters", "_flatMapData_Key"),
+			createStringColumn("Values", "_flatMapData_Value"),
+		}),
+
 		// Factory ingress details rules
 		createCustomColumnsOverride("factory-kube-ingress-details-rules", []any{
 			createStringColumn("Host", ".host"),

--- a/packages/apps/vpc/charts/cozy-lib
+++ b/packages/apps/vpc/charts/cozy-lib
@@ -1,0 +1,1 @@
+../../../library/cozy-lib

--- a/packages/apps/vpc/templates/vpc.yaml
+++ b/packages/apps/vpc/templates/vpc.yaml
@@ -60,13 +60,33 @@ kind: ConfigMap
 metadata:
   name: {{ $.Release.Name }}-subnets
   labels:
+    apps.cozystack.io/application.group: apps.cozystack.io
+    apps.cozystack.io/application.kind: VirtualPrivateCloud
+    apps.cozystack.io/application.name: {{ trimPrefix "virtualprivatecloud-" .Release.Name }}
     cozystack.io/vpcId: {{ $vpcId }}
     cozystack.io/tenantName: {{ $.Release.Namespace }}
 data:
   {{- range $subnetName, $subnetConfig := .Values.subnets }}
-  {{ $subnetName }}: |-
-    subnetName: {{ $subnetName }}
-    subnetId: {{ print "subnet-" (print $.Release.Namespace "/" $vpcId "/" $subnetName | sha256sum | trunc 8) }}
-    subnetCIDR: {{ $subnetConfig.cidr }}
+  {{ $subnetName }}.ID: {{ print "subnet-" (print $.Release.Namespace "/" $vpcId "/" $subnetName | sha256sum | trunc 8) }}
+  {{ $subnetName }}.CIDR: {{ $subnetConfig.cidr }}
   {{- end }}
-
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ .Release.Name }}-subnets"
+subjects: {{- include "cozy-lib.rbac.subjectsForTenant" (list "view" .Release.Namespace ) | nindent 2 }}
+roleRef:
+  kind: Role
+  name: "{{ .Release.Name }}-subnets"
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ .Release.Name }}-subnets"
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get","list","watch"]
+  resourceNames: ["{{ .Release.Name }}-subnets"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VPC subnets are now displayed in the dashboard details view with dedicated information blocks
  * Subnet data is presented with improved formatting and structured columns for better visibility
  * Access controls updated to support proper subnet data permissions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->