### PR TITLE
[monitoring-agents] Set minReplicas to 1 for VPA for VMAgent

### DIFF
--- a/packages/system/monitoring-agents/templates/vpa.yaml
+++ b/packages/system/monitoring-agents/templates/vpa.yaml
@@ -9,6 +9,7 @@ spec:
     name: vmagent
   updatePolicy:
     updateMode: Auto
+    minReplicas: 1
   resourcePolicy:
     containerPolicies:
       - containerName: config-reloader


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Set minReplicas for VPA for VMAgent to work correctly in the default case when replicas = 1
Fixes https://github.com/cozystack/cozystack/issues/1893

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[monitoring-agents] set minReplicas=1 in VPA for cluster-wide VMAgent to allow recrating single replica
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Changes

* **Chores**
  * Updated system monitoring autoscaler configuration to enforce minimum replica constraints, enhancing service resilience and availability during scaling operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->