### PR TITLE
[multus] Remove memory limit

### DIFF
--- a/packages/system/multus/patches/customize-deployment.patch
+++ b/packages/system/multus/patches/customize-deployment.patch
@@ -34,7 +34,7 @@
    labels:
      tier: node
      app: multus
-@@ -159,10 +159,10 @@ spec:
+@@ -159,10 +159,9 @@ spec:
            resources:
              requests:
                cpu: "100m"
@@ -43,7 +43,6 @@
              limits:
                cpu: "100m"
 -              memory: "50Mi"
-+              memory: "900Mi"
            securityContext:
              privileged: true
            terminationMessagePolicy: FallbackToLogsOnError

--- a/packages/system/multus/templates/multus-daemonset-thick.yml
+++ b/packages/system/multus/templates/multus-daemonset-thick.yml
@@ -162,7 +162,6 @@ spec:
               memory: "100Mi"
             limits:
               cpu: "100m"
-              memory: "900Mi"
           securityContext:
             privileged: true
           terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
## What this PR does
Removes multus memory limit due to short but unpredictable and large memory consumption in some cases, such as starting up after a node reboot (reported up to 3Gi).
The root cause will be fixed in future releases.

### Release note
```release-note
Multus memory limit removed.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Multus system namespace configuration and DaemonSet naming for improved environment organization.
  * Adjusted container resource allocation: increased memory requests and refined memory limits for optimized performance.
  * Updated deployment template specifications to reflect infrastructure changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->