### PR TITLE
[linstor] Add linstor-scheduler package

### DIFF
--- a/packages/core/platform/bundles/distro-full.yaml
+++ b/packages/core/platform/bundles/distro-full.yaml
@@ -357,6 +357,12 @@ releases:
   privileged: true
   dependsOn: [piraeus-operator,cilium,cert-manager,snapshot-controller]
 
+- name: linstor-scheduler
+  releaseName: linstor-scheduler
+  chart: cozy-linstor-scheduler
+  namespace: cozy-linstor
+  dependsOn: [linstor,cert-manager]
+
 - name: nfs-driver
   releaseName: nfs-driver
   chart: cozy-nfs-driver

--- a/packages/core/platform/bundles/paas-full.yaml
+++ b/packages/core/platform/bundles/paas-full.yaml
@@ -430,6 +430,12 @@ releases:
   privileged: true
   dependsOn: [piraeus-operator,cilium,kubeovn,cert-manager,snapshot-controller]
 
+- name: linstor-scheduler
+  releaseName: linstor-scheduler
+  chart: cozy-linstor-scheduler
+  namespace: cozy-linstor
+  dependsOn: [linstor,cert-manager]
+
 - name: nfs-driver
   releaseName: nfs-driver
   chart: cozy-nfs-driver

--- a/packages/core/platform/sources/linstor-scheduler.yaml
+++ b/packages/core/platform/sources/linstor-scheduler.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: cozystack.io/v1alpha1
+kind: PackageSource
+metadata:
+  name: cozystack.linstor-scheduler
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: cozystack-packages
+    namespace: cozy-system
+    path: /
+  variants:
+  - name: default
+    dependsOn:
+    - cozystack.linstor
+    - cozystack.cert-manager
+    components:
+    - name: linstor-scheduler
+      path: system/linstor-scheduler
+      install:
+        namespace: cozy-linstor
+        releaseName: linstor-scheduler

--- a/packages/system/linstor-scheduler/.helmignore
+++ b/packages/system/linstor-scheduler/.helmignore
@@ -1,0 +1,1 @@
+examples

--- a/packages/system/linstor-scheduler/Chart.yaml
+++ b/packages/system/linstor-scheduler/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: cozy-linstor-scheduler
+version: 0.0.0 # Placeholder, the actual version will be automatically set during the build process

--- a/packages/system/linstor-scheduler/Makefile
+++ b/packages/system/linstor-scheduler/Makefile
@@ -1,0 +1,10 @@
+export NAME=linstor-scheduler
+export NAMESPACE=cozy-linstor
+
+include ../../../scripts/package.mk
+
+update:
+	rm -rf charts
+	helm repo add piraeus-charts https://piraeus.io/helm-charts/
+	helm repo update piraeus-charts
+	helm pull piraeus-charts/linstor-scheduler --untar --untardir charts

--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/Chart.yaml
+++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+appVersion: v0.3.2
+deprecated: true
+description: 'Deploys a new kubernetes scheduler, configured to take advantage of
+  storage system information. If a Pod is using a LINSTOR volume, the scheduler will
+  prefer nodes with local data instead of accessing the data via a DRBD diskless. '
+home: https://github.com/piraeusdatastore/helm-charts
+icon: https://raw.githubusercontent.com/piraeusdatastore/piraeus/master/artwork/sandbox-artwork/icon/color.svg
+keywords:
+- storage
+- scheduler
+maintainers:
+- name: The Piraeus Maintainers
+  url: https://github.com/piraeusdatastore/
+name: linstor-scheduler
+sources:
+- https://github.com/piraeusdatastore/linstor-scheduler-extender
+type: application
+version: 0.2.3

--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/LICENSE
+++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/README.md
+++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/README.md
@@ -1,0 +1,72 @@
+# linstor-scheduler
+
+Deploys a new Kubernetes scheduler, extended by
+the [linstor-scheduler-extender](https://github.com/piraeusdatastore/linstor-scheduler-extender).
+
+> [!IMPORTANT]
+> The LINSTOR Scheduler is no longer maintained. Prefer using `volumeBindingMode: WaitForFirstConsumer` on your
+> StorageClasses.
+
+The schedule is volume placement aware. That means that it prefers placing Pods on the same nodes as any Persistent
+Volume they might use. This works for any setup using LINSTOR, i.e. Piraeus Datastore or LINBIT SDS.
+
+## Installation
+
+The scheduler is meant to be installed in the same namespace as LINSTOR itself, otherwise additional steps may be
+required.
+
+If installed along side Piraeus Operator, the LINSTOR endpoint is determined automatically. Otherwise, you need
+to set `linstor.endpoint` and `linstor.clientSecret` values as appropriate.
+
+The following command will install the scheduler for a typical Piraeus Data-Store configuration with TLS enabled:
+
+```
+helm repo add piraeus-charts https://piraeus.io/helm-charts/
+helm install linstor-scheduler piraeus-charts/linstor-scheduler --set linstorEndpoint=https://piraeus-op-cs.piraeus.svc:3371 --set linstorClientSecret=piraeus-client-secret
+```
+
+## Usage
+
+To use the scheduler, you need to configure it on your Pods (or Pod templates):
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: some-pod
+spec:
+  schedulerName: linstor-scheduler
+  ...
+```
+
+## Configuration
+
+The following options are available:
+
+| Option                                        | Usage                                                                                                  | Default                                                                                            |
+|-----------------------------------------------|--------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
+| `replicaCount`                                | Number of replicas to deploy.                                                                          | `1`                                                                                                |
+| `linstor.endpoint`                            | URL of the LINSTOR Controller API.                                                                     | `""`                                                                                               |
+| `linstor.clientSecret`                        | TLS secret to use to authenticate with the LINSTOR API                                                 | `""`                                                                                               |
+| `extender.image.repository`                   | Repository to pull the linstor-scheduler-extender image from.                                          | `quay.io/piraeusdatastore/linstor-scheduler-extender`                                              |
+| `extender.image.pullPolicy`                   | Pull policy to use. Possible values: `IfNotPresent`, `Always`, `Never`                                 | `IfNotPresent`                                                                                     |
+| `extender.image.tag`                          | Override the tag to pull. If not given, defaults to charts `AppVersion`.                               | `""`                                                                                               |
+| `extender.resources`                          | Resources to request and limit on the container.                                                       | `{}`                                                                                               |
+| `extender.securityContext`                    | Configure container security context. Defaults to dropping all capabilties and running as user 1000.   | `{capabilities: {drop: [ALL]}, readOnlyRootFilesystem: true, runAsNonRoot: true, runAsUser: 1000}` |
+| `scheduler.image.repository`                  | Repository to pull the kubernetes scheduler image from.                                                | `registry.k8s.io/kube-scheduler`                                                                   |
+| `scheduler.image.pullPolicy`                  | Pull policy to use. Possible values: `IfNotPresent`, `Always`, `Never`                                 | `IfNotPresent`                                                                                     |
+| `scheduler.image.tag`                         | Override the tag to pull. If not given, defaults to kubernetes version.                                | `""`                                                                                               |
+| `scheduler.image.compatibleKubernetesRelease` | Compatible kubernetes version for this scheduler, used to generate configuration in the right version. | `""`                                                                                               |
+| `scheduler.resources`                         | Resources to request and limit on the container.                                                       | `{}`                                                                                               |
+| `scheduler.securityContext`                   | Configure container security context. Defaults to dropping all capabilties and running as user 1000.   | `{capabilities: {drop: [ALL]}, readOnlyRootFilesystem: true, runAsNonRoot: true, runAsUser: 1000}` |
+| `imagePullSecrets`                            | Image pull secrets to add to the deployment.                                                           | `[]`                                                                                               |
+| `podAnnotations`                              | Annotations to add to every pod in the deployment.                                                     | `{}`                                                                                               |
+| `podSecurityContext`                          | Security context to set on the webhook pod.                                                            | `{}`                                                                                               |
+| `nodeSelector`                                | Node selector to add to each webhook pod.                                                              | `{}`                                                                                               |
+| `tolerations`                                 | Tolerations to add to each webhook pod.                                                                | `[]`                                                                                               |
+| `affinity`                                    | Affinity to set on each webhook pod.                                                                   | `{}`                                                                                               |
+| `rbac.create`                                 | Create the necessary roles and bindings for the snapshot controller.                                   | `true`                                                                                             |
+| `serviceAccount.create`                       | Create the service account resource                                                                    | `true`                                                                                             |
+| `serviceAccount.name`                         | Sets the name of the service account. If left empty, will use the release name as default              | `""`                                                                                               |
+| `podDisruptionBudget.enabled`                 | Enable creation of a pod disruption budget to protect the availability of the scheduler                | `true`                                                                                             |
+| `autoscaling.enabled`                         | Enable creation of a horizontal pod autoscaler to ensure availability in case of high usage`           | `"false`                                                                                           |

--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/NOTES.txt
+++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/NOTES.txt
@@ -1,0 +1,12 @@
+Scheduler {{ include "linstor-scheduler.fullname" . }} deployed!
+
+Used LINSTOR URL: {{ include "linstor-scheduler.linstorEndpoint" .}}
+
+Please run `helm test {{ .Release.Name }}` to ensure it's properly working.
+
+Specify the scheduler on your pods to start smart scheduling based on your Persistent Volumes:
+
+---
+spec:
+  schedulerName: {{ include "linstor-scheduler.fullname" . }}
+---

--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/_helpers.tpl
+++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/_helpers.tpl
@@ -1,0 +1,141 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "linstor-scheduler.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "linstor-scheduler.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "linstor-scheduler.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "linstor-scheduler.labels" -}}
+helm.sh/chart: {{ include "linstor-scheduler.chart" . }}
+{{ include "linstor-scheduler.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "linstor-scheduler.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "linstor-scheduler.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "linstor-scheduler.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "linstor-scheduler.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get the kubernetes version we should assume for creating scheduler configs
+*/}}
+{{- define "linstor-scheduler.kubeVersion" }}
+{{- .Values.scheduler.image.compatibleKubernetesRelease | default .Capabilities.KubeVersion.Version }}
+{{- end }}
+
+{{/*
+Find the linstor client secret containing TLS certificates
+*/}}
+{{- define "linstor-scheduler.linstorClientSecretName" -}}
+{{- if .Values.linstor.clientSecret }}
+{{- .Values.linstor.clientSecret }}
+{{- else if .Capabilities.APIVersions.Has "piraeus.linbit.com/v1/LinstorController" }}
+{{- $crs := (lookup "piraeus.linbit.com/v1" "LinstorController" .Release.Namespace "").items }}
+{{- if $crs }}
+{{- if eq (len $crs) 1 }}
+{{- $item := index $crs 0 }}
+{{- $item.spec.linstorHttpsClientSecret }}
+{{- end }}
+{{- end }}
+{{- else if .Capabilities.APIVersions.Has "linstor.linbit.com/v1/LinstorController" }}
+{{- $crs := (lookup "linstor.linbit.com/v1" "LinstorController" .Release.Namespace "").items }}
+{{- if $crs }}
+{{- if eq (len $crs) 1 }}
+{{- $item := index $crs 0 }}
+{{- $item.spec.linstorHttpsClientSecret }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Find the linstor URL by operator resources
+*/}}
+{{- define "linstor-scheduler.linstorEndpointFromCRD" -}}
+{{- if .Capabilities.APIVersions.Has "piraeus.linbit.com/v1/LinstorController" }}
+{{- $crs := (lookup "piraeus.linbit.com/v1" "LinstorController" .Release.Namespace "").items }}
+{{- if $crs }}
+{{- if eq (len $crs) 1 }}
+{{- $item := index $crs 0 }}
+{{- if include "linstor-scheduler.linstorClientSecretName" . }}
+{{- printf "https://%s.%s.svc:3371" $item.metadata.name $item.metadata.namespace }}
+{{- else }}
+{{- printf "http://%s.%s.svc:3370" $item.metadata.name $item.metadata.namespace }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- else if .Capabilities.APIVersions.Has "linstor.linbit.com/v1/LinstorController" }}
+{{- $crs := (lookup "linstor.linbit.com/v1" "LinstorController" .Release.Namespace "").items }}
+{{- if $crs }}
+{{- if eq (len $crs) 1 }}
+{{- $item := index $crs 0 }}
+{{- if include "linstor-scheduler.linstorClientSecretName" . }}
+{{- printf "https://%s.%s.svc:3371" $item.metadata.name $item.metadata.namespace }}
+{{- else }}
+{{- printf "http://%s.%s.svc:3370" $item.metadata.name $item.metadata.namespace }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Find the linstor URL either by override or cluster resources
+*/}}
+{{- define "linstor-scheduler.linstorEndpoint" -}}
+{{- if .Values.linstor.endpoint }}
+{{- .Values.linstor.endpoint }}
+{{- else }}
+{{- $piraeus := include "linstor-scheduler.linstorEndpointFromCRD" . }}
+{{- if $piraeus }}
+{{- $piraeus }}
+{{- else }}
+{{- fail "Please specify linstor.endpoint, no default URL could be determined" }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/admission-deployment.yaml
+++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/admission-deployment.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.admission.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}-admission
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admission
+spec:
+  replicas: {{ .Values.admission.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "linstor-scheduler.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: admission
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "linstor-scheduler.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: admission
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "linstor-scheduler.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: linstor-scheduler-admission
+          image: {{ .Values.extender.image.repository }}:{{ .Values.extender.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.extender.image.pullPolicy }}
+          command: ["/linstor-scheduler-admission"]
+          args:
+            - -scheduler={{ include "linstor-scheduler.fullname" . }}
+            - -tls-cert-file=/etc/webhook/certs/tls.crt
+            - -tls-key-file=/etc/webhook/certs/tls.key
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          ports:
+            - containerPort: 8080
+              name: https
+              protocol: TCP
+          env:
+            - name: LS_CONTROLLERS
+              value: {{ include "linstor-scheduler.linstorEndpoint" . }}
+            {{- if include "linstor-scheduler.linstorClientSecretName" . }}
+            - name: LS_USER_CERTIFICATE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "linstor-scheduler.linstorClientSecretName" . }}
+                  key: tls.crt
+            - name: LS_USER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "linstor-scheduler.linstorClientSecretName" . }}
+                  key: tls.key
+            - name: LS_ROOT_CA
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "linstor-scheduler.linstorClientSecretName" . }}
+                  key: ca.crt
+            {{- end }}
+          volumeMounts:
+            - name: webhook-certs
+              mountPath: /etc/webhook/certs
+              readOnly: true
+          resources:
+            {{- toYaml .Values.admission.resources | nindent 12 }}
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: {{ include "linstor-scheduler.fullname" . }}-admission-tls
+            defaultMode: 0400
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/admission-service.yaml
+++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/admission-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.admission.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}-admission
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admission
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      targetPort: 8080
+      protocol: TCP
+      name: https
+  selector:
+    {{- include "linstor-scheduler.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: admission
+{{- end }}

--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/certmanager.yaml
+++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/certmanager.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.admission.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}-admission-selfsigned
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}-admission-root-ca
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "linstor-scheduler.fullname" . }}-admission-root-ca
+  duration: 43800h  # 5 years
+  commonName: {{ include "linstor-scheduler.fullname" . }}-admission-root-ca
+  issuerRef:
+    name: {{ include "linstor-scheduler.fullname" . }}-admission-selfsigned
+  isCA: true
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}-admission-ca-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: {{ include "linstor-scheduler.fullname" . }}-admission-root-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}-admission-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "linstor-scheduler.fullname" . }}-admission-tls
+  duration: 8760h  # 1 year
+  renewBefore: 24h
+  issuerRef:
+    name: {{ include "linstor-scheduler.fullname" . }}-admission-ca-issuer
+  commonName: {{ include "linstor-scheduler.fullname" . }}-admission
+  dnsNames:
+    - {{ include "linstor-scheduler.fullname" . }}-admission
+    - {{ include "linstor-scheduler.fullname" . }}-admission.{{ .Release.Namespace }}.svc
+{{- end }}

--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/config.yaml
+++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/config.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+data:
+{{- if semverCompare ">= 1.22-0" (include "linstor-scheduler.kubeVersion" .) }}
+  scheduler-config.yaml: |-
+{{- if semverCompare ">= 1.25-0" (include "linstor-scheduler.kubeVersion" .) }}
+      apiVersion: kubescheduler.config.k8s.io/v1
+{{- else if semverCompare ">= 1.23-0" (include "linstor-scheduler.kubeVersion" .) }}
+      apiVersion: kubescheduler.config.k8s.io/v1beta3
+{{- else }}
+      apiVersion: kubescheduler.config.k8s.io/v1beta2
+{{- end }}
+      kind: KubeSchedulerConfiguration
+      profiles:
+        - schedulerName: {{ include "linstor-scheduler.fullname" . }}
+      extenders:
+        - urlPrefix: http://localhost:8099
+          filterVerb: filter
+          prioritizeVerb: prioritize
+          weight: 5
+          enableHTTPS: false
+          httpTimeout: 10s
+          nodeCacheCapable: false
+{{- else }}
+  policy.cfg: |-
+    {
+      "kind": "Policy",
+      "apiVersion": "v1",
+      "extenders": [
+        {
+          "urlPrefix": "http://localhost:8099",
+          "apiVersion": "v1beta1",
+          "filterVerb": "filter",
+          "prioritizeVerb": "prioritize",
+          "weight": 5,
+          "enableHttps": false,
+          "nodeCacheCapable": false
+        }
+      ]
+    }
+{{- end }}

--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/deployment.yaml
+++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/deployment.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "linstor-scheduler.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "linstor-scheduler.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "linstor-scheduler.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: kube-scheduler
+          image: "{{ .Values.scheduler.image.repository }}:{{ .Values.scheduler.image.tag | default .Capabilities.KubeVersion.Version }}"
+          securityContext:
+            {{- toYaml .Values.scheduler.securityContext | nindent 12 }}
+          command:
+            - kube-scheduler
+            {{- if semverCompare ">= 1.22-0" (include "linstor-scheduler.kubeVersion" .) }}
+            - --config=/etc/kubernetes/scheduler-config.yaml
+            {{- else }}
+            - --scheduler-name={{ include "linstor-scheduler.fullname" . }}
+            - --policy-configmap={{ include "linstor-scheduler.fullname" . }}
+            - --policy-configmap-namespace=$(NAMESPACE)
+            {{- end }}
+            - --leader-elect=true
+            - --leader-elect-resource-lock=leases
+            - --leader-elect-resource-name={{ include "linstor-scheduler.fullname" . }}
+            - --leader-elect-resource-namespace=$(NAMESPACE)
+            {{- if .Values.scheduler.args }}
+            {{- toYaml .Values.scheduler.args | nindent 12 }}
+            {{- end }}
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          imagePullPolicy: {{ .Values.scheduler.image.pullPolicy }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 10259
+              scheme: HTTPS
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 10259
+              scheme: HTTPS
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 10259
+              scheme: HTTPS
+          {{- if semverCompare ">= 1.22-0" (include "linstor-scheduler.kubeVersion" .) }}
+          volumeMounts:
+            - mountPath: /etc/kubernetes
+              name: scheduler-config
+          {{- end }}
+          resources:
+            {{- toYaml .Values.scheduler.resources | nindent 12 }}
+        - name: linstor-scheduler-extender
+          image: {{ .Values.extender.image.repository }}:{{ .Values.extender.image.tag | default .Chart.AppVersion }}
+          resources:
+            {{- toYaml .Values.extender.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.extender.securityContext | nindent 12 }}
+          imagePullPolicy: {{ .Values.extender.image.pullPolicy }}
+          args:
+            - --verbose=true
+          env:
+            - name: LS_CONTROLLERS
+              value: {{ include "linstor-scheduler.linstorEndpoint" . }}
+            {{- if include "linstor-scheduler.linstorClientSecretName" . }}
+            - name: LS_USER_CERTIFICATE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "linstor-scheduler.linstorClientSecretName" . }}
+                  key: tls.crt
+            - name: LS_USER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "linstor-scheduler.linstorClientSecretName" . }}
+                  key: tls.key
+            - name: LS_ROOT_CA
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "linstor-scheduler.linstorClientSecretName" . }}
+                  key: ca.crt
+            {{- end }}
+      {{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.Version }}
+      volumes:
+        - configMap:
+            name: {{ include "linstor-scheduler.fullname" . }}
+          name: scheduler-config
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/hpa.yaml
+++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "linstor-scheduler.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/mutatingwebhookconfiguration.yaml
+++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/mutatingwebhookconfiguration.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.admission.enabled }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}-admission
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "linstor-scheduler.fullname" . }}-admission-cert
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+webhooks:
+  - name: linstor-scheduler-admission.linbit.com
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    failurePolicy: {{ .Values.admission.failurePolicy }}
+    clientConfig:
+      service:
+        name: {{ include "linstor-scheduler.fullname" . }}-admission
+        namespace: {{ .Release.Namespace }}
+        path: /mutate
+        port: 443
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+        scope: "*"
+    {{- with .Values.admission.namespaceSelector }}
+    namespaceSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end }}

--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/poddisruptionbudget.yaml
+++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "linstor-scheduler.selectorLabels" . | nindent 6 }}
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end -}}

--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/rbac.yaml
+++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/rbac.yaml
@@ -1,0 +1,108 @@
+{{- if .Values.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
+{{- if semverCompare "< 1.22-0" (include "linstor-scheduler.kubeVersion" .) }}
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}
+{{- if .Values.admission.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}-admission
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "persistentvolumeclaims", "persistentvolumes"]
+    verbs: ["get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}-admission
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "linstor-scheduler.fullname" . }}-admission
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "linstor-scheduler.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . | trunc 57 }}-as-ks
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kube-scheduler
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "linstor-scheduler.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . | trunc 57 }}-as-vs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:volume-scheduler
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "linstor-scheduler.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "linstor-scheduler.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "linstor-scheduler.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "linstor-scheduler.fullname" . | trunc 58 }}-auth
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "linstor-scheduler.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/serviceaccount.yaml
+++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "linstor-scheduler.serviceAccountName" . }}
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/tests/test-scheduler.yaml
+++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/tests/test-scheduler.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "linstor-scheduler.fullname" . | trunc 49 }}-test-schedule"
+  labels:
+    {{- include "linstor-scheduler.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  # Smoke test: just test the scheduler without volumes
+  schedulerName: {{ include "linstor-scheduler.fullname" . }}
+  containers:
+    - name: wget
+      image: busybox
+      command: []
+  restartPolicy: Never

--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/values.yaml
+++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/values.yaml
@@ -1,0 +1,106 @@
+replicaCount: 1
+
+linstor:
+  endpoint: ""
+  clientSecret: ""
+
+scheduler:
+  args: []
+  image:
+    repository: registry.k8s.io/kube-scheduler
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the kubernetes release
+    tag: ""
+    # Overrides which config is written. The default is determined by the current Kubernetes version
+    compatibleKubernetesRelease: ""
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+extender:
+  image:
+    repository: quay.io/piraeusdatastore/linstor-scheduler-extender
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the app version
+    tag: ""
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+rbac:
+  create: true
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+  # maxUnavailable: 1
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+admission:
+  enabled: false
+  replicaCount: 2
+  failurePolicy: Ignore
+  namespaceSelector: {}
+  #  matchExpressions:
+  #    - key: kubernetes.io/metadata.name
+  #      operator: NotIn
+  #      values:
+  #        - kube-system
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 10m
+    #   memory: 64Mi

--- a/packages/system/linstor-scheduler/values.yaml
+++ b/packages/system/linstor-scheduler/values.yaml
@@ -1,0 +1,7 @@
+linstor-scheduler:
+  fullnameOverride: linstor-scheduler
+  linstor:
+    endpoint: "https://linstor-controller.cozy-linstor.svc:3371"
+    clientSecret: "linstor-client-tls"
+  admission:
+    enabled: true


### PR DESCRIPTION
## What this PR does

Add linstor-scheduler-extender for optimal pod placement on nodes with LINSTOR storage.

### How it works

The linstor-scheduler consists of two components:

#### 1. Scheduler Extender
A custom Kubernetes scheduler that works alongside the default kube-scheduler. When a pod requests LINSTOR-backed storage, the scheduler extender communicates with the LINSTOR controller to find nodes that have local replicas of the requested volumes, prioritizing placement on nodes with existing data to minimize network traffic.

#### 2. Admission Webhook
A MutatingWebhookConfiguration that automatically sets `schedulerName: linstor-scheduler` on pods that use LINSTOR CSI driver volumes. This ensures that only pods with LINSTOR PVCs are routed through the custom scheduler, while all other pods continue using the default scheduler.

The webhook inspects pod creation requests and checks if any of the pod's PVCs use a StorageClass with the LINSTOR CSI provisioner (`linstor.csi.linbit.com`). If so, it mutates the pod spec to use the linstor-scheduler.

### Components

- `linstor-scheduler` package in `packages/system/linstor-scheduler/`
- PackageSource definition in `packages/core/platform/sources/linstor-scheduler.yaml`
- Integration into `paas-full` and `distro-full` bundles

### Upstream PRs

- https://github.com/piraeusdatastore/helm-charts/pull/67 — fix: KubeSchedulerConfiguration v1 support for Kubernetes 1.25+
- https://github.com/piraeusdatastore/helm-charts/pull/68 — feat: admission webhook support with cert-manager
- https://github.com/piraeusdatastore/helm-charts/pull/69 — fix chart template issues

### Release note

```release-note
[linstor] Add linstor-scheduler for optimal pod placement on nodes with local LINSTOR replicas. Includes admission webhook that automatically routes pods using LINSTOR CSI volumes to the custom scheduler.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LINSTOR scheduler component to the platform, packaged as a Helm chart and installable package.
  * Includes admission webhook, scheduler extender, autoscaling support, pod disruption budget, RBAC and service account integration, and Helm test hooks.
* **Documentation**
  * Added chart README and default configuration values for easy deployment and customization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->