### PR TITLE
[vm] Always expose VMs with a service

### DIFF
--- a/packages/apps/virtual-machine/templates/service.yaml
+++ b/packages/apps/virtual-machine/templates/service.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.external }}
 ---
 apiVersion: v1
 kind: Service
@@ -7,17 +6,24 @@ metadata:
   labels:
     apps.cozystack.io/user-service: "true"
     {{- include "virtual-machine.labels" . | nindent 4 }}
+{{- if .Values.external }}
   annotations:
     networking.cozystack.io/wholeIP: "true"
+{{- end }}
 spec:
   type: {{ ternary "LoadBalancer" "ClusterIP" .Values.external }}
+{{- if .Values.external }}
   externalTrafficPolicy: Local
     {{- if ((include "cozy-lib.network.disableLoadBalancerNodePorts" $) | fromYaml) }}
   allocateLoadBalancerNodePorts: false
     {{- end }}
+{{- else }}
+  clusterIP: None
+{{- end }}
   selector:
     {{- include "virtual-machine.selectorLabels" . | nindent 4 }}
   ports:
+{{- if .Values.external }}
     {{- if and (eq .Values.externalMethod "WholeIP") (not .Values.externalPorts) }}
     - port: 65535
     {{- else }}
@@ -27,4 +33,6 @@ spec:
       targetPort: {{ . }}
     {{- end }}
     {{- end }}
+{{- else }}
+    - port: 65535
 {{- end }}

--- a/packages/apps/vm-instance/templates/service.yaml
+++ b/packages/apps/vm-instance/templates/service.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.external }}
 ---
 apiVersion: v1
 kind: Service
@@ -7,17 +6,24 @@ metadata:
   labels:
     apps.cozystack.io/user-service: "true"
     {{- include "virtual-machine.labels" . | nindent 4 }}
+{{- if .Values.external }}
   annotations:
     networking.cozystack.io/wholeIP: "true"
+{{- end }}
 spec:
   type: {{ ternary "LoadBalancer" "ClusterIP" .Values.external }}
+{{- if .Values.external }}
   externalTrafficPolicy: Local
     {{- if ((include "cozy-lib.network.disableLoadBalancerNodePorts" $) | fromYaml) }}
   allocateLoadBalancerNodePorts: false
     {{- end }}
+{{- else }}
+  clusterIP: None
+{{- end }}
   selector:
     {{- include "virtual-machine.selectorLabels" . | nindent 4 }}
   ports:
+{{- if .Values.external }}
     {{- if and (eq .Values.externalMethod "WholeIP") (not .Values.externalPorts) }}
     - port: 65535
     {{- else }}
@@ -27,4 +33,6 @@ spec:
       targetPort: {{ . }}
     {{- end }}
     {{- end }}
+{{- else }}
+    - port: 65535
 {{- end }}


### PR DESCRIPTION
## What this PR does

When VMs are created without a public IP, no service is created for them and they have no in-cluster DNS name. This PR fixes this and resolves #1731.

### Release note

```release-note
[vm] Always expose VMs with at least a ClusterIP service.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Service templates now conditionally enable external-specific annotations and settings when external mode is enabled.
  * External LoadBalancer deployments support richer port configuration (including whole-IP fallback), while internal services retain a single default port (65535).
  * External traffic policy and node port allocation are applied only in external mode to preserve internal behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->