### PR TITLE
[system] kubeovn: increase limits

### DIFF
--- a/packages/system/kubeovn/values.yaml
+++ b/packages/system/kubeovn/values.yaml
@@ -44,7 +44,7 @@ kube-ovn:
       memory: "50Mi"
     limits:
       cpu: "1000m"
-      memory: "1Gi"
+      memory: "2Gi"
   kube-ovn-pinger:
     requests:
       cpu: "10m"


### PR DESCRIPTION
## What this PR does
Increases kube-ovn-cni limits

### Release note
```release-note
Increased kube-ovn-cni limits so that it is not oomkilled during startup on busy nodes.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated memory allocation for system components to optimize resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->