### PR TITLE
[multus] Increase memory limit

### DIFF
--- a/packages/system/multus/Makefile
+++ b/packages/system/multus/Makefile
@@ -9,6 +9,5 @@ update:
 	mkdir templates
 	$(eval RELEASE := $(shell curl -s https://api.github.com/repos/k8snetworkplumbingwg/multus-cni/releases/latest?per_page=1 | jq -r '.name'))
 	wget -q https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/refs/tags/$(RELEASE)/deployments/multus-daemonset-thick.yml -O templates/multus-daemonset-thick.yml
-	sed -i 's/namespace: kube-system/namespace: $(NAMESPACE)/;/multus-cni/s/snapshot-thick/$(RELEASE)-thick/' templates/multus-daemonset-thick.yml && \
-	sed -i '/name:/s/kube-multus-ds/cozy-multus/;/memory:/s/"50Mi"/"100Mi"/' templates/multus-daemonset-thick.yml
-
+	sed -i '/multus-cni/s/snapshot-thick/$(RELEASE)-thick/' templates/multus-daemonset-thick.yml && \
+	patch --no-backup-if-mismatch -p4 < patches/customize-deployment.patch

--- a/packages/system/multus/patches/customize-deployment.patch
+++ b/packages/system/multus/patches/customize-deployment.patch
@@ -1,0 +1,49 @@
+--- a/packages/system/multus/templates/multus-daemonset-thick.yml
++++ b/packages/system/multus/templates/multus-daemonset-thick.yml
+@@ -93,19 +93,19 @@ roleRef:
+ subjects:
+   - kind: ServiceAccount
+     name: multus
+-    namespace: kube-system
++    namespace: cozy-multus
+ ---
+ apiVersion: v1
+ kind: ServiceAccount
+ metadata:
+   name: multus
+-  namespace: kube-system
++  namespace: cozy-multus
+ ---
+ kind: ConfigMap
+ apiVersion: v1
+ metadata:
+   name: multus-daemon-config
+-  namespace: kube-system
++  namespace: cozy-multus
+   labels:
+     tier: node
+     app: multus
+@@ -125,8 +125,8 @@ data:
+ apiVersion: apps/v1
+ kind: DaemonSet
+ metadata:
+-  name: kube-multus-ds
+-  namespace: kube-system
++  name: cozy-multus
++  namespace: cozy-multus
+   labels:
+     tier: node
+     app: multus
+@@ -159,10 +159,10 @@ spec:
+           resources:
+             requests:
+               cpu: "100m"
+-              memory: "50Mi"
++              memory: "100Mi"
+             limits:
+               cpu: "100m"
+-              memory: "50Mi"
++              memory: "900Mi"
+           securityContext:
+             privileged: true
+           terminationMessagePolicy: FallbackToLogsOnError

--- a/packages/system/multus/templates/multus-daemonset-thick.yml
+++ b/packages/system/multus/templates/multus-daemonset-thick.yml
@@ -162,7 +162,7 @@ spec:
               memory: "100Mi"
             limits:
               cpu: "100m"
-              memory: "300Mi"
+              memory: "900Mi"
           securityContext:
             privileged: true
           terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
## What this PR does
Increases multus memory limit.
Based on multiple community reports stating that multus tend to consume a lot of memory during startup after a node reboot.

### Release note
```release-note
Multus memory limit increased.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Multus networking component deployment configuration and namespace organization
  * Adjusted memory resource allocation for the Multus daemon (increased memory requests from 50Mi to 100Mi and limits from 50Mi to 900Mi)
  * Streamlined deployment customization process

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->