### PR TITLE
[dashboard] Improve dashboard session params

### DIFF
--- a/packages/system/dashboard/templates/gatekeeper.yaml
+++ b/packages/system/dashboard/templates/gatekeeper.yaml
@@ -64,6 +64,7 @@ spec:
             - --cookie-secure=true
             - --cookie-secret=$(OAUTH2_PROXY_COOKIE_SECRET)
             - --skip-provider-button
+            - --scope=openid email profile offline_access
           env:
             - name: OAUTH2_PROXY_CLIENT_ID
               value: dashboard

--- a/packages/system/dashboard/templates/keycloakclient.yaml
+++ b/packages/system/dashboard/templates/keycloakclient.yaml
@@ -66,6 +66,12 @@ spec:
   defaultClientScopes:
     - groups
     - kubernetes-client
+  optionalClientScopes:
+    - offline_access
+  attributes:
+    post.logout.redirect.uris: "+"
+    client.session.idle.timeout: "86400"
+    client.session.max.lifespan: "604800"
   redirectUris:
     - "https://dashboard.{{ $host }}/oauth2/callback/*"
     {{- range $i, $v := $extraRedirectUris }}


### PR DESCRIPTION
## What this PR does

This patch enables the `offline_access` scope for the dashbord keycloak client, so that users get a refresh token which gatekeeper can use to automatically refresh an expiring access token. Also session timeouts were increased.

### Release note

```release-note
[dashboard] Increase session timeouts, add the offline_access scope,
enable refresh tokens to improve the overall user experience when
working with the dashboard.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication configuration with additional OAuth2 scope parameters to enhance security credentials handling.
  * Enhanced Keycloak client configuration with optional client scopes and session management attributes, including logout redirect settings and session timeout controls for improved session lifecycle management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->