### PR TITLE
[dashboard] Add resource quota usage to tenant details page

### DIFF
--- a/internal/controller/dashboard/customcolumns.go
+++ b/internal/controller/dashboard/customcolumns.go
@@ -34,9 +34,6 @@ func (m *Manager) ensureCustomColumnsOverride(ctx context.Context, crd *cozyv1al
 	obj.SetName(name)
 
 	href := fmt.Sprintf("/openapi-ui/{2}/{reqsJsonPath[0]['.metadata.namespace']['-']}/factory/%s/{reqsJsonPath[0]['.metadata.name']['-']}", detailsSegment)
-	if g == "apps.cozystack.io" && kind == "Tenant" && plural == "tenants" {
-		href = "/openapi-ui/{2}/{reqsJsonPath[0]['.status.namespace']['-']}/api-table/core.cozystack.io/v1alpha1/tenantmodules"
-	}
 
 	desired := map[string]any{
 		"spec": map[string]any{

--- a/internal/controller/dashboard/factory.go
+++ b/internal/controller/dashboard/factory.go
@@ -174,6 +174,48 @@ func detailsTab(kind, endpoint, schemaJSON string, keysOrder [][]string) map[str
 			}),
 		)
 	}
+	if kind == "Info" {
+		rightColStack = append(rightColStack,
+			antdFlexVertical("resource-quotas-block", 4, []any{
+				antdText("resource-quotas-label", true, "Resource Quotas", map[string]any{
+					"fontSize":     float64(20),
+					"marginBottom": float64(12),
+				}),
+				map[string]any{
+					"type": "EnrichedTable",
+					"data": map[string]any{
+						"id":                   "resource-quotas-table",
+						"baseprefix":           "/openapi-ui",
+						"clusterNamePartOfUrl": "{2}",
+						"customizationId":      "factory-resource-quotas",
+						"fetchUrl":             "/api/clusters/{2}/k8s/api/v1/namespaces/{3}/resourcequotas",
+						"pathToItems":          []any{`items`},
+					},
+				},
+			}),
+		)
+	}
+	if kind == "Tenant" {
+		rightColStack = append(rightColStack,
+			antdFlexVertical("resource-quotas-block", 4, []any{
+				antdText("resource-quotas-label", true, "Resource Quotas", map[string]any{
+					"fontSize":     float64(20),
+					"marginBottom": float64(12),
+				}),
+				map[string]any{
+					"type": "EnrichedTable",
+					"data": map[string]any{
+						"id":                   "resource-quotas-table",
+						"baseprefix":           "/openapi-ui",
+						"clusterNamePartOfUrl": "{2}",
+						"customizationId":      "factory-resource-quotas",
+						"fetchUrl":             "/api/clusters/{2}/k8s/api/v1/namespaces/{3}/resourcequotas",
+						"pathToItems":          []any{`items`},
+					},
+				},
+			}),
+		)
+	}
 
 	return map[string]any{
 		"key":   "details",

--- a/internal/controller/dashboard/static_refactored.go
+++ b/internal/controller/dashboard/static_refactored.go
@@ -189,6 +189,14 @@ func CreateAllCustomColumnsOverrides() []*dashboardv1alpha1.CustomColumnsOverrid
 			createStringColumn("Values", "_flatMapData_Value"),
 		}),
 
+		// Factory resource quotas
+		createCustomColumnsOverride("factory-resource-quotas", []any{
+			createFlatMapColumn("Data", ".spec.hard"),
+			createStringColumn("Resource", "_flatMapData_Key"),
+			createStringColumn("Hard", "_flatMapData_Value"),
+			createStringColumn("Used", ".status.used['{_flatMapData_Key}']"),
+		}),
+
 		// Factory ingress details rules
 		createCustomColumnsOverride("factory-kube-ingress-details-rules", []any{
 			createStringColumn("Host", ".host"),


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

- Add Tenant details page to dashboard
- Add Resource Quota usage to Tenant page in dashboard

<img width="1800" height="939" alt="resource quota in tenant" src="https://github.com/user-attachments/assets/7f4f6ed6-e9b8-4258-a60b-15f203443a1f" />



### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[dashboard] Add Tenant details page and resource quota usage to tenant page
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Resource Quotas section to the Details tab to show allocation limits and usage.
  * Info and Tenant types now display quota data in an interactive table with columns for resource, limits, and current usage.
  * Enhanced quota table presentation with additional columns for flattened resource keys and values for clearer reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->