### PR TITLE
fix(kubernetes): increase kube-apiserver startup probe threshold

### DIFF
--- a/packages/system/kamaji/images/kamaji/patches/increase-startup-probe-threshold.diff
+++ b/packages/system/kamaji/images/kamaji/patches/increase-startup-probe-threshold.diff
@@ -1,0 +1,31 @@
+diff --git a/internal/builders/controlplane/deployment.go b/internal/builders/controlplane/deployment.go
+index e7f0b88..d67a851 100644
+--- a/internal/builders/controlplane/deployment.go
++++ b/internal/builders/controlplane/deployment.go
+@@ -376,7 +376,7 @@ func (d Deployment) buildScheduler(podSpec *corev1.PodSpec, tenantControlPlane k
+ 		TimeoutSeconds:      1,
+ 		PeriodSeconds:       10,
+ 		SuccessThreshold:    1,
+-		FailureThreshold:    3,
++		FailureThreshold:    30,
+ 	}
+ 
+ 	switch {
+@@ -469,7 +469,7 @@ func (d Deployment) buildControllerManager(podSpec *corev1.PodSpec, tenantContro
+ 		TimeoutSeconds:      1,
+ 		PeriodSeconds:       10,
+ 		SuccessThreshold:    1,
+-		FailureThreshold:    3,
++		FailureThreshold:    30,
+ 	}
+ 	switch {
+ 	case tenantControlPlane.Spec.ControlPlane.Deployment.Resources == nil:
+@@ -600,7 +600,7 @@ func (d Deployment) buildKubeAPIServer(podSpec *corev1.PodSpec, tenantControlPla
+ 		TimeoutSeconds:      1,
+ 		PeriodSeconds:       10,
+ 		SuccessThreshold:    1,
+-		FailureThreshold:    3,
++		FailureThreshold:    30,
+ 	}
+ 	podSpec.Containers[index].ImagePullPolicy = corev1.PullAlways
+ 	// Volume mounts


### PR DESCRIPTION
## What this PR does

Increases the `startupProbe.failureThreshold` for kube-apiserver container from 3 to 30.

The default 30 seconds (3 failures × 10s period) is often insufficient for kube-apiserver to complete RBAC bootstrap, especially:
- Under high load conditions
- With slower etcd connections  
- During initial cluster provisioning

This change gives kube-apiserver up to 300 seconds to initialize, preventing unnecessary CrashLoopBackOff cycles.

### Release note

```release-note
[kubernetes] Increase kube-apiserver startup probe threshold to prevent CrashLoopBackOff during slow RBAC initialization
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated startup probe threshold configuration to enhance system initialization stability across core components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->