### PR TITLE
[kubernetes] Cleanup loadbalancer services

### DIFF
--- a/packages/apps/kubernetes/templates/delete.yaml
+++ b/packages/apps/kubernetes/templates/delete.yaml
@@ -6,11 +6,11 @@ metadata:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "10"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation,hook-failed
-  name: {{ .Release.Name }}-datavolume-cleanup
+  name: {{ .Release.Name }}-cleanup
 spec:
   template:
     spec:
-      serviceAccountName: {{ .Release.Name }}-datavolume-cleanup
+      serviceAccountName: {{ .Release.Name }}-cleanup
       restartPolicy: Never
       tolerations:
         - key: CriticalAddonsOnly
@@ -28,12 +28,17 @@ spec:
               -l "cluster.x-k8s.io/cluster-name={{ .Release.Name }}"
               --ignore-not-found=true
 
+              kubectl -n {{ .Release.Namespace }} delete services
+              -l "cluster.x-k8s.io/cluster-name={{ .Release.Name }}"
+              --field-selector spec.type=LoadBalancer
+              --ignore-not-found=true
+
 
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-datavolume-cleanup
+  name: {{ .Release.Name }}-cleanup
   annotations:
     helm.sh/hook: post-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-failed,hook-succeeded
@@ -46,12 +51,20 @@ metadata:
     "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation,hook-failed
     "helm.sh/hook-weight": "5"
-  name: {{ .Release.Name }}-datavolume-cleanup
+  name: {{ .Release.Name }}-cleanup
 rules:
   - apiGroups:
       - "cdi.kubevirt.io"
     resources:
       - datavolumes
+    verbs:
+      - get
+      - list
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - services
     verbs:
       - get
       - list
@@ -64,13 +77,13 @@ metadata:
     "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation,hook-failed
     "helm.sh/hook-weight": "5"
-  name: {{ .Release.Name }}-datavolume-cleanup
+  name: {{ .Release.Name }}-cleanup
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Name }}-datavolume-cleanup
+  name: {{ .Release.Name }}-cleanup
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-datavolume-cleanup
+    name: {{ .Release.Name }}-cleanup
     namespace: {{ .Release.Namespace }}
 


### PR DESCRIPTION
## What this PR does

Similar to an earlier issue with DataVolumes remaining after deleting the tenant k8s cluster using them, a similar problem is observed with LoadBalancer services consuming external IPs. This patch adds another step to the cleanup Helm hook to delete any such services.

### Release note

```release-note
[kubernetes] Add a cleanup hook to delete LoadBalancer services after
deleting the tenant Kubernetes cluster that they were servicing.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of LoadBalancer services during resource deletion workflows.

* **Chores**
  * Updated resource naming conventions for consistency.
  * Extended service management permissions in access control configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->