### PR TITLE
[dashboard] Add External IPs tab for LoadBalancer services

### DIFF
--- a/internal/controller/dashboard/sidebar.go
+++ b/internal/controller/dashboard/sidebar.go
@@ -111,6 +111,8 @@ func (m *Manager) ensureSidebar(ctx context.Context, crd *cozyv1alpha1.Applicati
 	keysAndTags["services"] = []any{"service-sidebar"}
 	keysAndTags["secrets"] = []any{"secret-sidebar"}
 	keysAndTags["ingresses"] = []any{"ingress-sidebar"}
+	// Add sidebar for v1/services type loadbalancer
+	keysAndTags["loadbalancer-services"] = []any{"external-ips-sidebar"}
 
 	// Add sidebar for backups.cozystack.io Plan resource
 	keysAndTags["plans"] = []any{"plan-sidebar"}
@@ -211,6 +213,11 @@ func (m *Manager) ensureSidebar(ctx context.Context, crd *cozyv1alpha1.Applicati
 				"link":  "/openapi-ui/{clusterName}/{namespace}/api-table/core.cozystack.io/v1alpha1/tenantmodules",
 			},
 			map[string]any{
+				"key":   "loadbalancer-services",
+				"label": "External IPs",
+				"link":  "/openapi-ui/{clusterName}/{namespace}/factory/external-ips",
+			},
+			map[string]any{
 				"key":   "tenants",
 				"label": "Tenants",
 				"link":  "/openapi-ui/{clusterName}/{namespace}/api-table/apps.cozystack.io/v1alpha1/tenants",
@@ -236,6 +243,7 @@ func (m *Manager) ensureSidebar(ctx context.Context, crd *cozyv1alpha1.Applicati
 		"stock-project-factory-plan-details",
 		"stock-project-factory-backupjob-details",
 		"stock-project-factory-backup-details",
+		"stock-project-factory-external-ips",
 		"stock-project-api-form",
 		"stock-project-api-table",
 		"stock-project-builtin-form",

--- a/internal/controller/dashboard/static_refactored.go
+++ b/internal/controller/dashboard/static_refactored.go
@@ -1885,6 +1885,46 @@ func CreateAllFactories() []*dashboardv1alpha1.Factory {
 	}
 	backupSpec := createUnifiedFactory(backupConfig, backupTabs, []any{"/api/clusters/{2}/k8s/apis/backups.cozystack.io/v1alpha1/namespaces/{3}/backups/{6}"})
 
+	// External IPs factory (filtered services)
+	externalIPsTabs := []any{
+		map[string]any{
+			"key":   "services",
+			"label": "Services",
+			"children": []any{
+				map[string]any{
+					"type": "EnrichedTable",
+					"data": map[string]any{
+						"id":                   "external-ips-table",
+						"fetchUrl":             "/api/clusters/{2}/k8s/api/v1/namespaces/{3}/services",
+						"clusterNamePartOfUrl": "{2}",
+						"baseprefix":           "/openapi-ui",
+						"customizationId":      "factory-details-v1.services",
+						"pathToItems":          []any{"items"},
+						"fieldSelector": map[string]any{
+							"spec.type": "LoadBalancer",
+						},
+					},
+				},
+			},
+		},
+	}
+	externalIPsSpec := map[string]any{
+		"key":                           "external-ips",
+		"sidebarTags":                   []any{"external-ips-sidebar"},
+		"withScrollableMainContentCard": true,
+		"urlsToFetch":                   []any{},
+		"data": []any{
+			map[string]any{
+				"type": "antdTabs",
+				"data": map[string]any{
+					"id":               "tabs-root",
+					"defaultActiveKey": "services",
+					"items":            externalIPsTabs,
+				},
+			},
+		},
+	}
+
 	return []*dashboardv1alpha1.Factory{
 		createFactory("marketplace", marketplaceSpec),
 		createFactory("namespace-details", namespaceSpec),
@@ -1897,6 +1937,7 @@ func CreateAllFactories() []*dashboardv1alpha1.Factory {
 		createFactory("plan-details", planSpec),
 		createFactory("backupjob-details", backupJobSpec),
 		createFactory("backup-details", backupSpec),
+		createFactory("external-ips", externalIPsSpec),
 	}
 }
 


### PR DESCRIPTION
Introduce a new "External IPs" sidebar and associated dashboard factory to display services of type LoadBalancer.

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Add External IPs tab to sidebar with all `Service` resources of type `LoadBalancer` in tenant

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[dashboard] add External IPs tab with `Service` resources of type `LoadBalancer`
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added External IPs menu item in the Administration section for quick access to load balancer services
  * Introduced a new dashboard view displaying external IPs with tabbed interface for enhanced visibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->