### PR TITLE
[tenant] Run cleanup job from system namespace

### DIFF
--- a/packages/apps/tenant/templates/cleanup-job.yaml
+++ b/packages/apps/tenant/templates/cleanup-job.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "tenant.name" . }}-cleanup
-  namespace: {{ include "tenant.name" . }}
+  namespace: cozy-system
   annotations:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -39,13 +39,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "tenant.name" . }}-cleanup
-  namespace: {{ include "tenant.name" . }}
+  namespace: cozy-system
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "tenant.name" . }}-cleanup
-  namespace: {{ include "tenant.name" . }}
+  namespace: cozy-system
   annotations:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded


### PR DESCRIPTION
## What this PR does

The Helm hook that creates a job deleting all applications in a tenant before deleting the tenant itself now runs this job from the cozy-system namespace. This prevents conflicts with resource quotas (not enough resources to run cleanup job) without temporary increases of the quota or similar vulnerability-introducing hacks.

### Release note

```release-note
[tenant] Run cleanup job in system namespace to avoid conflicts on
resource quotas.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Updates**
  * Updated cleanup job namespace targeting to use a fixed system configuration
  * Adjusted cleanup job execution priority level

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->