### PR TITLE
[apps] kubernetes: volumesnapshot_crd: rm cilium dependency

### DIFF
--- a/packages/apps/kubernetes/templates/helmreleases/volumesnapshot_crd.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/volumesnapshot_crd.yaml
@@ -37,5 +37,3 @@ spec:
   - name: {{ .Release.Name }}
     namespace: {{ .Release.Namespace }}
   {{- end }}
-  - name: {{ .Release.Name }}-cilium
-    namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
## What this PR does
Kubernetes app: removes volumesnaphot crd hr dependency on cilium.

### Release note

```release-note
[App kubernetes: removed volumesnapshot dependency on cilium]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined volume snapshot deployment configuration by removing a redundant secondary dependency declaration, simplifying the overall dependency management structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->