### PR TITLE
[apiserver] Fix Watch resourceVersion and bookmark handling

### DIFF
--- a/pkg/registry/utils.go
+++ b/pkg/registry/utils.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2024 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// MaxResourceVersion returns the maximum resourceVersion from all items in a list.
+// This is useful when the list's ResourceVersion is empty (e.g., from controller-runtime cache).
+func MaxResourceVersion(list runtime.Object) (string, error) {
+	var max uint64
+
+	err := meta.EachListItem(list, func(obj runtime.Object) error {
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return err
+		}
+
+		rvStr := accessor.GetResourceVersion()
+		if rvStr == "" {
+			return nil
+		}
+
+		rv, err := strconv.ParseUint(rvStr, 10, 64)
+		if err != nil {
+			return err
+		}
+
+		if rv > max {
+			max = rv
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return strconv.FormatUint(max, 10), nil
+}


### PR DESCRIPTION
## What this PR does

Fixes aggregated API server Watch implementation to properly work with controller-runtime informers. External controllers watching Tenant resources via the aggregated API were experiencing issues with cache sync timeouts and missing reconciliations on startup.

### Changes

**ResourceVersion handling in List:**
- Compute ResourceVersion from items when the cached client doesn't set it on the list itself

**Bookmark handling:**
- Pass through bookmark events with converted types for proper informer sync

**ADDED event filtering (main fix):**
- Simplified the filtering logic that was incorrectly skipping initial events
- Only skip ADDED events when `startingRV > 0` AND `objRV <= startingRV` (client already has from List)
- When `startingRV == 0`, always send ADDED events (client wants full state)
- Removed the complex `initialSyncComplete` tracking that had inverted logic

### Problem

When a controller starts watching resources, controller-runtime may call Watch with `resourceVersion=""`. The server should send all existing objects as ADDED events. The previous `initialSyncComplete` logic was inverted and could skip these events, causing objects (like Tenants with lock annotations) to not be reconciled on controller startup.

### Release note

```release-note
[apiserver] Fix Watch resourceVersion and bookmark handling for controller-runtime compatibility
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced resource watching and synchronization with Kubernetes 1.27+ compatibility, including proper handling of initial events and bookmarks.
  * Optimized event filtering and resource version tracking for applications, tenant modules, tenant namespaces, and tenant secrets to reduce unnecessary event noise.
  * Improved list metadata consistency by deriving accurate resource versions when unavailable in responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->