### PR TITLE
[kubevirt-operator] Fix typo in VMNotRunningFor10Minutes alert

### DIFF
--- a/packages/system/kubevirt-operator/alerts/PrometheusRule.yaml
+++ b/packages/system/kubevirt-operator/alerts/PrometheusRule.yaml
@@ -10,7 +10,7 @@ spec:
       expr: |
         max_over_time(
           kubevirt_vm_info{
-            status!="running",
+            status!="Running",
             exported_namespace=~".+",
             name=~".+"
           }[10m]


### PR DESCRIPTION
## What this PR does

Fix case sensitivity in status check for VMNotRunningFor10Minutes alert rule.

The metric `kubevirt_vm_info` uses `status="Running"` (capital R), but the alert rule was checking for `status!="running"` (lowercase), causing false alerts for running VMs.

Fixes https://github.com/cozystack/cozystack/issues/1552

### Release note

```release-note
[kubevirt-operator] Fix VMNotRunningFor10Minutes alert false positives
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed alert rule condition for virtual machine status detection to ensure proper matching of running VMs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->