### PR TITLE
[kube-ovn] Update to v1.14.25

### DIFF
--- a/packages/system/kubeovn/Chart.yaml
+++ b/packages/system/kubeovn/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: cozy-kubeovn
-version: 0.39.0
+version: 0.38.0

--- a/packages/system/kubeovn/Makefile
+++ b/packages/system/kubeovn/Makefile
@@ -1,4 +1,4 @@
-KUBEOVN_TAG=v0.39.0
+KUBEOVN_TAG=v0.40.0
 
 export NAME=kubeovn
 export NAMESPACE=cozy-$(NAME)

--- a/packages/system/kubeovn/charts/kube-ovn/Chart.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v1.14.11
+version: v1.14.25
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.14.11"
+appVersion: "1.14.25"
 
 kubeVersion: ">= 1.29.0-0"

--- a/packages/system/kubeovn/charts/kube-ovn/README.md
+++ b/packages/system/kubeovn/charts/kube-ovn/README.md
@@ -2,6 +2,18 @@
 
 Currently supported version: 1.9
 
+## Installing the Chart
+
+### From OCI Registry
+
+The Helm chart is available from GitHub Container Registry:
+
+```bash
+helm install kube-ovn oci://ghcr.io/kubeovn/charts/kube-ovn --version v1.15.0
+```
+
+### From Source
+
 Installation :
 
 ```bash

--- a/packages/system/kubeovn/charts/kube-ovn/templates/_helpers.tpl
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/_helpers.tpl
@@ -1,8 +1,10 @@
 {{/*
-Get IP-addresses of master nodes
+Get IP-addresses of master nodes. If no nodes are returned, we assume this is
+a dry-run/template call and return nothing.
 */}}
 {{- define "kubeovn.nodeIPs" -}}
 {{- $nodes := lookup "v1" "Node" "" "" -}}
+{{- if $nodes -}}
 {{- $ips := list -}}
 {{- range $node := $nodes.items -}}
   {{- $label := splitList "=" $.Values.MASTER_NODES_LABEL }}
@@ -24,6 +26,7 @@ Get IP-addresses of master nodes
   {{- fail (printf "No nodes found with label '%s'. Please check your MASTER_NODES_LABEL configuration or ensure master nodes are properly labeled." $.Values.MASTER_NODES_LABEL) -}}
 {{- end -}}
 {{ join "," $ips }}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/packages/system/kubeovn/charts/kube-ovn/templates/central-deploy.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/central-deploy.yaml
@@ -39,7 +39,11 @@ spec:
               topologyKey: kubernetes.io/hostname
       priorityClassName: system-cluster-critical
       serviceAccountName: ovn-ovs
+      automountServiceAccountToken: true
       hostNetwork: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         - name: hostpath-init
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}

--- a/packages/system/kubeovn/charts/kube-ovn/templates/controller-deploy.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/controller-deploy.yaml
@@ -46,7 +46,11 @@ spec:
               topologyKey: kubernetes.io/hostname
       priorityClassName: system-cluster-critical
       serviceAccountName: ovn
+      automountServiceAccountToken: true
       hostNetwork: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         - name: hostpath-init
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}

--- a/packages/system/kubeovn/charts/kube-ovn/templates/ic-controller-deploy.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/ic-controller-deploy.yaml
@@ -40,7 +40,11 @@ spec:
               topologyKey: kubernetes.io/hostname
       priorityClassName: system-cluster-critical
       serviceAccountName: ovn
+      automountServiceAccountToken: true
       hostNetwork: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         - name: hostpath-init
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}

--- a/packages/system/kubeovn/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -1200,6 +1200,52 @@ spec:
                           required:
                             - key
                             - operator
+                tolerations:
+                  description: optional tolerations applied to the workload pods
+                  items:
+                    description: |-
+                      The pod this Toleration is attached to tolerates any taint that matches
+                      the triple <key,value,effect> using the matching operator <operator>.
+                    properties:
+                      effect:
+                        description: |-
+                          Effect indicates the taint effect to match. Empty means match all taint effects.
+                          When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: |-
+                          Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                          If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                        type: string
+                      operator:
+                        description: |-
+                          Operator represents a key's relationship to the value.
+                          Valid operators are Exists and Equal. Defaults to Equal.
+                          Exists is equivalent to wildcard for value, so that a pod can
+                          tolerate all taints of a particular category.
+                        type: string
+                        enum:
+                          - Exists
+                          - Equal
+                      tolerationSeconds:
+                        description: |-
+                          TolerationSeconds represents the period of time the toleration (which must be
+                          of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                          it is not set, which means tolerate the taint forever (do not evict). Zero and
+                          negative values will be treated as 0 (evict immediately) by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: |-
+                          Value is the taint value the toleration matches to.
+                          If the operator is Exists, the value should be empty, otherwise just a regular string.
+                        type: string
+                    type: object
+                  type: array
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2871,6 +2917,8 @@ spec:
                   type: array
                   items:
                     type: string
+                autoCreateVlanSubinterfaces:
+                  type: boolean
               required:
                 - defaultInterface
             status:

--- a/packages/system/kubeovn/charts/kube-ovn/templates/monitor-deploy.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/monitor-deploy.yaml
@@ -37,7 +37,11 @@ spec:
               topologyKey: kubernetes.io/hostname
       priorityClassName: system-cluster-critical
       serviceAccountName: kube-ovn-app
+      automountServiceAccountToken: true
       hostNetwork: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         - name: hostpath-init
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}

--- a/packages/system/kubeovn/charts/kube-ovn/templates/ovn-dpdk-ds.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/ovn-dpdk-ds.yaml
@@ -27,8 +27,12 @@ spec:
       - operator: Exists
       priorityClassName: system-node-critical
       serviceAccountName: ovn-ovs
+      automountServiceAccountToken: true
       hostNetwork: true
       hostPID: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: openvswitch
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.DPDK_IMAGE_TAG }}

--- a/packages/system/kubeovn/charts/kube-ovn/templates/ovn-sa.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/ovn-sa.yaml
@@ -3,6 +3,7 @@ kind: ServiceAccount
 metadata:
   name: ovn
   namespace: {{ .Values.namespace }}
+automountServiceAccountToken: false
 {{-  if .Values.global.registry.imagePullSecrets }}
 imagePullSecrets:
 {{- range $index, $secret := .Values.global.registry.imagePullSecrets }}
@@ -18,6 +19,7 @@ kind: ServiceAccount
 metadata:
   name: ovn-ovs
   namespace: {{ .Values.namespace }}
+automountServiceAccountToken: false
 {{-  if .Values.global.registry.imagePullSecrets }}
 imagePullSecrets:
 {{- range $index, $secret := .Values.global.registry.imagePullSecrets }}
@@ -33,6 +35,7 @@ kind: ServiceAccount
 metadata:
   name: kube-ovn-cni
   namespace: {{ .Values.namespace }}
+automountServiceAccountToken: false
 {{-  if .Values.global.registry.imagePullSecrets }}
 imagePullSecrets:
 {{- range $index, $secret := .Values.global.registry.imagePullSecrets }}
@@ -48,6 +51,7 @@ kind: ServiceAccount
 metadata:
   name: kube-ovn-app
   namespace: {{ .Values.namespace }}
+automountServiceAccountToken: false
 {{-  if .Values.global.registry.imagePullSecrets }}
 imagePullSecrets:
 {{- range $index, $secret := .Values.global.registry.imagePullSecrets }}

--- a/packages/system/kubeovn/charts/kube-ovn/templates/ovncni-ds.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/ovncni-ds.yaml
@@ -26,8 +26,12 @@ spec:
           operator: Exists
       priorityClassName: system-node-critical
       serviceAccountName: kube-ovn-cni
+      automountServiceAccountToken: true
       hostNetwork: true
       hostPID: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
       - name: hostpath-init
         image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
@@ -35,7 +39,9 @@ spec:
         command:
           - sh
           - -xec
-          - iptables -V
+          - |
+            chmod +t /usr/local/sbin
+            iptables -V
         securityContext:
           allowPrivilegeEscalation: true
           capabilities:
@@ -60,16 +66,21 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - /kube-ovn/install-cni.sh
-          - --cni-conf-dir={{ .Values.cni_conf.CNI_CONF_DIR }}
+          - --cni-conf-dir={{ .Values.cni_conf.MOUNT_CNI_CONF_DIR }}
           - --cni-conf-file={{ .Values.cni_conf.CNI_CONF_FILE }}
           - --cni-conf-name={{- .Values.cni_conf.CNI_CONFIG_PRIORITY -}}-kube-ovn.conflist
+        env:
+          - name: POD_IPS
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIPs
         securityContext:
           runAsUser: 0
           privileged: true
         volumeMounts:
           - mountPath: /opt/cni/bin
             name: cni-bin
-          - mountPath: /etc/cni/net.d
+          - mountPath: {{ .Values.cni_conf.MOUNT_CNI_CONF_DIR }}
             name: cni-conf
           {{- if .Values.cni_conf.MOUNT_LOCAL_BIN_DIR }}
           - mountPath: /usr/local/bin

--- a/packages/system/kubeovn/charts/kube-ovn/templates/ovsovn-ds.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/ovsovn-ds.yaml
@@ -34,8 +34,12 @@ spec:
           operator: Exists
       priorityClassName: system-node-critical
       serviceAccountName: ovn-ovs
+      automountServiceAccountToken: true
       hostNetwork: true
       hostPID: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         - name: hostpath-init
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
@@ -44,6 +48,7 @@ spec:
             - sh
             - -xec
             - |
+              chmod +t /usr/local/sbin
               chown -R nobody: /var/run/ovn /var/log/ovn /etc/openvswitch /var/run/openvswitch /var/log/openvswitch
               iptables -V
               {{- if not .Values.DISABLE_MODULES_MANAGEMENT }}

--- a/packages/system/kubeovn/charts/kube-ovn/templates/pinger-ds.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/pinger-ds.yaml
@@ -28,7 +28,11 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       serviceAccountName: kube-ovn-app
-      hostPID: true
+      automountServiceAccountToken: true
+      hostPID: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         - name: hostpath-init
           image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}

--- a/packages/system/kubeovn/charts/kube-ovn/templates/post-delete-hook.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/post-delete-hook.yaml
@@ -9,6 +9,7 @@ metadata:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -102,8 +103,11 @@ spec:
       hostNetwork: true
       nodeSelector:
         kubernetes.io/os: "linux"
-      serviceAccount: kube-ovn-post-delete-hook
       serviceAccountName: kube-ovn-post-delete-hook
+      automountServiceAccountToken: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: remove-subnet-finalizer
           image: "{{ .Values.global.registry.address}}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}"

--- a/packages/system/kubeovn/charts/kube-ovn/templates/upgrade-ovs-ovn.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/upgrade-ovs-ovn.yaml
@@ -11,6 +11,7 @@ metadata:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -133,8 +134,11 @@ spec:
       hostNetwork: true
       nodeSelector:
         kubernetes.io/os: "linux"
-      serviceAccount: ovs-ovn-upgrade
       serviceAccountName: ovs-ovn-upgrade
+      automountServiceAccountToken: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: ovs-ovn-upgrade
           image: "{{ .Values.global.registry.address}}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}"

--- a/packages/system/kubeovn/charts/kube-ovn/values.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/values.yaml
@@ -9,7 +9,7 @@ global:
     kubeovn:
       repository: kube-ovn
       vpcRepository: vpc-nat-gateway
-      tag: v1.14.11
+      tag: v1.14.25
       support_arm: true
       thirdparty: true
 
@@ -111,6 +111,7 @@ debug:
 cni_conf:
   CNI_CONFIG_PRIORITY: "01"
   CNI_CONF_DIR: "/etc/cni/net.d"
+  MOUNT_CNI_CONF_DIR: "/etc/cni/net.d"
   CNI_BIN_DIR: "/opt/cni/bin"
   CNI_CONF_FILE: "/kube-ovn/01-kube-ovn.conflist"
   LOCAL_BIN_DIR: "/usr/local/bin"

--- a/packages/system/kubeovn/values.yaml
+++ b/packages/system/kubeovn/values.yaml
@@ -65,4 +65,4 @@ global:
   images:
     kubeovn:
       repository: kubeovn
-      tag: v1.14.11@sha256:0e3e9db960a9600d58c33c0787cabd0e9bf263930fd8c9fe65417e258c383d01
+      tag: v1.14.25@sha256:d0b29daaf36e81cac0f9fb15d0ea6b1b49f1abba81a14c73b88a2e60ffcc5978


### PR DESCRIPTION
## What this PR does

Update kube-ovn from v1.14.11 to v1.14.25.

Changes synced from upstream include:
- Updated chart templates
- New configuration options in values

### Release note

```release-note
[kube-ovn] Update to v1.14.25
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tolerations support for VpcNatGateway resources
  * Added automatic VLAN subinterface creation capability for provider networks
  * Enhanced installation documentation with OCI Registry and Talos Linux deployment examples

* **Security Improvements**
  * Applied runtime-default seccomp profiles across deployments
  * Configured service account token mounting behavior for improved pod security

* **Chores**
  * Updated Kube-OVN to v1.14.25
  * Updated Helm chart metadata and dependencies

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->