### PR TITLE
[kubernetes] use ingress-nginx nodeport service

### DIFF
--- a/packages/apps/kubernetes/templates/helmreleases/ingress-nginx.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/ingress-nginx.yaml
@@ -4,9 +4,12 @@ ingress-nginx:
   controller:
     kind: DaemonSet
     {{- if eq .Values.addons.ingressNginx.exposeMethod "Proxied" }}
-    hostNetwork: true
     service:
-      enabled: false
+      enabled: true
+      type: NodePort
+      nodePorts:
+        http: 30000
+        https: 30001
     {{- end }}
     {{- if not .Values.addons.certManager.enabled }}
     admissionWebhooks:

--- a/packages/apps/kubernetes/templates/ingress.yaml
+++ b/packages/apps/kubernetes/templates/ingress.yaml
@@ -56,11 +56,11 @@ spec:
   - appProtocol: http
     name: http
     port: 80
-    targetPort: 80
+    targetPort: 30000
   - appProtocol: https
     name: https
     port: 443
-    targetPort: 443
+    targetPort: 30001
   selector:
     cluster.x-k8s.io/cluster-name: {{ .Release.Name }}
     node-role.kubernetes.io/ingress-nginx: ""


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

- Removes `hostNetwork` for Ingress NGINX Controller for Managed kubernetes cluster
- Adds Service of type NodePort for load balancing

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[kubernetes] use NodePort service instead of hostNetwork for ingress-nginx
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated ingress-nginx controller to use NodePort exposure method (ports 30000 for HTTP, 30001 for HTTPS) when configured as "Proxied."
  * Removed unnecessary hostNetwork configuration for the controller.
  * Service port mappings updated to align with new NodePort settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->