### PR TITLE
[linstor] Enable auto-diskful for diskless nodes

### DIFF
--- a/packages/system/linstor/templates/cluster.yaml
+++ b/packages/system/linstor/templates/cluster.yaml
@@ -14,6 +14,12 @@ spec:
       name: linstor-api-ca
       kind: Issuer
   properties:
+  {{- if .Values.linstor.autoDiskful.enabled }}
+  - name: DrbdOptions/auto-diskful
+    value: {{ .Values.linstor.autoDiskful.minutes | quote }}
+  - name: DrbdOptions/auto-diskful-allow-cleanup
+    value: {{ .Values.linstor.autoDiskful.allowCleanup | quote }}
+  {{- end }}
   - name: DrbdOptions/Net/connect-int
     value: "15"
   - name: DrbdOptions/Net/ping-int

--- a/packages/system/linstor/values.yaml
+++ b/packages/system/linstor/values.yaml
@@ -2,3 +2,9 @@ piraeusServer:
   image:
     repository: ghcr.io/cozystack/cozystack/piraeus-server
     tag: latest@sha256:417532baa2801288147cd9ac9ae260751c1a7754f0b829725d09b72a770c111a
+
+linstor:
+  autoDiskful:
+    enabled: true
+    minutes: 30
+    allowCleanup: true


### PR DESCRIPTION
## What this PR does

Enable DRBD auto-diskful options to automatically convert diskless nodes to diskful when they remain in Primary state for an extended period.

### How it works

When LINSTOR is integrated with Kubernetes, the platform may schedule workloads on nodes that don't have local storage replicas. In such cases, DRBD operates in "diskless" mode, accessing data over the network from nodes that have actual disk replicas.

The `auto-diskful` feature addresses this by:

1. **Monitoring Primary state duration**: When a diskless node holds a DRBD resource in Primary state (actively using the volume) for more than the configured time (30 minutes), LINSTOR automatically creates a local disk replica on that node.

2. **Automatic cleanup**: With `auto-diskful-allow-cleanup` enabled, when the resource is no longer in Primary state on that node, LINSTOR can automatically remove the disk replica that was created, freeing up storage space.

### Configuration

- `DrbdOptions/auto-diskful: 30` — Convert diskless to diskful after 30 minutes in Primary state
- `DrbdOptions/auto-diskful-allow-cleanup: true` — Allow automatic removal of auto-created replicas when no longer needed

### Benefits

- Improves I/O performance for long-running workloads by creating local replicas
- Reduces network traffic for frequently accessed data
- Automatic cleanup prevents storage waste from temporary replicas

### Release note

```release-note
[linstor] Enable auto-diskful to automatically create local replicas on diskless nodes that hold volumes in Primary state for more than 30 minutes, improving I/O performance for long-running workloads.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an "auto diskful" option to automatically manage diskful resources with configurable interval and optional cleanup.
* **Chores**
  * Added default configuration values to enable and time the auto-diskful behavior and to control automatic cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->