### PR TITLE
[dashboard] Add config hash annotations to restart pods on config changes

### DIFF
--- a/packages/system/dashboard/templates/nginx.yaml
+++ b/packages/system/dashboard/templates/nginx.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configmap-configurationnginxfile: 258c66b019c8c7f4a5d0a78dfd7bf297ce486b213346fbd2879c466abfc377e0
+        checksum/config: {{ include (print $.Template.BasePath "/nginx-config.yaml") . | sha256sum }}
       labels:
         app.kubernetes.io/instance: incloud-web
         app.kubernetes.io/name: nginx

--- a/packages/system/dashboard/templates/web.yaml
+++ b/packages/system/dashboard/templates/web.yaml
@@ -15,7 +15,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations: null
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         app.kubernetes.io/instance: incloud-web
         app.kubernetes.io/name: web


### PR DESCRIPTION
## What this PR does

This PR adds config hash annotations to the dashboard deployment templates to ensure pods are automatically restarted when their configuration changes.

Changes:
- Added `checksum/config` annotation to `nginx.yaml` deployment that computes a hash of `nginx-config.yaml`
- Added `checksum/config` annotation to `web.yaml` deployment that computes a hash of `configmap.yaml`

This replaces the hardcoded checksum in nginx.yaml with a dynamically computed one, and adds a new checksum for the web deployment.

### Release note

```release-note
[dashboard] Add config hash annotations to automatically restart pods when configuration changes
```

