### PR TITLE
[vm] allow changing field external after creation

### DIFF
--- a/packages/apps/virtual-machine/templates/vm-update-hook.yaml
+++ b/packages/apps/virtual-machine/templates/vm-update-hook.yaml
@@ -3,14 +3,17 @@
 
 {{- $existingVM := lookup "kubevirt.io/v1" "VirtualMachine" $namespace $vmName -}}
 {{- $existingPVC := lookup "v1" "PersistentVolumeClaim" $namespace $vmName -}}
+{{- $existingService := lookup "v1" "Service" $namespace $vmName -}}
 
 {{- $instanceType := .Values.instanceType | default "" -}}
 {{- $instanceProfile := .Values.instanceProfile | default "" -}}
 {{- $desiredStorage := .Values.systemDisk.storage | default "" -}}
+{{- $desiredServiceType := ternary "LoadBalancer" "ClusterIP" .Values.external -}}
 
 {{- $needUpdateType := false -}}
 {{- $needUpdateProfile := false -}}
 {{- $needResizePVC := false -}}
+{{- $needRecreateService := false -}}
 
 {{- if and $existingVM $instanceType -}}
   {{- if not (eq $existingVM.spec.instancetype.name $instanceType) -}}
@@ -35,7 +38,14 @@
   {{- end -}}
 {{- end -}}
 
-{{- if or $needUpdateType $needUpdateProfile $needResizePVC }}
+{{- if $existingService -}}
+  {{- $currentServiceType := $existingService.spec.type -}}
+  {{- if ne $currentServiceType $desiredServiceType -}}
+    {{- $needRecreateService = true -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if or $needUpdateType $needUpdateProfile $needResizePVC $needRecreateService }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -86,6 +96,11 @@ spec:
                 --type merge \
                 -p '{"spec":{"resources":{"requests":{"storage":"{{ $desiredStorage }}"}}}}'
               {{- end }}
+
+              {{- if $needRecreateService }}
+              echo "Removing Service..."
+              kubectl delete service --cascade=orphan -n {{ $namespace }} {{ $vmName }}
+              {{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -111,6 +126,10 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["patch", "get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["{{ $vmName }}"]
+    verbs: ["delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Service will be recreated

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Allow changing field `external` after creation.

Service will be deleted and then created with correct type.

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[vm] recreate service on `external` change to allow changing this field after creation
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects Service type changes during virtual machine updates and automatically recreates the Service as needed; update workflow now runs a job to remove and recreate Services before reconciliation.

* **Chores**
  * Updated RBAC to grant the update workflow permissions to manage (delete) the targeted Service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->