### PR TITLE
[docs] Generate changelogs for v0.39.5, v0.40.1, and v0.40.2

### DIFF
--- a/docs/changelogs/v0.39.5.md
+++ b/docs/changelogs/v0.39.5.md
@@ -1,0 +1,11 @@
+<!--
+https://github.com/cozystack/cozystack/releases/tag/v0.39.5
+-->
+
+## Fixes
+
+* **[linstor] Update piraeus-server patches with critical fixes**: Backported critical patches to piraeus-server that address storage stability issues and improve DRBD resource handling. These patches fix edge cases in device management and ensure more reliable storage operations ([**@kvaps**](https://github.com/kvaps) in #1850, #1853).
+
+---
+
+**Full Changelog**: [v0.39.4...v0.39.5](https://github.com/cozystack/cozystack/compare/v0.39.4...v0.39.5)

--- a/docs/changelogs/v0.40.1.md
+++ b/docs/changelogs/v0.40.1.md
@@ -1,0 +1,11 @@
+<!--
+https://github.com/cozystack/cozystack/releases/tag/v0.40.1
+-->
+
+## Fixes
+
+* **[linstor] Update piraeus-server patches with critical fixes**: Backported critical patches to piraeus-server that address storage stability issues and improve DRBD resource handling. These patches fix edge cases in device management and ensure more reliable storage operations ([**@kvaps**](https://github.com/kvaps) in #1850, #1852).
+
+---
+
+**Full Changelog**: [v0.40.0...v0.40.1](https://github.com/cozystack/cozystack/compare/v0.40.0...v0.40.1)

--- a/docs/changelogs/v0.40.2.md
+++ b/docs/changelogs/v0.40.2.md
@@ -1,0 +1,15 @@
+<!--
+https://github.com/cozystack/cozystack/releases/tag/v0.40.2
+-->
+
+## Improvements
+
+* **[linstor] Refactor node-level RWX validation**: Refactored the node-level ReadWriteMany (RWX) validation logic in LINSTOR CSI. The validation has been moved to the CSI driver level with a custom linstor-csi image build, providing more reliable RWX volume handling and clearer error messages when RWX requirements cannot be satisfied ([**@kvaps**](https://github.com/kvaps) in #1856, #1857).
+
+## Fixes
+
+* **[linstor] Remove node-level RWX validation**: Removed the problematic node-level RWX validation that was causing issues with volume provisioning. The validation logic has been refactored and moved to a more appropriate location in the LINSTOR CSI driver ([**@kvaps**](https://github.com/kvaps) in #1851).
+
+---
+
+**Full Changelog**: [v0.40.1...v0.40.2](https://github.com/cozystack/cozystack/compare/v0.40.1...v0.40.2)


### PR DESCRIPTION
## What this PR does

Adds missing changelog files for the recent patch releases:
- v0.39.5 - LINSTOR critical patches backport
- v0.40.1 - LINSTOR critical patches backport  
- v0.40.2 - LINSTOR RWX validation refactoring

### Release note

```release-note
[docs] Add changelogs for v0.39.5, v0.40.1, and v0.40.2 releases
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added changelog entries for releases v0.39.5, v0.40.1, and v0.40.2.

* **Bug Fixes**
  * v0.39.5 and v0.40.1 include critical stability patches addressing storage operations, DRBD resource handling, and device management edge cases.

* **Improvements**
  * v0.40.2 refactors RWX validation, moving it to the LINSTOR CSI driver for more reliable handling and clearer error messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->