### PR TITLE
[keycloak] Make kubernetes client public

### DIFF
--- a/packages/extra/info/templates/kubeconfig.yaml
+++ b/packages/extra/info/templates/kubeconfig.yaml
@@ -1,14 +1,18 @@
 {{- $host := .Values._namespace.host | default (index .Values._cluster "root-host") }}
-{{- $k8sClientSecret := lookup "v1" "Secret" "cozy-keycloak" "k8s-client" }}
-
-{{- if $k8sClientSecret }}
-{{- $apiServerEndpoint := index .Values._cluster "api-server-endpoint" }}
-{{- $managementKubeconfigEndpoint := default "" (index .Values._cluster "management-kubeconfig-endpoint") }}
-{{- if and $managementKubeconfigEndpoint (ne $managementKubeconfigEndpoint "") }}
-{{- $apiServerEndpoint = $managementKubeconfigEndpoint }}
-{{- end }}
-{{- $k8sClient := index $k8sClientSecret.data "client-secret-key" | b64dec }}
-{{- $k8sCa := index .Values._cluster "kube-root-ca" }}
+{{- $oidcEnabled := index .Values._cluster "oidc-enabled" }}
+{{- if $oidcEnabled }}
+{{-   $apiServerEndpoint := index .Values._cluster "api-server-endpoint" }}
+{{-   $managementKubeconfigEndpoint := default "" (index .Values._cluster "management-kubeconfig-endpoint") }}
+{{-   if and $managementKubeconfigEndpoint (ne $managementKubeconfigEndpoint "") }}
+{{-     $apiServerEndpoint = $managementKubeconfigEndpoint }}
+{{-   end }}
+{{-   $k8sCa := index .Values._cluster "kube-root-ca" }}
+{{-   if .Capabilities.APIVersions.Has "helm.toolkit.fluxcd.io/v2" }}
+{{-     $tenantRoot := lookup "helm.toolkit.fluxcd.io/v2" "HelmRelease" "tenant-root" "tenant-root" }}
+{{-     if and $tenantRoot $tenantRoot.spec $tenantRoot.spec.values $tenantRoot.spec.values.host }}
+{{-       $host = $tenantRoot.spec.values.host }}
+{{-     end }}
+{{-   end }}
 ---
 apiVersion: v1
 kind: Secret
@@ -39,7 +43,6 @@ stringData:
           - get-token
           - --oidc-issuer-url=https://keycloak.{{ $host }}/realms/cozy
           - --oidc-client-id=kubernetes
-          - --oidc-client-secret={{ $k8sClient }}
           - --skip-open-browser
           command: kubectl
 {{- end }}

--- a/packages/system/dashboard/templates/keycloakclient.yaml
+++ b/packages/system/dashboard/templates/keycloakclient.yaml
@@ -1,7 +1,6 @@
 {{- $host := index .Values._cluster "root-host" }}
 {{- $extraRedirectUris := splitList "," ((index .Values._cluster "extra-keycloak-redirect-uri-for-dashboard") | default "") }}
 
-{{- $existingK8sSecret := lookup "v1" "Secret" .Release.Namespace "k8s-client" }}
 {{- $existingDashboardSecret := lookup "v1" "Secret" .Release.Namespace "dashboard-client" }}
 
 {{ $dashboardClient := "" }}

--- a/packages/system/keycloak-configure/templates/configure-kk.yaml
+++ b/packages/system/keycloak-configure/templates/configure-kk.yaml
@@ -2,33 +2,14 @@
 {{- $extraRedirectUris := splitList "," ((index .Values._cluster "extra-keycloak-redirect-uri-for-dashboard") | default "") }}
 {{- $k8sCa := index .Values._cluster "kube-root-ca" }}
 
-{{- $existingK8sSecret := lookup "v1" "Secret" .Release.Namespace "k8s-client" }}
 {{- $existingKubeappsSecret := lookup "v1" "Secret" .Release.Namespace "kubeapps-client" }}
 {{- $existingAuthConfig := lookup "v1" "Secret" "cozy-dashboard" "kubeapps-auth-config" }}
 {{- $brandingConfig := .Values._cluster.branding | default dict }}
-
-{{ $k8sClient := "" }}
-{{- if $existingK8sSecret }}
-  {{- $k8sClient = index $existingK8sSecret.data "client-secret-key" | b64dec }}
-{{- else }}
-  {{- $k8sClient = randAlphaNum 32 }}
-{{- end }}
 
 {{ $branding := "" }}
 {{- if $brandingConfig }}
   {{- $branding = $brandingConfig.branding }}
 {{- end }}
-
----
-
-apiVersion: v1
-kind: Secret
-metadata:
-  name: k8s-client
-  namespace: {{ .Release.Namespace }}
-type: Opaque
-data:
-  client-secret-key: {{ $k8sClient | b64enc }}
 
 ---
 
@@ -90,23 +71,19 @@ kind: KeycloakClient
 metadata:
   name: keycloakclient
 spec:
-  serviceAccount:
-    enabled: true
+  advancedProtocolMappers: true
+  authorizationServicesEnabled: true
+  clientId: kubernetes
+  defaultClientScopes:
+    - groups
+  name: kubernetes
+  public: true
   realmRef:
     name: keycloakrealm-cozy
     kind: ClusterKeycloakRealm
-  secret: $k8s-client:client-secret-key
-  advancedProtocolMappers: true
-  authorizationServicesEnabled: true
-  name: kubernetes
-  clientId: kubernetes
-  directAccess: true
-  public: false
   webUrl: https://localhost:8000/oauth2/callback
   webOrigins:
     - /*
-  defaultClientScopes:
-    - groups
   redirectUris:
     - http://localhost:18000
     - http://localhost:8000


### PR DESCRIPTION
## What this PR does

By its nature, the kubernetes client provisioned in keycloak is public: anyone can read the client secret. Therefore the secret is not necessary and the client should be explicitly provisioned as a public client, not as a confidential client.

### Release note

```release-note
[keycloak] Change the kubernetes client to be public, without a client
secret.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add OIDC enablement flag and optional host derivation from tenant release; allow explicit management kubeconfig endpoint override.

* **Refactor**
  * Convert Keycloak client to public mode and remove reliance on a Kubernetes client secret, simplifying authentication configuration.
  * Remove secret-based credential plumbing from deployment templates, streamlining kubeconfig generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->