### PR TITLE
[cozystack-operator] Add deployment files

### DIFF
--- a/packages/core/installer/Makefile
+++ b/packages/core/installer/Makefile
@@ -27,3 +27,31 @@ image-cozystack:
 	IMAGE="$(REGISTRY)/installer:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/installer.json -o json -r)" \
 		yq -i '.cozystack.image = strenv(IMAGE)' values.yaml
 	rm -f images/installer.json
+
+update-version:
+	TAG="$(call settag,$(TAG))" \
+			  yq -i '.cozystackOperator.cozystackVersion = strenv(TAG)' values.yaml
+
+image-operator:
+	docker buildx build -f images/cozystack-operator/Dockerfile ../../.. \
+		 --tag $(REGISTRY)/cozystack-operator:$(call settag,$(TAG)) \
+		 --cache-from type=registry,ref=$(REGISTRY)/cozystack-operator:latest \
+		 --cache-to type=inline \
+		 --metadata-file images/cozystack-operator.json \
+		 $(BUILDX_ARGS)
+	IMAGE="$(REGISTRY)/cozystack-operator:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/cozystack-operator.json -o json -r)" \
+		 yq -i '.cozystackOperator.image = strenv(IMAGE)' values.yaml
+	rm -f images/cozystack-operator.json
+
+
+image-packages: update-version
+	mkdir -p ../../../_out/assets images
+	flux push artifact \
+		 oci://$(REGISTRY)/platform-packages:$(call settag,$(TAG)) \
+		 --path=../../../packages \
+		 --source=https://github.com/cozystack/cozystack \
+		 --revision="$$(git describe --tags):$$(git rev-parse HEAD)" \
+		 2>&1 | tee images/cozystack-packages.log
+	export REPO="oci://$(REGISTRY)/platform-packages"; \
+	export DIGEST=$$(awk -F@ '/artifact successfully pushed/ {print $$2}' images/cozystack-packages.log; rm -f images/cozystack-packages.log); \
+		 test -n "$$DIGEST" && yq -i '.cozystackOperator.platformSource = (strenv(REPO) + "@" + strenv(DIGEST))' values.yaml

--- a/packages/core/installer/example/platform.yaml
+++ b/packages/core/installer/example/platform.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: cozystack.io/v1alpha1
+kind: Package
+metadata:
+  name: cozystack.cozystack-platform
+spec:
+  variant: isp-full
+  components:
+    platform:
+      values:
+        publishing:
+          host: "dev5.infra.aenix.org"
+          apiServerEndpoint: "https://api.dev5.infra.aenix.org"
+          externalIPs:
+          - 10.4.0.94
+          - 10.4.0.179
+          - 10.4.0.26
+        authentication:
+          oidc:
+            enabled: true

--- a/packages/core/installer/images/cozystack-operator/Dockerfile
+++ b/packages/core/installer/images/cozystack-operator/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.25-alpine as builder
+
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN apk add --no-cache make git
+
+COPY . /src/
+WORKDIR /src
+
+RUN go mod download
+
+# Build cozystack-operator
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+  -ldflags="-w -s" \
+  -o /cozystack-operator \
+  ./cmd/cozystack-operator
+
+FROM alpine:3.22
+
+COPY --from=builder /cozystack-operator /usr/bin/cozystack-operator
+
+ENTRYPOINT ["/usr/bin/cozystack-operator"]

--- a/packages/core/installer/images/cozystack-operator/Dockerfile.dockerignore
+++ b/packages/core/installer/images/cozystack-operator/Dockerfile.dockerignore
@@ -1,0 +1,12 @@
+# Exclude everything except src directory
+*
+!src/**
+!api/**
+!cmd/**
+!hack/**
+!internal/**
+!packages/**
+!pkg/**
+!scripts/**
+!go.mod
+!go.sum

--- a/packages/core/installer/templates/cozystack-operator.yaml
+++ b/packages/core/installer/templates/cozystack-operator.yaml
@@ -1,0 +1,122 @@
+{{- if .Values.cozystackOperator.enabled }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cozy-system
+  labels:
+    cozystack.io/system: "true"
+    pod-security.kubernetes.io/enforce: privileged
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cozystack
+  namespace: cozy-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cozystack
+subjects:
+- kind: ServiceAccount
+  name: cozystack
+  namespace: cozy-system
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cozystack-operator
+  namespace: cozy-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cozystack-operator
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: cozystack-operator
+    spec:
+      serviceAccountName: cozystack
+      containers:
+      - name: cozystack-operator
+        image: "{{ .Values.cozystackOperator.image }}"
+        args:
+        - --leader-elect=true
+        - --install-flux=true
+        - --metrics-bind-address=0
+        - --health-probe-bind-address=
+        - --cozystack-version={{ .Values.cozystackOperator.cozystackVersion }}
+        {{- if .Values.cozystackOperator.disableTelemetry }}
+        - --disable-telemetry
+        {{- end }}
+        - --platform-source-name=cozystack-platform
+        - --platform-source-url={{ .Values.cozystackOperator.platformSourceUrl }}
+        {{- if .Values.cozystackOperator.platformSourceRef }}
+        - --platform-source-ref={{ .Values.cozystackOperator.platformSourceRef }}
+        {{- end }}
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: localhost
+        - name: KUBERNETES_SERVICE_PORT
+          value: "7445"
+      hostNetwork: true
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node.cilium.io/agent-not-ready"
+        operator: "Exists"
+        effect: "NoSchedule"
+---
+apiVersion: cozystack.io/v1alpha1
+kind: PackageSource
+metadata:
+  name: cozystack.cozystack-platform
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: cozystack-packages
+    namespace: cozy-system
+    path: /
+  variants:
+  - name: default
+    components:
+    - install:
+        namespace: cozy-system
+        releaseName: cozystack-platform
+      name: cozystack-platform
+      path: core/platform
+      valuesFiles:
+      - values.yaml
+  - name: isp-full
+    components:
+    - install:
+        namespace: cozy-system
+        releaseName: cozystack-platform
+      name: cozystack-platform
+      path: core/platform
+      valuesFiles:
+      - values.yaml
+      - values-isp-full.yaml
+  - name: isp-hosted
+    components:
+    - install:
+        namespace: cozy-system
+        releaseName: cozystack-platform
+      name: cozystack-platform
+      path: core/platform
+      valuesFiles:
+      - values.yaml
+      - values-isp-hosted.yaml
+{{- end }}

--- a/packages/core/installer/templates/cozystack.yaml
+++ b/packages/core/installer/templates/cozystack.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.cozystackOperator.enabled }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -77,3 +78,4 @@ spec:
       - key: "node.cilium.io/agent-not-ready"
         operator: "Exists"
         effect: "NoSchedule"
+{{- end }}

--- a/packages/core/installer/templates/crds.yaml
+++ b/packages/core/installer/templates/crds.yaml
@@ -1,6 +1,6 @@
-{{/*
+{{- if .Values.cozystackOperator.enabled }}
 {{- range $path, $_ := .Files.Glob "definitions/*.yaml" }}
 ---
 {{ $.Files.Get $path }}
 {{- end }}
-*/}}
+{{- end }}

--- a/packages/core/installer/values.yaml
+++ b/packages/core/installer/values.yaml
@@ -1,2 +1,8 @@
 cozystack:
   image: ghcr.io/cozystack/cozystack/installer:v0.38.2@sha256:9ff92b655de6f9bea3cba4cd42dcffabd9aace6966dcfb1cc02dda2420ea4a15
+cozystackOperator:
+  enabled: false
+  image: ghcr.io/cozystack/cozystack/cozystack-operator:latest@sha256:f7f6e0fd9e896b7bfa642d0bfa4378bc14e646bc5c2e86e2e09a82770ef33181
+  platformSourceUrl: 'oci://ghcr.io/cozystack/cozystack/platform-packages'
+  platformSourceRef: 'digest=sha256:0576491291b33936cdf770a5c5b5692add97339c1505fc67a92df9d69dfbfdf6'
+  cozystackVersion: latest


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[cozystack-operator] Add deployment files
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployable CozyStack operator with configurable enablement, image, and platform-source settings
  * Operator-managed package source and variant-based platform installation options

* **Chores**
  * Release/packaging targets added to automate image and package publishing and update manifests
  * Configuration schema extended to include operator-related fields and versioning controls

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->