### PR TITLE
docs(changelogs): add changelogs for v0.40.3, v0.41.1, v0.41.2, v0.41.3

### DIFF
--- a/docs/changelogs/v0.40.3.md
+++ b/docs/changelogs/v0.40.3.md
@@ -1,0 +1,15 @@
+<!--
+https://github.com/cozystack/cozystack/releases/tag/v0.40.3
+-->
+
+## Fixes
+
+* **[apiserver] Fix Watch resourceVersion and bookmark handling**: Fixed issues with Watch API handling of resourceVersion and bookmarks, ensuring proper event streaming and state synchronization for API clients ([**@kvaps**](https://github.com/kvaps) in #1860).
+
+## Dependencies
+
+* **[cilium] Update Cilium to v1.18.6**: Updated Cilium CNI to v1.18.6 with security fixes and performance improvements ([**@sircthulhu**](https://github.com/sircthulhu) in #1868, #1870).
+
+---
+
+**Full Changelog**: [v0.40.2...v0.40.3](https://github.com/cozystack/cozystack/compare/v0.40.2...v0.40.3)

--- a/docs/changelogs/v0.41.1.md
+++ b/docs/changelogs/v0.41.1.md
@@ -1,0 +1,11 @@
+<!--
+https://github.com/cozystack/cozystack/releases/tag/v0.41.1
+-->
+
+## Improvements
+
+* **[kubernetes] Add enum validation for IngressNginx exposeMethod**: Added enum validation for the `exposeMethod` field in IngressNginx configuration, preventing invalid values and improving user experience with clear valid options ([**@sircthulhu**](https://github.com/sircthulhu) in #1895, #1897).
+
+---
+
+**Full Changelog**: [v0.41.0...v0.41.1](https://github.com/cozystack/cozystack/compare/v0.41.0...v0.41.1)

--- a/docs/changelogs/v0.41.2.md
+++ b/docs/changelogs/v0.41.2.md
@@ -1,0 +1,13 @@
+<!--
+https://github.com/cozystack/cozystack/releases/tag/v0.41.2
+-->
+
+## Improvements
+
+* **[monitoring-agents] Set minReplicas to 1 for VPA for VMAgent**: Configured VPA (Vertical Pod Autoscaler) to maintain at least 1 replica for VMAgent, ensuring monitoring availability during scaling operations ([**@sircthulhu**](https://github.com/sircthulhu) in #1894, #1905).
+
+* **[mongodb] Remove user-configurable images from MongoDB chart**: Removed user-configurable image options from the MongoDB chart to simplify configuration and ensure consistency with tested image versions ([**@kvaps**](https://github.com/kvaps) in #1901, #1904).
+
+---
+
+**Full Changelog**: [v0.41.1...v0.41.2](https://github.com/cozystack/cozystack/compare/v0.41.1...v0.41.2)

--- a/docs/changelogs/v0.41.3.md
+++ b/docs/changelogs/v0.41.3.md
@@ -1,0 +1,15 @@
+<!--
+https://github.com/cozystack/cozystack/releases/tag/v0.41.3
+-->
+
+## Improvements
+
+* **[kubernetes] Show Service and Ingress resources for Kubernetes app in dashboard**: Added visibility of Service and Ingress resources for Kubernetes applications in the dashboard, improving resource management and monitoring capabilities ([**@sircthulhu**](https://github.com/sircthulhu) in #1912, #1915).
+
+## Fixes
+
+* **[dashboard] Fix filtering on Pods tab for Service**: Fixed an issue where pod filtering was not working correctly on the Pods tab when viewing Services in the dashboard ([**@sircthulhu**](https://github.com/sircthulhu) in #1909, #1914).
+
+---
+
+**Full Changelog**: [v0.41.2...v0.41.3](https://github.com/cozystack/cozystack/compare/v0.41.2...v0.41.3)


### PR DESCRIPTION
## What this PR does

Add missing changelog documentation for recent patch releases that were released without changelog entries.

### Release note

```release-note
[docs] Add changelog documentation for v0.40.3, v0.41.1, v0.41.2, v0.41.3
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed apiserver Watch resourceVersion and bookmark handling for proper event streaming
  * Fixed Pods tab filtering when viewing Services in dashboard

* **Improvements**
  * Added enum validation for IngressNginx exposeMethod field
  * Kubernetes dashboard now displays Service and Ingress resources
  * monitoring-agents minReplicas configuration update
  * MongoDB chart image configuration restriction

* **Chores**
  * Updated Cilium CNI to v1.18.6

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->