### PR TITLE
[extra] ingress: rm spaces from external ip list

### DIFF
--- a/packages/extra/ingress/templates/nginx-ingress.yaml
+++ b/packages/extra/ingress/templates/nginx-ingress.yaml
@@ -1,6 +1,6 @@
 {{- $cozyConfig := lookup "v1" "ConfigMap" "cozy-system" "cozystack" }}
 {{- $exposeIngress := index $cozyConfig.data "expose-ingress" | default "tenant-root" }}
-{{- $exposeExternalIPs := (index $cozyConfig.data "expose-external-ips") | default "" }}
+{{- $exposeExternalIPs := (index $cozyConfig.data "expose-external-ips") | default "" | nospace }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:


### PR DESCRIPTION
## What this PR does
Remove spaces while processing exposed-external-ips list in cozystack configmap as they 1) are user-specified and 2) lead to an incorrect resource being created from it.

### Release note
```release-note
Remove spaces while processing exposed-external-ips list in cozystack configmap
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of external IP entries by trimming stray whitespace, reducing malformed or empty external IPs and improving how ingress external addresses are rendered and interpreted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->