### PR TITLE
[cozy-lib] Improve flatten function

### DIFF
--- a/packages/tests/cozy-lib-tests/tests/quota_test.yaml
+++ b/packages/tests/cozy-lib-tests/tests/quota_test.yaml
@@ -18,13 +18,33 @@ tests:
     asserts:
       - equal:
           path: spec.hard["limits.cpu"]
-          value: "2"
+          value: "20"
 
       - equal:
           path: spec.hard["requests.cpu"]
-          value: "0.2"
+          value: "2"
+
+      - equal:
+          path: spec.hard["limits.foobar"]
+          value: "3"
+
+      - equal:
+          path: spec.hard["requests.foobar"]
+          value: "3"
 
       - equal:
           path: spec.hard["services.loadbalancers"]
           value: "2"
 
+      - equal:
+          path: spec.hard["requests.storage"]
+          value: "5Gi"
+
+      - notExists:
+          path: spec.hard["limits.storage"]
+
+      - notExists:
+          path: spec.hard["limits.services.loadbalancers"]
+
+      - notExists:
+          path: spec.hard["requests.services.loadbalancers"]

--- a/packages/tests/cozy-lib-tests/tests/quota_values.yaml
+++ b/packages/tests/cozy-lib-tests/tests/quota_values.yaml
@@ -1,3 +1,5 @@
 quota:
   services.loadbalancers: "2"
-  cpu: "2"
+  cpu: "20"
+  storage: "5Gi"
+  foobar: "3"


### PR DESCRIPTION
This patch breaks introduces a helper function in cozy-lib to correctly handle special case resources when transforming a nested map of limits and requests to a flat map suitable for use in resourceQuotas. As a result, admins can now specify any types of resources as resource quotas for tenants, and they will be correctly transformed to the correct format for the underlying kubernetes ResourceQuota. In addition to the previously supported compute resources, such as CPU, memory, and custom resources, like GPUs, special quota strings such as "services.loadbalancers" are now correctly handled.

```release-note
[cozy-lib,platform] Support resource quotas for special kubernetes
quotas, such as service.loadbalncer count and others.
```

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[cozy-lib] Improve flatten function
```