### PR TITLE
[kubernetes] show Service and Ingress resources for kubernetes app in…

### DIFF
--- a/packages/apps/kubernetes/templates/cloud-config.yaml
+++ b/packages/apps/kubernetes/templates/cloud-config.yaml
@@ -10,3 +10,8 @@ data:
       enableEPSController: true
       selectorless: true
     namespace: {{ .Release.Namespace }}
+    infraLabels:
+      apps.cozystack.io/application.group: apps.cozystack.io
+      apps.cozystack.io/application.kind: Kubernetes
+      apps.cozystack.io/application.name: {{ .Release.Name | trimPrefix "kubernetes-" }}
+      internal.cozystack.io/tenantresource: "true"

--- a/packages/apps/kubernetes/templates/ingress.yaml
+++ b/packages/apps/kubernetes/templates/ingress.yaml
@@ -14,6 +14,11 @@ metadata:
       }
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+  labels:
+    apps.cozystack.io/application.group: apps.cozystack.io
+    apps.cozystack.io/application.kind: Kubernetes
+    apps.cozystack.io/application.name: {{ .Release.Name | trimPrefix "kubernetes-" }}
+    internal.cozystack.io/tenantresource: "true"
 spec:
   ingressClassName: "{{ $ingress }}"
   rules:
@@ -41,6 +46,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-ingress-nginx
+  labels:
+    apps.cozystack.io/application.group: apps.cozystack.io
+    apps.cozystack.io/application.kind: Kubernetes
+    apps.cozystack.io/application.name: {{ .Release.Name | trimPrefix "kubernetes-" }}
+    internal.cozystack.io/tenantresource: "true"
 spec:
   ports:
   - appProtocol: http

--- a/packages/system/kubernetes-rd/cozyrds/kubernetes.yaml
+++ b/packages/system/kubernetes-rd/cozyrds/kubernetes.yaml
@@ -37,8 +37,12 @@ spec:
     include:
       - resourceNames:
           - kubernetes-{{ .name }}
+          - kubernetes-{{ .name }}-ingress-nginx
+      - matchLabels:
+          cluster.x-k8s.io/cluster-name: kubernetes-{{ .name }}
   ingresses:
     exclude: []
     include:
       - resourceNames:
           - kubernetes-{{ .name }}
+          - kubernetes-{{ .name }}-ingress-nginx


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Add labels and selectors for Service and Ingress resources to correctly show them in corresponding tabs for Kubernetes app in dashboard

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[kubernetes] show Ingress and Service resources in dashboard
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced standardized metadata labels across Kubernetes application resources including cloud configuration, ingress, and service components to improve resource organization, tracking, identification, and multi-tenant environment management
  * Extended the system's resource management framework to include and manage additional Kubernetes infrastructure components, such as ingress-nginx, enhancing overall cluster orchestration and service networking capabilities

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->