### PR TITLE
[vpc] Fix access to subnet details configmap

### DIFF
--- a/packages/apps/vpc/templates/vpc.yaml
+++ b/packages/apps/vpc/templates/vpc.yaml
@@ -75,7 +75,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: "{{ .Release.Name }}-subnets"
-subjects: {{- include "cozy-lib.rbac.subjectsForTenant" (list "view" .Release.Namespace ) | nindent 2 }}
+subjects: {{- include "cozy-lib.rbac.subjectsForTenantAndAccessLevel" (list "view" .Release.Namespace ) | nindent 2 }}
 roleRef:
   kind: Role
   name: "{{ .Release.Name }}-subnets"


### PR DESCRIPTION
## What this PR does

The VPC chart incorrectly used the wrong template for the subjects that should have access to the configmap info resource. This patch grants this access to all subjects at or above a certain access level, rather than just at a specific level.

### Release note

```release-note
[vpc] Grant read access to the subnets configmap to all users inside a
tenant.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced role binding generation to better incorporate access level information in subject configuration and access control setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->