### PR TITLE
[tenant] Allow egress to parent ingress pods

### DIFF
--- a/packages/apps/tenant/templates/networkpolicy.yaml
+++ b/packages/apps/tenant/templates/networkpolicy.yaml
@@ -67,6 +67,19 @@ spec:
     {{- end }}
     {{- end }}
   {{- end }}
+  {{- if ne (include "tenant.name" .) "tenant-root" }}
+  - toEndpoints:
+    {{- if hasPrefix "tenant-" .Release.Namespace }}
+    {{- $parts := splitList "-" .Release.Namespace }}
+    {{- range $i, $v := $parts }}
+    {{- if ne $i 0 }}
+    - matchLabels:
+        cozystack.io/service: ingress
+        "k8s:io.kubernetes.pod.namespace": {{ join "-" (slice $parts 0 (add $i 1)) }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy


### PR DESCRIPTION
## What this PR does

Fixes egress policy for nested Kubernetes clusters using `exposeMethod: Proxied`.

The clusterwide egress policy blocks traffic from tenant pods to ingress pods in parent namespaces. This breaks:
- cert-manager HTTP-01 self-check
- Any scenario where pods need to access services exposed through parent ingress

Adds egress rule allowing traffic to ingress pods (`cozystack.io/service: ingress`) in parent namespaces, following the same pattern as existing vminsert and etcd rules.

### Release note

```release-note
[tenant] Fixed tenant egress policy to allow traffic to parent ingress pods, enabling cert-manager HTTP-01 challenges and external domain access for nested clusters with exposeMethod: Proxied
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced network policies for multi-tenant environments with improved traffic routing based on namespace hierarchies, enabling more granular egress control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->