### PR TITLE
fix(platform): fix migrations for v0.40 release

### DIFF
--- a/scripts/migrations/20
+++ b/scripts/migrations/20
@@ -33,11 +33,11 @@ else
   kubectl rollout status deploy/cozystack-api -n cozy-system --timeout=5m || exit 1
 fi
 
-helm upgrade --install -n cozy-system cozystack-controller ./packages/system/cozystack-controller/ --take-ownership
+cozyhr -n cozy-system -C ./packages/system/cozystack-controller apply cozystack-controller --take-ownership
 echo "Waiting for cozystack-controller"
 kubectl rollout status deploy/cozystack-controller -n cozy-system --timeout=5m || exit 1
 
-helm upgrade --install -n cozy-system lineage-controller-webhook ./packages/system/lineage-controller-webhook/ --take-ownership
+cozyhr -n cozy-system -C ./packages/system/lineage-controller-webhook/ apply lineage-controller-webhook --take-ownership
 echo "Waiting for lineage-webhook"
 kubectl rollout status ds/lineage-controller-webhook -n cozy-system --timeout=5m || exit 1
 

--- a/scripts/migrations/21
+++ b/scripts/migrations/21
@@ -3,14 +3,25 @@
 
 set -euo pipefail
 
+# Disable pruning on Flux CRDs
 for crd in $(kubectl get crd -o name | grep 'fluxcd.io$'); do
   kubectl annotate $crd fluxcd.controlplane.io/prune=disabled
 done
 
-kubectl delete hr -n cozy-fluxcd fluxcd --ignore-not-found
-kubectl delete hr -n cozy-fluxcd fluxcd-operator --ignore-not-found
+# Remove flux instance
+if kubectl get fluxinstance flux -n cozy-fluxcd >/dev/null 2>&1; then
+  kubectl annotate fluxinstance flux -n cozy-fluxcd fluxcd.controlplane.io/reconcile=disabled
+  kubectl delete fluxinstance flux -n cozy-fluxcd
+fi
+kubectl delete deploy -n cozy-fluxcd -l app.kubernetes.io/part-of=flux --ignore-not-found
+kubectl delete hr -n cozy-fluxcd fluxcd --ignore-not-found --wait=false
 
-for crd in $(kubectl get crd -o name | grep 'fluxcd.io$'); do
+# Remove fluxcd-operator
+kubectl delete hr -n cozy-fluxcd fluxcd-operator --ignore-not-found --wait=false
+kubectl delete deploy -n cozy-fluxcd flux-operator --ignore-not-found
+
+# Remove labels from CRDs
+for crd in $(kubectl get crd -o name | grep 'fluxcd\.io$'); do
   kubectl label $crd fluxcd.controlplane.io/name- fluxcd.controlplane.io/namespace-
 done
 

--- a/scripts/migrations/22
+++ b/scripts/migrations/22
@@ -3,6 +3,17 @@
 
 set -euo pipefail
 
+# Migrate Victoria Metrics Operator CRDs to prometheus-operator-crds Helm release
+for crd in $(kubectl get crd -o name | grep 'coreos\.com$'); do
+  kubectl annotate $crd meta.helm.sh/release-namespace=cozy-victoria-metrics-operator meta.helm.sh/release-name=prometheus-operator-crds --overwrite
+  kubectl label $crd app.kubernetes.io/managed-by=Helm helm.toolkit.fluxcd.io/namespace=cozy-victoria-metrics-operator helm.toolkit.fluxcd.io/name=prometheus-operator-crds --overwrite
+done
+kubectl delete secret -n cozy-victoria-metrics-operator -l name=victoria-metrics-operator,owner=helm --ignore-not-found
+
+# Remove CozyStack Resource Definitions HR
+kubectl delete hr -n cozy-system cozystack-resource-definitions --ignore-not-found --wait=false
+kubectl delete cozystackresourcedefinitions.cozystack.io --all --ignore-not-found --wait=false
+
 echo "Migrating HelmReleases: adding application labels for tenant-* namespaces"
 
 # Function to determine application type from HelmRelease name
@@ -153,6 +164,16 @@ kubectl get helmreleases --all-namespaces -l cozystack.io/ui=true -o json | \
     # Apply labels using kubectl label --overwrite
     kubectl label helmrelease -n "$namespace" "$name" --overwrite $labels
     echo "Added application labels to $namespace/$name: $labels"
+  done
+
+echo "Migrating PostgreSQL HelmReleases: adding default version v17"
+
+# Patch all PostgreSQL HelmReleases to add spec.values.version: v17
+kubectl get helmreleases --all-namespaces -l apps.cozystack.io/application.kind=PostgreSQL -o json | \
+  jq -r '.items[] | select(.spec.values.version == null) | "\(.metadata.namespace)|\(.metadata.name)"' | \
+  while IFS='|' read -r namespace name; do
+    echo "Patching PostgreSQL HelmRelease $namespace/$name to add version v17"
+    kubectl patch helmrelease -n "$namespace" "$name" --type=merge -p '{"spec":{"values":{"version":"v17"}}}'
   done
 
 echo "Migration completed"


### PR DESCRIPTION
## What this PR does

Fixes migration scripts for v0.40 release to ensure smooth upgrade process.

Changes:
- **Migration 20**: Replace `helm upgrade --install` with `cozyhr apply` for cozystack-controller and lineage-controller-webhook
- **Migration 21**: Improve Flux instance removal process:
  - Disable reconciliation on FluxInstance before deletion
  - Delete Flux deployments before HelmReleases
  - Add `--wait=false` flags to prevent hanging
  - Fix CRD grep pattern to properly match `fluxcd.io` domains
- **Migration 22**: Add new migration tasks:
  - Migrate Victoria Metrics Operator CRDs to prometheus-operator-crds Helm release
  - Remove CozyStack Resource Definitions HelmRelease
  - Add default version v17 to PostgreSQL HelmReleases without explicit version

### Release note

```release-note
[platform] Fix migration scripts for v0.40 release: improve Flux removal, add VictoriaMetrics CRD migration, set default PostgreSQL version
```