### PR TITLE
[fluxcd] Enable source-watcher

### DIFF
--- a/packages/system/fluxcd/values.yaml
+++ b/packages/system/fluxcd/values.yaml
@@ -9,6 +9,7 @@ flux-instance:
       registry: ghcr.io/fluxcd
     components:
       - source-controller
+      - source-watcher
       - kustomize-controller
       - helm-controller
       - notification-controller
@@ -38,12 +39,16 @@ flux-instance:
             - op: add
               path: /spec/template/spec/containers/0/args/-
               value: --storage-adv-addr=source-controller.cozy-fluxcd.svc
-            - op: add
-              path: /spec/template/spec/containers/0/args/-
-              value: --events-addr=http://notification-controller.cozy-fluxcd.svc/
         - target:
             kind: Deployment
-            name: (kustomize-controller|helm-controller|image-reflector-controller|image-automation-controller)
+            name: source-watcher
+          patch: |
+            - op: add
+              path: /spec/template/spec/containers/0/args/-
+              value: --storage-adv-addr=source-watcher.cozy-fluxcd.svc
+        - target:
+            kind: Deployment
+            name: (kustomize-controller|helm-controller|image-reflector-controller|image-automation-controller|source-controller|source-watcher)
           patch: |
             - op: add
               path: /spec/template/spec/containers/0/args/-


### PR DESCRIPTION
This change is extracted from
- https://github.com/cozystack/cozystack/pull/1641

and reworked to work standalone

Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[fluxcd] Enable source-watcher
```