### PR TITLE
[ci] Fix runner affinity for e2e tests

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -325,7 +325,7 @@ jobs:
     name: Collect debug information
     runs-on: ${{ needs.capture_runner.outputs.runner_name }}
     needs: [capture_runner, test_apps]
-    if: ${{ always() }}
+    if: ${{ always() && needs.capture_runner.result == 'success' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -358,8 +358,8 @@ jobs:
   cleanup:
     name: Tear down environment
     runs-on: ${{ needs.capture_runner.outputs.runner_name }}
-    needs: [capture_runner, collect_debug_information]
-    if: ${{ always() && needs.test_apps.result == 'success' }}
+    needs: [capture_runner, collect_debug_information, test_apps]
+    if: ${{ always() && needs.capture_runner.result == 'success' && needs.test_apps.result == 'success' }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What this PR does

Fixes e2e test failures caused by jobs running on different self-hosted runners.

**Problem:** Jobs like `install_cozystack` and `test_apps` were distributed across multiple runners. The sandbox container created on runner-1 didn't exist on runner-4, causing "No such container" errors.

**Solution:** Add a `capture_runner` job that captures `runner.name` and passes it to all downstream jobs via outputs.

Changes:
- Add new `capture_runner` job that outputs the runner name
- Update `prepare_env`, `install_cozystack`, `test_apps`, `collect_debug_information`, and `cleanup` jobs to use the captured runner name

### Release note

```release-note
[ci] Fix e2e test failures by ensuring all jobs run on the same self-hosted runner
```