### PR TITLE
[system:monitoring-agents] rename coredns metrics service

### DIFF
--- a/packages/system/monitoring-agents/templates/coredns-scrape.yaml
+++ b/packages/system/monitoring-agents/templates/coredns-scrape.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: coredns
+  name: coredns-metrics
   namespace: kube-system
   labels:
     app: coredns
@@ -19,7 +19,7 @@ spec:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMServiceScrape
 metadata:
-  name: coredns
+  name: coredns-metrics
   namespace: cozy-monitoring
 spec:
   selector:


### PR DESCRIPTION
## What this PR does
Renames coredns metrics service

### Release note
```release-note
Renamed coredns metrics service not to interfere with coredns service used for name resolution in tenant k8s clusters.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource identifiers in the CoreDNS monitoring configuration template for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->