### PR TITLE
[cilium] Enable automatic pod rollout on configmap updates

### DIFF
--- a/packages/system/cilium/values.yaml
+++ b/packages/system/cilium/values.yaml
@@ -18,3 +18,6 @@ cilium:
     digest: "sha256:81262986a41487bfa3d0465091d3a386def5bd1ab476350bd4af2fdee5846fe6"
   envoy:
     enabled: false
+  rollOutCiliumPods: true
+  operator:
+    rollOutPods: true


### PR DESCRIPTION
Enable automatic restart of cilium and cilium-operator pods when cilium-config ConfigMap is updated.

This change adds:
- `rollOutCiliumPods: true` - enables automatic rollout of cilium-agent pods
- `operator.rollOutPods: true` - enables automatic rollout of cilium-operator pods

When the ConfigMap is updated, pods will automatically restart due to the `cilium.io/cilium-configmap-checksum` annotation that contains the SHA256 hash of the configmap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cilium configuration settings to enable pod rollout behavior for Cilium and operator pods by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->