### PR TITLE
[rbac] Fix permissions for high-privilege users

### DIFF
--- a/packages/apps/tenant/templates/tenant.yaml
+++ b/packages/apps/tenant/templates/tenant.yaml
@@ -122,7 +122,7 @@ metadata:
   name: {{ include "tenant.name" . }}-view
   namespace: {{ include "tenant.name" . }}
 subjects:
-{{ include "cozy-lib.rbac.subjectsForTenant" (list "view" (include "tenant.name" .)) | nindent 2 }}
+{{ include "cozy-lib.rbac.subjectsForTenantAndAccessLevel" (list "view" (include "tenant.name" .)) | nindent 2 }}
 roleRef:
   kind: Role
   name: {{ include "tenant.name" . }}-view
@@ -200,7 +200,7 @@ metadata:
   name: {{ include "tenant.name" . }}-use
   namespace: {{ include "tenant.name" . }}
 subjects:
-{{ include "cozy-lib.rbac.subjectsForTenant" (list "use" (include "tenant.name" .)) | nindent 2 }}
+{{ include "cozy-lib.rbac.subjectsForTenantAndAccessLevel" (list "use" (include "tenant.name" .)) | nindent 2 }}
 roleRef:
   kind: Role
   name: {{ include "tenant.name" . }}-use
@@ -299,7 +299,7 @@ metadata:
   name: {{ include "tenant.name" . }}-admin
   namespace: {{ include "tenant.name" . }}
 subjects:
-{{ include "cozy-lib.rbac.subjectsForTenant" (list "admin" (include "tenant.name" .)) | nindent 2 }}
+{{ include "cozy-lib.rbac.subjectsForTenantAndAccessLevel" (list "admin" (include "tenant.name" .)) | nindent 2 }}
 roleRef:
   kind: Role
   name: {{ include "tenant.name" . }}-admin
@@ -373,7 +373,7 @@ metadata:
   name: {{ include "tenant.name" . }}-super-admin
   namespace: {{ include "tenant.name" . }}
 subjects:
-{{ include "cozy-lib.rbac.subjectsForTenant" (list "super-admin" (include "tenant.name" .) ) | nindent 2 }}
+{{ include "cozy-lib.rbac.subjectsForTenantAndAccessLevel" (list "super-admin" (include "tenant.name" .) ) | nindent 2 }}
 roleRef:
   kind: Role
   name: {{ include "tenant.name" . }}-super-admin


### PR DESCRIPTION
## What this PR does

This patch grants "admin" permissions to super-admins, "use" permissions to admins and super-admins, "view" permissions to "use"-privileged users, admins, and super-admins. Previously lower-privileged roles were not assigned to higher-privileged users, so a viewer could excercise their basic read-only permissions which were not available to high-privilege users. This patch corrects the template function used to generate subjects in rolebindings, fixing the issue.

### Release note

```release-note
[rbac] Fix issue of privileged users not having low-privilege read-only
permissions.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated access level handling in role-based authorization to ensure proper permission evaluation across tenant environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->