### PR TITLE
Add instance profile label to workload monitor

### DIFF
--- a/internal/controller/workloadmonitor_controller.go
+++ b/internal/controller/workloadmonitor_controller.go
@@ -466,8 +466,9 @@ func (r *WorkloadMonitorReconciler) getWorkloadMetadata(obj client.Object) map[s
 	annotations := obj.GetAnnotations()
 	if instanceType, ok := annotations["kubevirt.io/cluster-instancetype-name"]; ok {
 		labels["workloads.cozystack.io/kubevirt-vmi-instance-type"] = instanceType
-	if instanceProfile, ok := annotations["kubevirt.io/cluster-preference-name"]; ok {                                                                                                              
-        labels["workloads.cozystack.io/kubevirt-vmi-instance-profile"] = instanceProfile
+	}
+	if instanceProfile, ok := annotations["kubevirt.io/cluster-instanceprofile-name"]; ok {
+		labels["workloads.cozystack.io/kubevirt-vmi-instance-profile"] = instanceProfile
 	}
 	return labels
 }


### PR DESCRIPTION
Add instance profile metadata to workload monitor                                                                                                                                                          
                                                                                                                                                                                                             
Currently getWorkloadMetadata only extracts the kubevirt.io/cluster-instancetype-name annotation from VMI objects. This misses the instance profile information (kubevirt.io/cluster-instanceprofile-name), which is needed to track workload sizing/configuration alongside the instance type.                                                                                                                       
This change adds extraction of the cluster instance profile annotation and exposes it as the workloads.cozystack.io/kubevirt-vmi-instance-profile label on collected metrics.                           
                                                                                                                                                                               

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workload monitoring now detects kubevirt instance profile annotations and adds a matching workload label (workloads.cozystack.io/kubevirt-vmi-instance-profile) when present.
  * Enriched workload metadata for virtualized workloads.
  * No other behavior or control-flow changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->