### PR TITLE
[linstor] Remove node-level RWX validation

### DIFF
--- a/packages/system/linstor/images/linstor-csi/patches/001-rwx-validation.diff
+++ b/packages/system/linstor/images/linstor-csi/patches/001-rwx-validation.diff
@@ -1,25 +1,8 @@
 diff --git a/pkg/driver/driver.go b/pkg/driver/driver.go
-index bea69a8..848bd5b 100644
+index bea69a8..69e71a6 100644
 --- a/pkg/driver/driver.go
 +++ b/pkg/driver/driver.go
-@@ -401,6 +401,16 @@ func (d Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolum
- 		}
- 	}
- 
-+	// Validate RWX block volumes on node side using local filesystem check
-+	// This provides protection for the edge case where two pods from different VMs land on the same node
-+	if req.GetVolumeCapability().GetBlock() != nil &&
-+		req.GetVolumeCapability().GetAccessMode().GetMode() == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER {
-+		if err := d.validateRWXBlockOnNode(ctx, req.GetVolumeId(), req.GetTargetPath()); err != nil {
-+			return nil, status.Errorf(codes.FailedPrecondition,
-+				"NodePublishVolume failed for %s: %v", req.GetVolumeId(), err)
-+		}
-+	}
-+
- 	if block := req.GetVolumeCapability().GetBlock(); block != nil {
- 		volCtx.MountOptions = []string{"bind"}
- 	}
-@@ -707,6 +717,255 @@ func (d Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
+@@ -707,6 +707,219 @@ func (d Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
  	return &csi.DeleteVolumeResponse{}, nil
  }
  
@@ -236,53 +219,16 @@ index bea69a8..848bd5b 100644
 +	return vmName, nil
 +}
 +
-+// validateRWXBlockOnNode performs node-side validation of RWX block volumes using local filesystem check.
-+// This provides protection against the edge case where two pods from different VMs land on the same node.
-+// Since ControllerPublishVolume is called only once per (volumeID, nodeID) pair, not per pod,
-+// we need to check if the volume is already mounted for another pod on this node.
-+func (d Driver) validateRWXBlockOnNode(ctx context.Context, volumeID, targetPath string) error {
-+	// Extract base directory for this volume (contains subdirectories per pod UID)
-+	baseDir := filepath.Dir(targetPath)
-+
-+	// List existing mounts for this volume
-+	entries, err := os.ReadDir(baseDir)
-+	if err != nil {
-+		if os.IsNotExist(err) {
-+			// Directory doesn't exist yet - first mount
-+			return nil
-+		}
-+
-+		d.log.WithError(err).Warn("cannot check existing mounts for RWX validation")
-+
-+		return nil
-+	}
-+
-+	// If there are already other mounts, block the second one
-+	if len(entries) > 0 {
-+		d.log.WithFields(logrus.Fields{
-+			"volumeID":       volumeID,
-+			"existingMounts": len(entries),
-+			"baseDir":        baseDir,
-+		}).Warn("blocking RWX block volume mount: already mounted for another pod on this node")
-+
-+		return fmt.Errorf("RWX block volume is already mounted for another pod on this node - " +
-+			"multiple pods on the same node sharing a block device is not supported (only for live migration across nodes)")
-+	}
-+
-+	return nil
-+}
-+
  // ControllerPublishVolume https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#controllerpublishvolume
  func (d Driver) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
  	if req.GetVolumeId() == "" {
-@@ -751,6 +1010,15 @@ func (d Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controller
+@@ -751,6 +964,14 @@ func (d Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controller
  	// ReadWriteMany block volume
  	rwxBlock := req.VolumeCapability.AccessMode.GetMode() == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER && req.VolumeCapability.GetBlock() != nil
  
 +	// Validate RWX block attachment to prevent misuse of allow-two-primaries
 +	if rwxBlock {
-+		_, err := d.validateRWXBlockAttachment(ctx, req.GetVolumeId())
-+		if err != nil {
++		if _, err := d.validateRWXBlockAttachment(ctx, req.GetVolumeId()); err != nil {
 +			return nil, status.Errorf(codes.FailedPrecondition,
 +				"ControllerPublishVolume failed for %s: %v", req.GetVolumeId(), err)
 +		}


### PR DESCRIPTION
## What this PR does

Removes node-level RWX block validation from linstor-csi as controller-level check is sufficient. The controller already validates that all pods attached to RWX block volume belong to the same VM by extracting vmName from pod owner references (VirtualMachineInstance).

This simplifies the validation logic and fixes VM live migration issues.

### Release note

```release-note
[linstor] Remove node-level RWX block validation to fix VM live migration
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced RWX (read-write-many) block validation with VM-aware checks across node and controller flows, including support for hotplug-disk pods and stricter prevention of cross-VM block sharing.
  * Improved propagation and resolution of VM identity for attachments to ensure consistent validation.

* **Tests**
  * Added comprehensive unit tests covering single/multiple pod scenarios, VM ownership, hotplug disks, upgrade paths, and legacy volumes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->