### PR TITLE
[linstor] Update piraeus-operator v2.10.2

### DIFF
--- a/packages/system/piraeus-operator/charts/piraeus/Chart.yaml
+++ b/packages/system/piraeus-operator/charts/piraeus/Chart.yaml
@@ -3,8 +3,8 @@ name: piraeus
 description: |
   The Piraeus Operator manages software defined storage clusters using LINSTOR in Kubernetes.
 type: application
-version: 2.10.1
-appVersion: "v2.10.1"
+version: 2.10.2
+appVersion: "v2.10.2"
 maintainers:
   - name: Piraeus Datastore
     url: https://piraeus.io

--- a/packages/system/piraeus-operator/charts/piraeus/templates/config.yaml
+++ b/packages/system/piraeus-operator/charts/piraeus/templates/config.yaml
@@ -23,10 +23,10 @@ data:
         tag: v1.32.3
         image: piraeus-server
       linstor-csi:
-        tag: v1.10.2
+        tag: v1.10.3
         image: piraeus-csi
       nfs-server:
-        tag: v1.10.2
+        tag: v1.10.3
         image: piraeus-csi-nfs-server
       drbd-reactor:
         tag: v1.10.0
@@ -44,7 +44,7 @@ data:
         tag: v1.3.0
         image: linstor-affinity-controller
       drbd-module-loader:
-        tag: v9.2.15
+        tag: v9.2.16
         # The special "match" attribute is used to select an image based on the node's reported OS.
         # The operator will first check the k8s node's ".status.nodeInfo.osImage" field, and compare it against the list
         # here. If one matches, that specific image name will be used instead of the fallback image.
@@ -99,7 +99,7 @@ data:
         tag: v2.17.0
         image: livenessprobe
       csi-provisioner:
-        tag: v6.0.0
+        tag: v6.1.0
         image: csi-provisioner
       csi-snapshotter:
         tag: v8.4.0

--- a/packages/system/piraeus-operator/charts/piraeus/templates/crds.yaml
+++ b/packages/system/piraeus-operator/charts/piraeus/templates/crds.yaml
@@ -993,6 +993,24 @@ spec:
                 - Retain
                 - Delete
                 type: string
+              evacuationStrategy:
+                description: EvacuationStrategy configures the evacuation of volumes
+                  from a Satellite when DeletionPolicy "Evacuate" is used.
+                nullable: true
+                properties:
+                  attachedVolumeReattachTimeout:
+                    default: 5m
+                    description: |-
+                      AttachedVolumeReattachTimeout configures how long evacuation waits for attached volumes to reattach on
+                      different nodes. Setting this to 0 disable this evacuation step.
+                    type: string
+                  unattachedVolumeAttachTimeout:
+                    default: 5m
+                    description: |-
+                      UnattachedVolumeAttachTimeout configures how long evacuation waits for unattached volumes to attach on
+                      different nodes. Setting this to 0 disable this evacuation step.
+                    type: string
+                type: object
               internalTLS:
                 description: |-
                   InternalTLS configures secure communication for the LINSTOR Satellite.
@@ -1683,6 +1701,23 @@ spec:
                 - Retain
                 - Delete
                 type: string
+              evacuationStrategy:
+                description: EvacuationStrategy configures the evacuation of volumes
+                  from a Satellite when DeletionPolicy "Evacuate" is used.
+                properties:
+                  attachedVolumeReattachTimeout:
+                    default: 5m
+                    description: |-
+                      AttachedVolumeReattachTimeout configures how long evacuation waits for attached volumes to reattach on
+                      different nodes. Setting this to 0 disable this evacuation step.
+                    type: string
+                  unattachedVolumeAttachTimeout:
+                    default: 5m
+                    description: |-
+                      UnattachedVolumeAttachTimeout configures how long evacuation waits for unattached volumes to attach on
+                      different nodes. Setting this to 0 disable this evacuation step.
+                    type: string
+                type: object
               internalTLS:
                 description: |-
                   InternalTLS configures secure communication for the LINSTOR Satellite.


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

This release updates LINSTOR CSI to fix issues with the new fsck behaviour.

```
MountVolume.SetUp failed for volume "pvc-37245cc3-bf28-4da4-a127-e5c9c03cc088" : rpc error: code = Internal desc = NodePublishVolume failed for pvc-37245cc3-bf28-4da4-a127-e5c9c03cc088: failed to run fsck on device '/dev/zvol/data/pvc-37245cc3-bf28-4da4-a127-e5c9c03cc088_00000': failed to run fsck: output: "fsck from util-linux 2.41
/dev/zd832 is mounted.
e2fsck: Cannot continue, aborting.
```

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[linstor] Update piraeus-operator v2.10.2
```