### PR TITLE
[linstor] fix: prevent DRBD device race condition in updateDiscGran

### DIFF
--- a/packages/system/linstor/images/piraeus-server/patches/skip-adjust-when-device-inaccessible.diff
+++ b/packages/system/linstor/images/piraeus-server/patches/skip-adjust-when-device-inaccessible.diff
@@ -1,3 +1,28 @@
+diff --git a/satellite/src/main/java/com/linbit/linstor/core/devmgr/DeviceHandlerImpl.java b/satellite/src/main/java/com/linbit/linstor/core/devmgr/DeviceHandlerImpl.java
+index abc123def..def456abc 100644
+--- a/satellite/src/main/java/com/linbit/linstor/core/devmgr/DeviceHandlerImpl.java
++++ b/satellite/src/main/java/com/linbit/linstor/core/devmgr/DeviceHandlerImpl.java
+@@ -83,6 +83,8 @@ import java.util.TreeMap;
+ import java.util.TreeSet;
+ import java.util.concurrent.atomic.AtomicBoolean;
+ import java.util.function.Function;
++import java.nio.file.Files;
++import java.nio.file.Paths;
+
+ @Singleton
+ public class DeviceHandlerImpl implements DeviceHandler
+@@ -1646,7 +1648,10 @@ public class DeviceHandlerImpl implements DeviceHandler
+     private void updateDiscGran(VlmProviderObject<Resource> vlmData) throws DatabaseException, StorageException
+     {
+         String devicePath = vlmData.getDevicePath();
+-        if (devicePath != null && vlmData.exists())
++        // Check if device path physically exists before calling lsblk
++        // This is important for DRBD devices which might be temporarily unavailable during adjust
++        // (drbdadm adjust brings devices down/up, and kernel might not have created the device node yet)
++        if (devicePath != null && vlmData.exists() && Files.exists(Paths.get(devicePath)))
+         {
+             if (vlmData.getDiscGran() == VlmProviderObject.UNINITIALIZED_SIZE)
+             {
 diff --git a/satellite/src/main/java/com/linbit/linstor/layer/drbd/DrbdLayer.java b/satellite/src/main/java/com/linbit/linstor/layer/drbd/DrbdLayer.java
 index 01967a3..871d830 100644
 --- a/satellite/src/main/java/com/linbit/linstor/layer/drbd/DrbdLayer.java


### PR DESCRIPTION
## Problem

After satellite restart with patched linstor-server, some DRBD resources ended up in **Unknown** state. Investigation revealed a race condition between `drbdadm adjust` completion and `updateDiscGran()` lsblk check:

1. `drbdadm adjust` completes successfully (21:53:49.791) - brings devices up
2. `updateDiscGran()` immediately tries to check discard granularity (21:53:49.799)
3. `/dev/drbd*` device node doesn't exist yet - kernel hasn't created it
4. `lsblk` fails with exit code 32: "not a block device"  
5. `StorageException` interrupts DeviceManager cycle (21:53:50.811)
6. DRBD device remains in incomplete state → **Unknown**

### Timeline from logs

```
21:53:49.791 - [DeviceManager] Resource 'pvc-aafbd92a' [DRBD] adjusted ✓
21:53:49.799 - [lsblk_parser] ERROR: /dev/drbd1169 not a block device
21:53:49.804-50.807 - [lsblk_parser] 10+ retry errors (every ~100ms)
21:53:50.811 - [DeviceManager] ERROR: Error executing lsblk
21:53:50.878 - [DeviceManager] End cycle 9 (WITH ERROR!)
```

## Solution

Update `skip-adjust-when-device-inaccessible.diff` patch to add physical device path existence check before calling `lsblk`:

- Check `Files.exists(devicePath)` in `updateDiscGran()` before lsblk
- If device doesn't exist yet → skip check, set `discGran = UNINITIALIZED_SIZE`
- Next DeviceManager cycle (few seconds later) → device node available → lsblk succeeds

This complements the existing patch which checks **child layer** devices (LUKS/Storage) for deletion scenarios, while this fix addresses the **DRBD device itself** during adjust operations.

## Testing

Manual `drbdadm up` on affected devices confirmed they were in down state and brought them back to UpToDate, proving the issue was incomplete device initialization.

## Related

- Upstream linstor-server PR: https://github.com/LINBIT/linstor-server/pull/471#issuecomment-3723392917

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness for storage operations by adding device accessibility validation. Operations now gracefully skip when device paths are unavailable or invalid, preventing unnecessary failures and improving system resilience during device access issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->