### PR TITLE
[backups] Scaffold a backup strategy API group

### DIFF
--- a/api/backups/strategy/v1alpha1/groupversion_info.go
+++ b/api/backups/strategy/v1alpha1/groupversion_info.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v1alpha1 contains API Schema definitions for the  v1alpha1 API group.
+// +kubebuilder:object:generate=true
+// +groupName=strategy.backups.cozystack.io
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	GroupVersion  = schema.GroupVersion{Group: "strategy.backups.cozystack.io", Version: "v1alpha1"}
+	SchemeBuilder = runtime.NewSchemeBuilder(addGroupVersion)
+	AddToScheme   = SchemeBuilder.AddToScheme
+)
+
+func addGroupVersion(scheme *runtime.Scheme) error {
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}


### PR DESCRIPTION
## What this PR does

This patch adds the boilerplate for the `strategy.backups.cozystack.io` API group that will contain reference backup/restore strategy implementations that will live in Cozystack core.

### Release note

```release-note
    [backups] Scaffold the `strategy.backups.cozystack.io` API group to
    provide a well-defined point for adding reference strategy
    implementations.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced v1alpha1 backup strategy API group registration, enabling support for backup strategy resources within the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->