### PR TITLE
[system:coredns] update coredns app labels to match Talos coredns labels

### DIFF
--- a/packages/system/coredns/values.yaml
+++ b/packages/system/coredns/values.yaml
@@ -4,3 +4,5 @@ coredns:
     tag: v1.12.4
   replicaCount: 2
   k8sAppLabelOverride: kube-dns
+  service:
+    name: kube-dns


### PR DESCRIPTION
## What this PR does
Updates coredns app labels to match Talos coredns labels

### Release note

```release-note
Coredns app labels updated to match Talos coredns labels.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new configuration option to set the Kubernetes app label override and corresponding service name for CoreDNS; defaults remain unchanged. This exposes label and service-name settings so deployments can be adjusted via configuration without other changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->