### PR TITLE
[bucket] Add script for locking bucket

### DIFF
--- a/packages/apps/bucket/.helmignore
+++ b/packages/apps/bucket/.helmignore
@@ -1,0 +1,4 @@
+.helmignore
+/logos
+/Makefile
+/hack

--- a/packages/apps/bucket/hack/bucket-lock.sh
+++ b/packages/apps/bucket/hack/bucket-lock.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+
+set -e
+
+usage() {
+    echo "Usage: $0 <lock|unlock> <namespace> <bucket-name>"
+    echo ""
+    echo "Commands:"
+    echo "  lock    - Block deletion and modification of objects in the bucket"
+    echo "  unlock  - Restore full access to the bucket"
+    echo ""
+    echo "Example:"
+    echo "  $0 lock tenant-root somebucket"
+    echo "  $0 unlock tenant-root somebucket"
+    exit 1
+}
+
+if [ $# -ne 3 ]; then
+    usage
+fi
+
+ACTION="$1"
+NAMESPACE="$2"
+BUCKET_NAME="$3"
+
+if [ "$ACTION" != "lock" ] && [ "$ACTION" != "unlock" ]; then
+    echo "Error: First argument must be 'lock' or 'unlock'"
+    usage
+fi
+
+# Check if bucket exists
+if ! kubectl get buckets.apps.cozystack.io -n "$NAMESPACE" "$BUCKET_NAME" > /dev/null 2>&1; then
+    echo "Error: Bucket '$BUCKET_NAME' not found in namespace '$NAMESPACE'"
+    exit 1
+fi
+
+# Get secret and extract bucket config and bucket name using go-template + jq
+SECRET_NAME="bucket-$BUCKET_NAME"
+BUCKET_INFO=$(kubectl get secret -n "$NAMESPACE" "$SECRET_NAME" -o go-template='{{ .data.BucketInfo | base64decode }}')
+BUCKET_CONFIG=$(echo "$BUCKET_INFO" | jq -r '.metadata.name')
+S3_BUCKET_NAME=$(echo "$BUCKET_INFO" | jq -r '.spec.bucketName')
+
+# Convert bc- prefix to ba- for bucket account username
+BUCKET_ACCOUNT=$(echo "$BUCKET_CONFIG" | sed 's/^bc-/ba-/')
+
+if [ -z "$BUCKET_ACCOUNT" ] || [ -z "$S3_BUCKET_NAME" ]; then
+    echo "Error: Could not extract bucket account or bucket name from secret '$SECRET_NAME'"
+    exit 1
+fi
+
+# Get seaweedfs namespace from namespace annotation
+SEAWEEDFS_NS=$(kubectl get namespace "$NAMESPACE" -o jsonpath='{.metadata.annotations.namespace\.cozystack\.io/seaweedfs}')
+
+if [ -z "$SEAWEEDFS_NS" ]; then
+    echo "Error: Could not find seaweedfs namespace annotation on namespace '$NAMESPACE'"
+    exit 1
+fi
+
+# Build the s3.configure command
+ACTIONS="Read:$S3_BUCKET_NAME,Write:$S3_BUCKET_NAME,List:$S3_BUCKET_NAME,Tagging:$S3_BUCKET_NAME"
+
+if [ "$ACTION" = "lock" ]; then
+    S3_CMD="s3.configure -actions $ACTIONS -user $BUCKET_ACCOUNT --delete --apply"
+    echo "Locking bucket '$BUCKET_NAME' in namespace '$NAMESPACE'..."
+else
+    S3_CMD="s3.configure -actions $ACTIONS -user $BUCKET_ACCOUNT --apply"
+    echo "Unlocking bucket '$BUCKET_NAME' in namespace '$NAMESPACE'..."
+fi
+
+echo "Executing command in seaweedfs-master-0 (namespace: $SEAWEEDFS_NS):"
+echo "  $S3_CMD"
+echo ""
+
+# Execute the command
+echo "$S3_CMD" | kubectl exec -i -n "$SEAWEEDFS_NS" seaweedfs-master-0 -- weed shell
+
+echo ""
+echo "Done. Bucket '$BUCKET_NAME' has been ${ACTION}ed."


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[bucket] Add script for locking bucket
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a bucket lock/unlock CLI utility for Kubernetes-managed SeaweedFS deployments. Lock mode restricts bucket deletion and modification operations for protection, while unlock mode restores full administrative access when needed.

* **Chores**
  * Added Helm packaging configuration to optimize deployment packages by excluding unnecessary files and directories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->