### PR TITLE
[system/cilium] Enable topology-aware routing for services

### DIFF
--- a/packages/system/cilium/values.yaml
+++ b/packages/system/cilium/values.yaml
@@ -10,6 +10,7 @@ cilium:
     enabled: true
   loadBalancer:
     algorithm: maglev
+    serviceTopology: true
   ipam:
     mode: "kubernetes"
   image:


### PR DESCRIPTION
## What this PR does
Enables topology-aware routing for services, see
https://docs.cilium.io/en/latest/network/kubernetes/kubeproxy-free/#traffic-distribution-and-topology-aware-hints

### Release note
```release-note
cilium: enable topology-aware routing for services 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled service topology for the load balancer configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->