### PR TITLE
fix coredns serviceaccount to match kubernetes bootstrap rbac

### DIFF
--- a/packages/system/coredns/values.yaml
+++ b/packages/system/coredns/values.yaml
@@ -6,3 +6,6 @@ coredns:
   k8sAppLabelOverride: kube-dns
   service:
     name: kube-dns
+  serviceAccount:
+    create: true
+    name: kube-dns


### PR DESCRIPTION
## Summary

- Configure CoreDNS chart to create `kube-dns` ServiceAccount matching Kubernetes bootstrap ClusterRoleBinding
- Fixes RBAC errors (`Failed to watch`) when CoreDNS pods restart

## Problem

Kubernetes bootstrap creates a `ClusterRoleBinding: system:kube-dns` that references `ServiceAccount: kube-dns` in `kube-system`. However, the coredns chart was using the `default` ServiceAccount because `serviceAccount.create` was not enabled.

This caused CoreDNS pods to fail with `[ERROR] plugin/kubernetes: Failed to watch` errors after restarts, as they lacked RBAC permissions to watch the Kubernetes API. Old pods worked due to cached data, but new pods failed after rollout.

## Solution

Add ServiceAccount configuration to `packages/system/coredns/values.yaml`:
```yaml
serviceAccount:
  create: true
  name: kube-dns
```

## Test plan

- [x] Verify ServiceAccount `kube-dns` is created: `kubectl get sa -n kube-system kube-dns`
- [x] Verify deployment uses correct ServiceAccount: `kubectl get deployment -n kube-system coredns -o jsonpath='{.spec.template.spec.serviceAccountName}'` → `kube-dns`
- [x] Restart CoreDNS pods and verify all pods are Ready
- [x] Check logs show no RBAC errors
- [x] Test DNS resolution works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated DNS service configuration with service account settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->