### PR TITLE
fix(registry): implement field selector filtering for label-based resources

### DIFF
--- a/pkg/registry/fields/filter.go
+++ b/pkg/registry/fields/filter.go
@@ -1,0 +1,70 @@
+// Copyright 2024 The Cozystack Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fields
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/fields"
+)
+
+// Filter holds field selector filters extracted from a field selector string.
+type Filter struct {
+	// Name is the value from metadata.name field selector, empty if not specified
+	Name string
+	// Namespace is the value from metadata.namespace field selector, empty if not specified
+	Namespace string
+}
+
+// ParseFieldSelector parses a field selector and extracts metadata.name and metadata.namespace values.
+// Other field selectors are silently ignored as controller-runtime cache doesn't support them.
+// See: https://github.com/kubernetes-sigs/controller-runtime/issues/612
+func ParseFieldSelector(fieldSelector fields.Selector) (*Filter, error) {
+	if fieldSelector == nil {
+		return &Filter{}, nil
+	}
+
+	fs, err := fields.ParseSelector(fieldSelector.String())
+	if err != nil {
+		return nil, fmt.Errorf("invalid field selector: %v", err)
+	}
+
+	filter := &Filter{}
+
+	// Check if selector is for metadata.name
+	if name, exists := fs.RequiresExactMatch("metadata.name"); exists {
+		filter.Name = name
+	}
+
+	// Check if selector is for metadata.namespace
+	if namespace, exists := fs.RequiresExactMatch("metadata.namespace"); exists {
+		filter.Namespace = namespace
+	}
+
+	// Note: Other field selectors are silently ignored as controller-runtime cache
+	// doesn't support them. See: https://github.com/kubernetes-sigs/controller-runtime/issues/612
+
+	return filter, nil
+}
+
+// MatchesName returns true if the filter has no name constraint or if the name matches.
+func (f *Filter) MatchesName(name string) bool {
+	return f.Name == "" || f.Name == name
+}
+
+// MatchesNamespace returns true if the filter has no namespace constraint or if the namespace matches.
+func (f *Filter) MatchesNamespace(namespace string) bool {
+	return f.Namespace == "" || f.Namespace == namespace
+}


### PR DESCRIPTION
## What this PR does

Fixes field selector filtering for registry resources (Applications, TenantModules, TenantSecrets) when using kubectl with field selectors like `--field-selector=metadata.namespace=tenant-kvaps` or `metadata.name=test`.

Controller-runtime cache doesn't support field selectors natively, which caused incorrect filtering behavior. This PR implements manual filtering for `metadata.name` and `metadata.namespace` field selectors in List() and Watch() methods.

Changes:
- Created `pkg/registry/fields` package with `ParseFieldSelector` utility for common field selector parsing
- Refactored field selector logic in application, tenantmodule, and tenantsecret registries to use the common implementation
- Implemented manual post-processing filtering after label-based queries
- Removed `Raw` field usage and field selectors from `client.ListOptions`

### Release note

```release-note
[registry] Fix field selector filtering for kubectl queries with metadata.name and metadata.namespace selectors
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced field selector filtering for Applications, TenantModules, and TenantSecrets to properly honor name and namespace field criteria.
  * List and Watch operations now correctly apply field-based filtering with proper namespace validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->