### PR TITLE
[dashboard] Fix CustomFormsOverride schema to nest properties under spec.properties

### DIFF
--- a/internal/controller/dashboard/customformsoverride.go
+++ b/internal/controller/dashboard/customformsoverride.go
@@ -105,8 +105,26 @@ func buildMultilineStringSchema(openAPISchema string) (map[string]any, error) {
 		"properties": map[string]any{},
 	}
 
+	// Check if there's a spec property
+	specProp, ok := props["spec"].(map[string]any)
+	if !ok {
+		return map[string]any{}, nil
+	}
+
+	specProps, ok := specProp["properties"].(map[string]any)
+	if !ok {
+		return map[string]any{}, nil
+	}
+
+	// Create spec.properties structure in schema
+	schemaProps := schema["properties"].(map[string]any)
+	specSchema := map[string]any{
+		"properties": map[string]any{},
+	}
+	schemaProps["spec"] = specSchema
+
 	// Process spec properties recursively
-	processSpecProperties(props, schema["properties"].(map[string]any))
+	processSpecProperties(specProps, specSchema["properties"].(map[string]any))
 
 	return schema, nil
 }

--- a/internal/controller/dashboard/customformsoverride_test.go
+++ b/internal/controller/dashboard/customformsoverride_test.go
@@ -9,41 +9,46 @@ func TestBuildMultilineStringSchema(t *testing.T) {
 	// Test OpenAPI schema with various field types
 	openAPISchema := `{
 		"properties": {
-			"simpleString": {
-				"type": "string",
-				"description": "A simple string field"
-			},
-			"stringWithEnum": {
-				"type": "string",
-				"enum": ["option1", "option2"],
-				"description": "String with enum should be skipped"
-			},
-			"numberField": {
-				"type": "number",
-				"description": "Number field should be skipped"
-			},
-			"nestedObject": {
+			"spec": {
 				"type": "object",
 				"properties": {
-					"nestedString": {
+					"simpleString": {
 						"type": "string",
-						"description": "Nested string should get multilineString"
+						"description": "A simple string field"
 					},
-					"nestedStringWithEnum": {
+					"stringWithEnum": {
 						"type": "string",
-						"enum": ["a", "b"],
-						"description": "Nested string with enum should be skipped"
-					}
-				}
-			},
-			"arrayOfObjects": {
-				"type": "array",
-				"items": {
-					"type": "object",
-					"properties": {
-						"itemString": {
-							"type": "string",
-							"description": "String in array item"
+						"enum": ["option1", "option2"],
+						"description": "String with enum should be skipped"
+					},
+					"numberField": {
+						"type": "number",
+						"description": "Number field should be skipped"
+					},
+					"nestedObject": {
+						"type": "object",
+						"properties": {
+							"nestedString": {
+								"type": "string",
+								"description": "Nested string should get multilineString"
+							},
+							"nestedStringWithEnum": {
+								"type": "string",
+								"enum": ["a", "b"],
+								"description": "Nested string with enum should be skipped"
+							}
+						}
+					},
+					"arrayOfObjects": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"itemString": {
+									"type": "string",
+									"description": "String in array item"
+								}
+							}
 						}
 					}
 				}
@@ -70,33 +75,44 @@ func TestBuildMultilineStringSchema(t *testing.T) {
 		t.Fatal("schema.properties is not a map")
 	}
 
-	// Check simpleString
-	simpleString, ok := props["simpleString"].(map[string]any)
+	// Check spec property exists
+	spec, ok := props["spec"].(map[string]any)
 	if !ok {
-		t.Fatal("simpleString not found in properties")
+		t.Fatal("spec not found in properties")
+	}
+
+	specProps, ok := spec["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("spec.properties is not a map")
+	}
+
+	// Check simpleString
+	simpleString, ok := specProps["simpleString"].(map[string]any)
+	if !ok {
+		t.Fatal("simpleString not found in spec.properties")
 	}
 	if simpleString["type"] != "multilineString" {
 		t.Errorf("simpleString should have type multilineString, got %v", simpleString["type"])
 	}
 
 	// Check stringWithEnum should not be present (or should not have multilineString)
-	if stringWithEnum, ok := props["stringWithEnum"].(map[string]any); ok {
+	if stringWithEnum, ok := specProps["stringWithEnum"].(map[string]any); ok {
 		if stringWithEnum["type"] == "multilineString" {
 			t.Error("stringWithEnum should not have multilineString type")
 		}
 	}
 
 	// Check numberField should not be present
-	if numberField, ok := props["numberField"].(map[string]any); ok {
+	if numberField, ok := specProps["numberField"].(map[string]any); ok {
 		if numberField["type"] != nil {
 			t.Error("numberField should not have any type override")
 		}
 	}
 
 	// Check nested object
-	nestedObject, ok := props["nestedObject"].(map[string]any)
+	nestedObject, ok := specProps["nestedObject"].(map[string]any)
 	if !ok {
-		t.Fatal("nestedObject not found in properties")
+		t.Fatal("nestedObject not found in spec.properties")
 	}
 	nestedProps, ok := nestedObject["properties"].(map[string]any)
 	if !ok {
@@ -113,9 +129,9 @@ func TestBuildMultilineStringSchema(t *testing.T) {
 	}
 
 	// Check array of objects
-	arrayOfObjects, ok := props["arrayOfObjects"].(map[string]any)
+	arrayOfObjects, ok := specProps["arrayOfObjects"].(map[string]any)
 	if !ok {
-		t.Fatal("arrayOfObjects not found in properties")
+		t.Fatal("arrayOfObjects not found in spec.properties")
 	}
 	items, ok := arrayOfObjects["items"].(map[string]any)
 	if !ok {


### PR DESCRIPTION
## What this PR does

Fixes the logic for generating CustomFormsOverride schema to properly nest properties under `spec.properties` instead of directly under `properties`.

Changes:
- Updated `buildMultilineStringSchema` to check for `spec` property in OpenAPI schema
- Process `spec.properties` instead of root `properties`
- Create schema structure as `schema.properties.spec.properties.*`
- Updated tests to reflect the new nested structure

### Release note

```release-note
[dashboard] Fix CustomFormsOverride schema generation to nest properties under spec.properties
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated custom form schema generation to organize form fields within a nested structure for improved organization.

* **Tests**
  * Expanded test coverage to validate the new schema organization and field type handling across nested levels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->