### PR TITLE
[backups] Fix malformed glob and split in template

### DIFF
--- a/packages/system/backup-controller/templates/crds.yaml
+++ b/packages/system/backup-controller/templates/crds.yaml
@@ -1,4 +1,4 @@
-{{- range $path, $_ := .Files.Glob "definitions/*" }}
+{{- range $path, $_ := .Files.Glob "definitions/*.yaml" }}
 ---
 {{ $.Files.Get $path }}
 {{- end }}

--- a/packages/system/backup-controller/templates/deployment.yaml
+++ b/packages/system/backup-controller/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         {{- end }}
         ports:
         - name: metrics
-          containerPort: {{ split ":" .Values.backupController.metrics.bindAddress | mustLast }}
+          containerPort: {{ splitList ":" .Values.backupController.metrics.bindAddress | mustLast }}
         - name: health
           containerPort: 8081
         readinessProbe:


### PR DESCRIPTION
## What this PR does

A malformed glob ("*" instead of "*.yaml") captured the .gitattributes file and sent it to the templating engine. Using `split` instead of `splitList` on a string returned a map instead of a list, so templating broke on `mustLast`. This patch corrects the errors.

### Release note

```release-note
[backups] Fix template-breaking errors in the backup-controller Helm
chart.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined configuration file filtering to load only valid resource definitions, improving deployment reliability.
  * Enhanced metrics port extraction to ensure accurate port configuration during deployment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->