### PR TITLE
[kubevirt-operator] Revert incorrect case change in VM alerts

### DIFF
--- a/packages/system/kubevirt-operator/alerts/PrometheusRule.yaml
+++ b/packages/system/kubevirt-operator/alerts/PrometheusRule.yaml
@@ -10,7 +10,7 @@ spec:
       expr: |
         max_over_time(
           kubevirt_vm_info{
-            status!="Running",
+            status!="running",
             exported_namespace=~".+",
             name=~".+"
           }[10m]
@@ -27,7 +27,7 @@ spec:
       expr: |
         max_over_time(
           kubevirt_vmi_info{
-            phase!="Running",
+            phase!="running",
             exported_namespace=~".+",
             name=~".+"
           }[10m]


### PR DESCRIPTION
## What this PR does

Reverts PR #1770 which incorrectly changed status/phase checks from lowercase to uppercase.

The actual KubeVirt metrics use **lowercase**:
- `kubevirt_vm_info` uses `status="running"` (not `"Running"`)
- `kubevirt_vmi_info` uses `phase="running"` (not `"Running"`)

### Verification

Queried virt-controller metrics directly in cluster:

```
kubevirt_vm_info{...,status="running",status_group="running",...} 1
kubevirt_vmi_info{...,phase="running",...} 1
```

Note: `kubectl get vm` shows `STATUS: Running` with capital R, but this is display formatting — the actual metric labels use lowercase.

### Release note

```release-note
[kubevirt-operator] Fix VM alert rules to use correct lowercase status values
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed alert condition logic for virtual machine monitoring to accurately detect non-running states, improving alert reliability and ensuring proper detection across virtual machines and virtual machine instances.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->