### PR TITLE
[apps] vpc: fix typo in README

### DIFF
--- a/packages/apps/vpc/README.md
+++ b/packages/apps/vpc/README.md
@@ -19,7 +19,7 @@ Subnet name and ip address range must be unique within a VPC.
 Subnet ip address space must not overlap with the default management network ip address range, subsets of 172.16.0.0/12 are recommended.
 Currently there are no fail-safe checks, however they are planned for the future.
 
-Different VPCs may have subnets with ovelapping ip address ranges.
+Different VPCs may have subnets with overlapping ip address ranges.
 
 A VM or a pod may be connected to multiple secondary Subnets at once. Each secondary connection will be represented as an additional network interface.
 


### PR DESCRIPTION
## What this PR does
VPC: fixed a typo in README

### Release note

```release-note
VPC: fixed a typo in README
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a spelling error in deployment notes documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->