### PR TITLE
[etcd] Increase probe thresholds for better recovery

### DIFF
--- a/packages/extra/etcd/templates/etcd-cluster.yaml
+++ b/packages/extra/etcd/templates/etcd-cluster.yaml
@@ -46,6 +46,15 @@ spec:
         - name: metrics
           containerPort: 2381
           protocol: TCP
+        startupProbe:
+          failureThreshold: 300
+          periodSeconds: 5
+        livenessProbe:
+          failureThreshold: 10
+          periodSeconds: 10
+        readinessProbe:
+          failureThreshold: 3
+          periodSeconds: 5
         {{- with .Values.resources }}
         resources: {{- include "cozy-lib.resources.sanitize" (list . $) | nindent 10 }}
         {{- end }}


### PR DESCRIPTION
## What this PR does

Increases etcd probe thresholds to allow more time for cluster synchronization after pod restarts. This addresses issues where etcd members were being killed by startup probes before they could fully sync with the cluster, especially when VPA assigns minimal resources.

Changes:
- `startupProbe.failureThreshold`: 3 → 300 (allows 25 minutes for initial sync)
- `livenessProbe.failureThreshold`: default → 10 (reduces unnecessary restarts)
- `readinessProbe.failureThreshold`: default → 3

### Release note

```release-note
[etcd] Increase probe thresholds to prevent premature pod termination during cluster synchronization
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved etcd service stability with automatic health monitoring and failover detection capabilities in Kubernetes environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->