### PR TITLE
[linstor] Update Piraeus Operator to v2.10.1 to enable RWX support

### DIFF
--- a/packages/system/piraeus-operator/charts/piraeus/Chart.yaml
+++ b/packages/system/piraeus-operator/charts/piraeus/Chart.yaml
@@ -3,8 +3,8 @@ name: piraeus
 description: |
   The Piraeus Operator manages software defined storage clusters using LINSTOR in Kubernetes.
 type: application
-version: 2.9.1
-appVersion: "v2.9.1"
+version: 2.10.1
+appVersion: "v2.10.1"
 maintainers:
   - name: Piraeus Datastore
     url: https://piraeus.io

--- a/packages/system/piraeus-operator/charts/piraeus/README.md
+++ b/packages/system/piraeus-operator/charts/piraeus/README.md
@@ -3,33 +3,8 @@
 Deploys the [Piraeus Operator](https://github.com/piraeusdatastore/piraeus-operator) which deploys and manages a simple
 and resilient storage solution for Kubernetes.
 
-The main deployment method for Piraeus Operator switched to [`kustomize`](../../docs/tutorial)
+The main deployment method for Piraeus Operator switched to [`kustomize`](https://piraeus.io/docs/stable/tutorial/get-started/)
 in release `v2.0.0`. This chart is intended for users who want to continue using Helm.
 
 This chart **only** configures the Operator, but does not create the `LinstorCluster` resource creating the actual
-storage system. Refer to the existing [tutorials](../../docs/tutorial)
-and [how-to guides](../../docs/how-to).
-
-## Deploying Piraeus Operator
-
-To deploy Piraeus Operator with Helm, clone this repository and deploy the chart:
-
-```
-$ git clone --branch v2 https://github.com/piraeusdatastore/piraeus-operator
-$ cd piraeus-operator
-$ helm install piraeus-operator charts/piraeus-operator --create-namespace -n piraeus-datastore
-```
-
-Follow the instructions printed by Helm to create your storage cluster:
-
-```
-$ kubectl apply -f - <<EOF
-apiVersion: piraeus.io/v1
-kind: LinstorCluster
-metadata:
-  name: linstorcluster
-spec: {}
-EOF
-```
-
-Check out our [documentation](../../docs) for more information.
+storage system. Refer to the [how-to guide](https://piraeus.io/docs/stable/how-to/helm/).

--- a/packages/system/piraeus-operator/charts/piraeus/templates/NOTES.txt
+++ b/packages/system/piraeus-operator/charts/piraeus/templates/NOTES.txt
@@ -14,7 +14,7 @@ Piraeus Operator installed.
 ` }}
 {{- end }}
 
-{{- if not (.Capabilities.APIVersions.Has "piraeus.io/v1/LinstorCluster") }}
+{{- if and (not (.Capabilities.APIVersions.Has "piraeus.io/v1/LinstorCluster")) (not .Values.installCRDs) }}
 It looks like the necessary CRDs for Piraeus Operator are still missing.
 
 To apply them via helm now use:
@@ -23,18 +23,12 @@ To apply them via helm now use:
 
 Alternatively, you can manage them manually:
 
-  kubectl apply --server-side -k "https://github.com/piraeusdatastore/piraeus-operator//config/crd?ref=v2"
+  kubectl apply --server-side -k "https://github.com/piraeusdatastore/piraeus-operator//config/crd?ref={{ .Chart.AppVersion }}"
 
 {{- end }}
 
-To get started with Piraeus, simply run:
+To get started with Piraeus Datastore deploy the "linstor-cluster" chart:
 
-$ kubectl apply -f - <<EOF
-apiVersion: piraeus.io/v1
-kind: LinstorCluster
-metadata:
-  name: linstorcluster
-spec: {}
-EOF
+$ helm upgrade --install --namespace {{ .Release.Namespace }} linstor-cluster oci://ghcr.io/piraeusdatastore/helm-charts/linstor-cluster
 
-For next steps, check out our documentation at https://github.com/piraeusdatastore/piraeus-operator/tree/v2/docs
+For next steps, check out our documentation at https://piraeus.io/docs/{{ .Chart.AppVersion }}

--- a/packages/system/piraeus-operator/charts/piraeus/templates/config.yaml
+++ b/packages/system/piraeus-operator/charts/piraeus/templates/config.yaml
@@ -23,20 +23,26 @@ data:
         tag: v1.32.3
         image: piraeus-server
       linstor-csi:
-        tag: v1.9.0
+        tag: v1.10.2
         image: piraeus-csi
+      nfs-server:
+        tag: v1.10.2
+        image: piraeus-csi-nfs-server
       drbd-reactor:
-        tag: v1.9.0
+        tag: v1.10.0
         image: drbd-reactor
       ha-controller:
-        tag: v1.3.0
+        tag: v1.3.1
         image: piraeus-ha-controller
       drbd-shutdown-guard:
-        tag: v1.0.0
+        tag: v1.1.1
         image: drbd-shutdown-guard
       ktls-utils:
         tag: v1.2.1
         image: ktls-utils
+      linstor-affinity-controller:
+        tag: v1.3.0
+        image: linstor-affinity-controller
       drbd-module-loader:
         tag: v9.2.15
         # The special "match" attribute is used to select an image based on the node's reported OS.
@@ -93,13 +99,13 @@ data:
         tag: v2.17.0
         image: livenessprobe
       csi-provisioner:
-        tag: v5.3.0
+        tag: v6.0.0
         image: csi-provisioner
       csi-snapshotter:
-        tag: v8.3.0
+        tag: v8.4.0
         image: csi-snapshotter
       csi-resizer:
-        tag: v1.14.0
+        tag: v2.0.0
         image: csi-resizer
       csi-external-health-monitor-controller:
         tag: v0.16.0

--- a/packages/system/piraeus-operator/charts/piraeus/templates/crds.yaml
+++ b/packages/system/piraeus-operator/charts/piraeus/templates/crds.yaml
@@ -15,7 +15,41 @@ spec:
     singular: linstorcluster
   scope: Cluster
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: If the LINSTOR Cluster is available
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: If the LINSTOR Cluster is fully configured
+      jsonPath: .status.conditions[?(@.type=='Configured')].status
+      name: Configured
+      type: string
+    - description: The version of the LINSTOR Cluster
+      jsonPath: .status.version
+      name: Version
+      priority: 10
+      type: string
+    - description: The number of running/expected Satellites
+      jsonPath: .status.satellites
+      name: Satellites
+      type: string
+    - description: The used capacity in all storage pools
+      jsonPath: .status.capacity
+      name: Used Capacity
+      type: string
+    - description: The number of volumes in the cluster
+      jsonPath: .status.numberOfVolumes
+      name: Volumes
+      type: integer
+    - description: The number of snapshots in the cluster
+      jsonPath: .status.numberOfSnapshots
+      name: Snapshots
+      priority: 10
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: LinstorCluster is the Schema for the linstorclusters API
@@ -40,6 +74,30 @@ spec:
           spec:
             description: LinstorClusterSpec defines the desired state of LinstorCluster
             properties:
+              affinityController:
+                description: AffinityController controls the deployment of the Affinity
+                  Controller Deployment.
+                properties:
+                  enabled:
+                    default: true
+                    description: Enable the component.
+                    type: boolean
+                  podTemplate:
+                    description: |-
+                      Template to apply to Pods of the component.
+
+                      The template is applied as a patch to the default deployment, so it can be "sparse", not listing any
+                      containers or volumes that should remain unchanged.
+                      See https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates
+                    type: object
+                    x-kubernetes-map-type: atomic
+                    x-kubernetes-preserve-unknown-fields: true
+                  replicas:
+                    description: Number of desired pods. Defaults to 1.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                type: object
               apiTLS:
                 description: |-
                   ApiTLS secures the LINSTOR API.
@@ -47,6 +105,11 @@ spec:
                   This configures the TLS key and certificate used to secure the LINSTOR API.
                 nullable: true
                 properties:
+                  affinityControllerSecretName:
+                    description: |-
+                      AffinityControllerSecretName references a secret holding the TLS key and certificate used by the Affinity
+                      Controller to monitor volume state. Defaults to "linstor-affinity-controller-tls".
+                    type: string
                   apiSecretName:
                     description: |-
                       ApiSecretName references a secret holding the TLS key and certificate used to protect the API.
@@ -114,6 +177,11 @@ spec:
                       CsiNodeSecretName references a secret holding the TLS key and certificate used by the CSI Nodes to query
                       the volume state. Defaults to "linstor-csi-node-tls".
                     type: string
+                  nfsServerSecretName:
+                    description: |-
+                      NFSServerSecretName references a secret holding the TLS key and certificate used by the NFS Server to query
+                      the cluster state. Defaults to "linstor-csi-nfs-server-tls".
+                    type: string
                 type: object
               controller:
                 description: Controller controls the deployment of the LINSTOR Controller
@@ -152,6 +220,11 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                     x-kubernetes-preserve-unknown-fields: true
+                  replicas:
+                    description: Number of desired pods. Defaults to 1.
+                    format: int32
+                    minimum: 0
+                    type: integer
                 type: object
               csiNode:
                 description: CSINode controls the deployment of the CSI Node DaemonSet.
@@ -272,6 +345,25 @@ spec:
                   * Store credentials for accessing remotes for backups.
                   See https://linbit.com/drbd-user-guide/linstor-guide-1_0-en/#s-encrypt_commands for more information.
                 type: string
+              nfsServer:
+                description: NFSServer controls the deployment of the LINSTOR CSI
+                  NFS Server DaemonSet.
+                properties:
+                  enabled:
+                    default: true
+                    description: Enable the component.
+                    type: boolean
+                  podTemplate:
+                    description: |-
+                      Template to apply to Pods of the component.
+
+                      The template is applied as a patch to the default deployment, so it can be "sparse", not listing any
+                      containers or volumes that should remain unchanged.
+                      See https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates
+                    type: object
+                    x-kubernetes-map-type: atomic
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               nodeAffinity:
                 description: |-
                   NodeAffinity selects the nodes on which LINSTOR Satellites will be deployed.
@@ -379,9 +471,16 @@ spec:
                     JSON patch and its targets.
                   properties:
                     options:
-                      additionalProperties:
-                        type: boolean
                       description: Options is a list of options for the patch
+                      properties:
+                        allowKindChange:
+                          description: AllowKindChange allows kind changes to the
+                            resource.
+                          type: boolean
+                        allowNameChange:
+                          description: AllowNameChange allows name changes to the
+                            resource.
+                          type: boolean
                       type: object
                     patch:
                       description: Patch is the content of a patch.
@@ -493,6 +592,15 @@ spec:
           status:
             description: LinstorClusterStatus defines the observed state of LinstorCluster
             properties:
+              availableCapacityBytes:
+                description: The number of bytes in total in all storage pools in
+                  the LINSTOR Cluster.
+                format: int64
+                type: integer
+              capacity:
+                description: Capacity mirrors the information from TotalCapacityBytes
+                  and FreeCapacityBytes in a human-readable string
+                type: string
               conditions:
                 description: Current LINSTOR Cluster state
                 items:
@@ -553,6 +661,35 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              freeCapacityBytes:
+                description: The number of bytes free in all storage pools in the
+                  LINSTOR Cluster.
+                format: int64
+                type: integer
+              numberOfSnapshots:
+                description: The number of snapshots in the LINSTOR Cluster.
+                format: int32
+                type: integer
+              numberOfVolumes:
+                description: The number of volumes in the LINSTOR Cluster.
+                format: int32
+                type: integer
+              runningSatellites:
+                description: The number of LINSTOR Satellites currently running.
+                format: int32
+                type: integer
+              satellites:
+                description: Satellites mirrors the information from ScheduledSatellites
+                  and RunningSatellites in a human-readable string
+                type: string
+              scheduledSatellites:
+                description: The number of LINSTOR Satellites that are expected to
+                  run.
+                format: int32
+                type: integer
+              version:
+                description: The Version of the LINSTOR Cluster.
+                type: string
             type: object
         type: object
     served: true
@@ -575,7 +712,15 @@ spec:
     singular: linstornodeconnection
   scope: Cluster
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: If the LINSTOR Node Connection is fully configured
+      jsonPath: .status.conditions[?(@.type=='Configured')].status
+      name: Configured
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: LinstorNodeConnection is the Schema for the linstornodeconnections
@@ -777,7 +922,28 @@ spec:
     singular: linstorsatelliteconfiguration
   scope: Cluster
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: The node selector used
+      jsonPath: .spec.nodeSelector
+      name: Selector
+      type: string
+    - description: If the Configuration was applied
+      jsonPath: .status.conditions[?(@.type=='Applied')].status
+      name: Applied
+      type: string
+    - description: Number of Satellites this Configuration has been applied to
+      jsonPath: .status.matched
+      name: Matched
+      type: integer
+    - description: Satellites this Configuration has been applied to
+      jsonPath: .status.appliedTo
+      name: Satellites
+      priority: 10
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: LinstorSatelliteConfiguration is the Schema for the linstorsatelliteconfigurations
@@ -1013,9 +1179,16 @@ spec:
                     JSON patch and its targets.
                   properties:
                     options:
-                      additionalProperties:
-                        type: boolean
                       description: Options is a list of options for the patch
+                      properties:
+                        allowKindChange:
+                          description: AllowKindChange allows kind changes to the
+                            resource.
+                          type: boolean
+                        allowNameChange:
+                          description: AllowNameChange allows name changes to the
+                            resource.
+                          type: boolean
                       type: object
                     patch:
                       description: Patch is the content of a patch.
@@ -1274,6 +1447,12 @@ spec:
             description: LinstorSatelliteConfigurationStatus defines the observed
               state of LinstorSatelliteConfiguration
             properties:
+              appliedTo:
+                description: AppliedTo lists the LinstorSatellite resource this configuration
+                  was applied to
+                items:
+                  type: string
+                type: array
               conditions:
                 description: Current LINSTOR Satellite Config state
                 items:
@@ -1334,6 +1513,10 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              matched:
+                description: Number of configured LinstorSatellite resource.
+                format: int64
+                type: integer
             type: object
         type: object
     served: true
@@ -1356,7 +1539,51 @@ spec:
     singular: linstorsatellite
   scope: Cluster
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: If the LINSTOR Satellite is connected
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Connected
+      type: string
+    - description: If the LINSTOR Satellite is fully configured
+      jsonPath: .status.conditions[?(@.type=='Configured')].status
+      name: Configured
+      type: string
+    - description: The Satellite Configurations applied to this Satellite
+      jsonPath: .metadata.annotations.piraeus\.io/applied-configurations
+      name: Applied Configurations
+      priority: 10
+      type: string
+    - description: The deletion policy of the Satellite
+      jsonPath: .spec.deletionPolicy
+      name: Deletion Policy
+      type: string
+    - description: The used capacity on the node
+      jsonPath: .status.capacity
+      name: Used Capacity
+      type: string
+    - description: The number of volumes on the node
+      jsonPath: .status.numberOfVolumes
+      name: Volumes
+      type: integer
+    - description: The number of snapshots on the node
+      jsonPath: .status.numberOfSnapshots
+      name: Snapshots
+      priority: 10
+      type: integer
+    - description: The storage providers supported by the node
+      jsonPath: .status.storageProviders
+      name: Storage Providers
+      priority: 10
+      type: string
+    - description: The device layers supported by the node
+      jsonPath: .status.deviceLayers
+      name: Device Layers
+      priority: 10
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: LinstorSatellite is the Schema for the linstorsatellites API
@@ -1546,9 +1773,16 @@ spec:
                     JSON patch and its targets.
                   properties:
                     options:
-                      additionalProperties:
-                        type: boolean
                       description: Options is a list of options for the patch
+                      properties:
+                        allowKindChange:
+                          description: AllowKindChange allows kind changes to the
+                            resource.
+                          type: boolean
+                        allowNameChange:
+                          description: AllowNameChange allows name changes to the
+                            resource.
+                          type: boolean
                       type: object
                     patch:
                       description: Patch is the content of a patch.
@@ -1801,6 +2035,15 @@ spec:
           status:
             description: LinstorSatelliteStatus defines the observed state of LinstorSatellite
             properties:
+              availableCapacityBytes:
+                description: The number of bytes in total in all storage pools on
+                  this Satellite.
+                format: int64
+                type: integer
+              capacity:
+                description: Capacity mirrors the information from TotalCapacityBytes
+                  and FreeCapacityBytes in a human-readable string.
+                type: string
               conditions:
                 description: Current LINSTOR Satellite state
                 items:
@@ -1861,6 +2104,31 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              deviceLayers:
+                description: DeviceLayers lists the device layers (LUKS, CACHE, etc...)
+                  this Satellite supports.
+                items:
+                  type: string
+                type: array
+              freeCapacityBytes:
+                description: The number of bytes free in all storage pools on this
+                  Satellite.
+                format: int64
+                type: integer
+              numberOfSnapshots:
+                description: The number of snapshots on this Satellite.
+                format: int32
+                type: integer
+              numberOfVolumes:
+                description: The number of volumes on this Satellite.
+                format: int32
+                type: integer
+              storageProviders:
+                description: StorageProviders lists the storage providers (LVM, ZFS,
+                  etc...) this Satellite supports.
+                items:
+                  type: string
+                type: array
             type: object
         type: object
     served: true

--- a/packages/system/piraeus-operator/charts/piraeus/templates/deployment.yaml
+++ b/packages/system/piraeus-operator/charts/piraeus/templates/deployment.yaml
@@ -13,9 +13,15 @@ spec:
   template:
     metadata:
       labels:
-      {{- include "piraeus-operator.selectorLabels" . | nindent 8 }}
+        {{- include "piraeus-operator.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - args:
@@ -90,6 +96,9 @@ spec:
       {{- end }}
       securityContext:
         runAsNonRoot: true
+        {{- with .Values.podSecurityContext }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
       serviceAccountName: {{ include "piraeus-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
       priorityClassName: {{ .Values.priorityClassName | default "system-cluster-critical" }}

--- a/packages/system/piraeus-operator/charts/piraeus/templates/rbac.yaml
+++ b/packages/system/piraeus-operator/charts/piraeus/templates/rbac.yaml
@@ -30,8 +30,18 @@ rules:
     - ""
   resources:
     - nodes
+  verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - ""
+  resources:
     - persistentvolumeclaims
   verbs:
+    - delete
     - get
     - list
     - patch
@@ -93,6 +103,21 @@ rules:
     - update
     - watch
 - apiGroups:
+    - cluster.x-k8s.io
+  resources:
+    - machines
+  verbs:
+    - get
+    - update
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+    - endpointslices/restricted
+  verbs:
+    - create
+    - delete
+- apiGroups:
     - events.k8s.io
   resources:
     - events
@@ -103,6 +128,32 @@ rules:
     - patch
     - update
     - watch
+- apiGroups:
+    - groupsnapshot.storage.k8s.io
+  resources:
+    - volumegroupsnapshotclasses
+    - volumesnapshots
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - groupsnapshot.storage.k8s.io
+  resources:
+    - volumegroupsnapshotcontents
+  verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - groupsnapshot.storage.k8s.io
+  resources:
+    - volumegroupsnapshotcontents/status
+  verbs:
+    - patch
+    - update
 - apiGroups:
     - internal.linstor.linbit.com
   resources:
@@ -194,7 +245,6 @@ rules:
   resources:
     - volumesnapshotcontents
   verbs:
-    - delete
     - get
     - list
     - patch

--- a/packages/system/piraeus-operator/charts/piraeus/values.yaml
+++ b/packages/system/piraeus-operator/charts/piraeus/values.yaml
@@ -1,3 +1,4 @@
+---
 replicaCount: 1
 
 installCRDs: false
@@ -18,6 +19,7 @@ operator:
 
   options:
     leaderElect: true
+    #clusterApiKubeconfig: "" # set to "<none>" to disable ClusterAPI integration
 
   resources: { }
     # limits:
@@ -80,6 +82,7 @@ rbac:
   create: true
 
 podAnnotations: { }
+podLabels: {}
 
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

This PR updates Piraeus Operator to enable RWX support released in https://github.com/piraeusdatastore/piraeus-operator/releases/tag/v2.10.0

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[linstor] Update Piraeus Operator to v2.10.1 to enable RWX support
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NFS server component and affinity controller support for enhanced storage configuration
  * Expanded kubectl output with additional status columns for improved cluster visibility
  * Added support for pod labels, annotations, and security context customization

* **Chores**
  * Updated Helm chart to version 2.10.1
  * Updated multiple component versions including CSI provisioner, snapshotter, DRBD reactor, and other dependencies

* **Documentation**
  * Updated README to reference external Helm-based deployment guidelines

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->