### PR TITLE
[core:installer] Address buildx warnings

### DIFF
--- a/packages/core/installer/images/cozystack/Dockerfile
+++ b/packages/core/installer/images/cozystack/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine as k8s-await-election-builder
+FROM golang:1.24-alpine AS k8s-await-election-builder
 
 ARG K8S_AWAIT_ELECTION_GITREPO=https://github.com/LINBIT/k8s-await-election
 ARG K8S_AWAIT_ELECTION_VERSION=0.4.1
@@ -13,7 +13,7 @@ RUN git clone ${K8S_AWAIT_ELECTION_GITREPO} /usr/local/go/k8s-await-election/ \
  && make \
  && mv ./out/k8s-await-election-${TARGETARCH} /k8s-await-election
 
-FROM golang:1.24-alpine as builder
+FROM golang:1.24-alpine AS builder
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
## What this PR does
Buildx is worried about Dockerfile syntax, this pr fixes it.
```
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 16)
```

### Release note
```release-note
Buildx warnings addressed.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dockerfile formatting for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->