### PR TITLE
docs(tenant): add resourceQuotas configuration documentation

### DIFF
--- a/packages/apps/tenant/README.md
+++ b/packages/apps/tenant/README.md
@@ -79,3 +79,34 @@ tenant-u1
 | `isolated`       | Enforce tenant namespace with network policies (default: true).                                                            | `bool`                | `true`  |
 | `resourceQuotas` | Define resource quotas for the tenant.                                                                                     | `map[string]quantity` | `{}`    |
 
+
+## Configuration
+
+### Resource Quotas
+
+The `resourceQuotas` parameter allows you to limit resources available to the tenant. Supported keys include:
+
+**Compute resources** (converted to `requests.X` and `limits.X`):
+- `cpu` - Total CPU cores (e.g., `"4"` or `"500m"`)
+- `memory` - Total memory (e.g., `"4Gi"` or `"512Mi"`)
+- `ephemeral-storage` - Ephemeral storage limit (e.g., `"10Gi"`)
+- `storage` - Total persistent storage (e.g., `"100Gi"`)
+
+**Object count quotas** (passed as-is):
+- `pods` - Maximum number of pods
+- `services` - Maximum number of services
+- `services.loadbalancers` - Maximum number of LoadBalancer services
+- `services.nodeports` - Maximum number of NodePort services
+- `configmaps` - Maximum number of ConfigMaps
+- `secrets` - Maximum number of Secrets
+- `persistentvolumeclaims` - Maximum number of PVCs
+
+**Example:**
+```yaml
+resourceQuotas:
+  cpu: 4
+  memory: 4Gi
+  storage: 10Gi
+  services.loadbalancers: "3"
+  pods: "50"
+```


### PR DESCRIPTION
## Summary

- Add documentation for the `resourceQuotas` parameter in tenant README
- Document supported compute resources (cpu, memory, ephemeral-storage, storage)
- Document object count quotas (pods, services, configmaps, secrets, etc.)
- Include usage example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Configuration section describing resource quotas, including compute resource mappings (CPU, memory, storage), object count restrictions (pods, services, configmaps, secrets, persistent volumes), and example YAML configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->