### PR TITLE
[virtual-machine,vm-instance] Add nodeAffinity for Windows VMs based on scheduling config

### DIFF
--- a/packages/apps/virtual-machine/templates/vm.yaml
+++ b/packages/apps/virtual-machine/templates/vm.yaml
@@ -124,6 +124,8 @@ spec:
 
       terminationGracePeriodSeconds: 30
 
+      {{- include "virtual-machine.nodeAffinity" . | nindent 6 }}
+
       volumes:
         - name: systemdisk
           dataVolume:

--- a/packages/apps/vm-instance/templates/vm.yaml
+++ b/packages/apps/vm-instance/templates/vm.yaml
@@ -95,6 +95,9 @@ spec:
             noCloud: {}
       {{- end }}
       terminationGracePeriodSeconds: 30
+
+      {{- include "virtual-machine.nodeAffinity" . | nindent 6 }}
+
       volumes:
       {{- range .Values.disks }}
       - name: disk-{{ .name }}


### PR DESCRIPTION
This PR adds nodeAffinity configuration to virtual-machine and vm-instance charts to support dedicated nodes for Windows VMs.

## Changes
- Added logic to check `cozystack-scheduling` ConfigMap in `cozy-system` namespace
- If `dedicatedNodesForWindowsVMs` is enabled, adds appropriate nodeAffinity:
  - **Windows VMs**: Strong affinity (required) to nodes with label `scheduling.cozystack.io/vm-windows=true`
  - **Non-Windows VMs**: Soft affinity (preferred) to nodes without the Windows label

## Implementation
- Windows detection based on `instanceProfile` value starting with "windows"
- Strong affinity uses `requiredDuringSchedulingIgnoredDuringExecution`
- Soft affinity uses `preferredDuringSchedulingIgnoredDuringExecution` with weight 100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable node-affinity for VM scheduling: when the cluster scheduling flag is enabled, Windows VMs are placed on dedicated Windows nodes (required rule), while non-Windows VMs are preferred to avoid those nodes (soft preference).
  * Change is gated by the cluster scheduling configuration and only affects placement rules; no other VM specs were altered.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->