### PR TITLE
[platform] Separate assets server into dedicated deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ build: build-deps
 	make -C packages/system/bucket image
 	make -C packages/system/objectstorage-controller image
 	make -C packages/core/testing image
+	make -C packages/core/platform image
 	make -C packages/core/installer image
 	make manifests
 

--- a/packages/core/installer/images/cozystack/Dockerfile
+++ b/packages/core/installer/images/cozystack/Dockerfile
@@ -26,10 +26,6 @@ WORKDIR /src
 
 RUN go mod download
 
-RUN go build -o /cozystack-assets-server -ldflags '-extldflags "-static" -w -s' ./cmd/cozystack-assets-server
-
-RUN make repos
-
 FROM alpine:3.22
 
 RUN wget -O- https://github.com/cozystack/cozypkg/raw/refs/heads/main/hack/install.sh | sh -s -- -v 1.2.0
@@ -39,10 +35,7 @@ RUN apk add --no-cache make kubectl helm coreutils git jq
 COPY --from=builder /src/scripts /cozystack/scripts
 COPY --from=builder /src/packages/core /cozystack/packages/core
 COPY --from=builder /src/packages/system /cozystack/packages/system
-COPY --from=builder /src/_out/repos /cozystack/assets/repos
-COPY --from=builder /cozystack-assets-server /usr/bin/cozystack-assets-server
 COPY --from=k8s-await-election-builder /k8s-await-election /usr/bin/k8s-await-election
-COPY --from=builder /src/dashboards /cozystack/assets/dashboards
 
 WORKDIR /cozystack
 ENTRYPOINT ["/usr/bin/k8s-await-election", "/cozystack/scripts/installer.sh" ]

--- a/packages/core/installer/templates/cozystack.yaml
+++ b/packages/core/installer/templates/cozystack.yaml
@@ -68,15 +68,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-      - name: assets
-        image: "{{ .Values.cozystack.image }}"
-        command:
-        - /usr/bin/cozystack-assets-server
-        - "-dir=/cozystack/assets"
-        - "-address=:8123"
-        ports:
-        - name: http
-          containerPort: 8123
       tolerations:
       - key: "node.kubernetes.io/not-ready"
         operator: "Exists"
@@ -84,17 +75,3 @@ spec:
       - key: "node.cilium.io/agent-not-ready"
         operator: "Exists"
         effect: "NoSchedule"
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: cozystack
-  namespace: cozy-system
-spec:
-  ports:
-  - name: http
-    port: 80
-    targetPort: 8123
-  selector:
-    app: cozystack
-  type: ClusterIP

--- a/packages/core/platform/Makefile
+++ b/packages/core/platform/Makefile
@@ -1,6 +1,8 @@
 NAME=platform
 NAMESPACE=cozy-system
 
+include ../../../scripts/common-envs.mk
+
 show:
 	cozypkg show -n $(NAMESPACE) $(NAME) --plain
 
@@ -18,3 +20,15 @@ namespaces-apply:
 
 diff:
 	cozypkg show -n $(NAMESPACE) $(NAME) --plain | kubectl diff -f-
+
+image: image-assets
+image-assets:
+	docker buildx build -f images/cozystack-assets/Dockerfile ../../.. \
+		--tag $(REGISTRY)/cozystack-assets:$(call settag,$(TAG)) \
+		--cache-from type=registry,ref=$(REGISTRY)/cozystack-assets:latest \
+		--cache-to type=inline \
+		--metadata-file images/cozystack-assets.json \
+		$(BUILDX_ARGS)
+	IMAGE="$(REGISTRY)/cozystack-assets:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/cozystack-assets.json -o json -r)" \
+		yq -i '.assets.image = strenv(IMAGE)' values.yaml
+	rm -f images/cozystack-assets.json

--- a/packages/core/platform/images/cozystack-assets/Dockerfile
+++ b/packages/core/platform/images/cozystack-assets/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:1.24-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN apk add --no-cache make git
+RUN apk add helm --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
+
+COPY . /src/
+WORKDIR /src
+
+RUN go mod download
+
+RUN go build -o /cozystack-assets-server -ldflags '-extldflags "-static" -w -s' ./cmd/cozystack-assets-server
+
+RUN make repos
+
+FROM alpine:3.22
+
+COPY --from=builder /src/_out/repos /cozystack/assets/repos
+COPY --from=builder /cozystack-assets-server /usr/bin/cozystack-assets-server
+COPY --from=builder /src/dashboards /cozystack/assets/dashboards
+
+WORKDIR /cozystack
+ENTRYPOINT ["/usr/bin/cozystack-assets-server"]

--- a/packages/core/platform/templates/cozystack-assets.yaml
+++ b/packages/core/platform/templates/cozystack-assets.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cozystack-assets
+  namespace: cozy-system
+  labels:
+    app: cozystack-assets
+spec:
+  serviceName: cozystack-assets
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cozystack-assets
+  template:
+    metadata:
+      labels:
+        app: cozystack-assets
+    spec:
+      hostNetwork: true
+      containers:
+      - name: assets-server
+        image: "{{ .Values.assets.image }}"
+        args:
+        - "-dir=/cozystack/assets"
+        - "-address=:8123"
+        ports:
+        - name: http
+          containerPort: 8123
+          hostPort: 8123
+      tolerations:
+      - operator: Exists
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cozystack-assets-reader
+  namespace: cozy-system
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods/proxy
+    resourceNames:
+      - cozystack-assets-0
+    verbs:
+      - get
+      - create
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cozystack-assets-reader
+  namespace: cozy-system
+subjects:
+  - kind: User
+    name: cozystack-assets-reader
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: cozystack-assets-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cozystack-assets
+  namespace: cozy-system
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8123
+  selector:
+    app: cozystack-assets
+  type: ClusterIP

--- a/packages/core/platform/templates/helmrepos.yaml
+++ b/packages/core/platform/templates/helmrepos.yaml
@@ -8,7 +8,7 @@ metadata:
     cozystack.io/repository: system
 spec:
   interval: 5m0s
-  url: http://cozystack.cozy-system.svc/repos/system
+  url: http://cozystack-assets.cozy-system.svc/repos/system
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
@@ -20,7 +20,7 @@ metadata:
     cozystack.io/repository: apps
 spec:
   interval: 5m0s
-  url: http://cozystack.cozy-system.svc/repos/apps
+  url: http://cozystack-assets.cozy-system.svc/repos/apps
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
@@ -31,4 +31,4 @@ metadata:
     cozystack.io/repository: extra
 spec:
   interval: 5m0s
-  url: http://cozystack.cozy-system.svc/repos/extra
+  url: http://cozystack-assets.cozy-system.svc/repos/extra

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -1,0 +1,2 @@
+assets:
+  image: ghcr.io/cozystack/cozystack/cozystack-assets:latest@sha256:19b166819d0205293c85d8351a3e038dc4c146b876a8e2ae21dce1d54f0b9e33

--- a/packages/extra/monitoring/templates/dashboards.yaml
+++ b/packages/extra/monitoring/templates/dashboards.yaml
@@ -11,6 +11,6 @@ spec:
   instanceSelector:
     matchLabels:
       dashboards: grafana
-  url: http://cozystack.cozy-system.svc/dashboards/{{ . }}.json
+  url: http://cozystack-assets.cozy-system.svc/dashboards/{{ . }}.json
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## What this PR does

Separates the assets server from the main cozystack installer into a dedicated StatefulSet deployment. This improves separation of concerns and allows the assets server to run independently from the installer.

Changes:
- Created new `cozystack-assets` StatefulSet in the platform package
- Added dedicated Dockerfile for assets server image (`packages/core/platform/images/cozystack-assets/Dockerfile`)
- Removed assets server container and Service from installer deployment
- Updated HelmRepository URLs to point to new `cozystack-assets` service
- Updated dashboard URLs in monitoring package to use new service
- Added image build target to platform Makefile
- Configured assets server with hostNetwork and proper RBAC permissions

### Release note

```release-note
[platform] Separate assets server into dedicated StatefulSet deployment
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored assets server deployment architecture: separated the assets server into a dedicated, independently deployable service for improved scalability and maintainability.
  * Updated Helm repository and dashboard service endpoints to use the new assets service location.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->