### PR TITLE
fix(seaweedfs): Add reloader annotation for certificate renewal

### DIFF
--- a/packages/system/seaweedfs/Makefile
+++ b/packages/system/seaweedfs/Makefile
@@ -11,5 +11,6 @@ update:
 	tar xzvf - --strip 3 -C charts seaweedfs-$${version}/k8s/charts/seaweedfs
 	patch --no-backup-if-mismatch -p4 < patches/resize-api-server-annotation.diff
 	patch --no-backup-if-mismatch -p4 < patches/s3-traffic-distribution.patch
+	patch --no-backup-if-mismatch -p4 < patches/certificate-reload-annotation.patch
 	#patch --no-backup-if-mismatch -p4 < patches/retention-policy-delete.yaml
 

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/admin/admin-statefulset.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/admin/admin-statefulset.yaml
@@ -46,6 +46,10 @@ spec:
       {{- with .Values.admin.podAnnotations }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.global.enableSecurity }}
+        {{- $name := include "seaweedfs.name" . }}
+        secret.reloader.stakater.com/reload: "{{ $name }}-ca-cert,{{ $name }}-master-cert,{{ $name }}-volume-cert,{{ $name }}-filer-cert,{{ $name }}-client-cert"
+      {{- end }}
     spec:
       restartPolicy: {{ default .Values.global.restartPolicy .Values.admin.restartPolicy }}
       {{- if .Values.admin.affinity }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/filer/filer-statefulset.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/filer/filer-statefulset.yaml
@@ -49,6 +49,10 @@ spec:
       {{- with .Values.filer.podAnnotations }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.global.enableSecurity }}
+        {{- $name := include "seaweedfs.name" . }}
+        secret.reloader.stakater.com/reload: "{{ $name }}-ca-cert,{{ $name }}-master-cert,{{ $name }}-volume-cert,{{ $name }}-filer-cert,{{ $name }}-client-cert"
+      {{- end }}
       {{- if .Values.filer.s3.existingConfigSecret }}
         {{- $configSecret := (lookup "v1" "Secret" .Release.Namespace .Values.filer.s3.existingConfigSecret) | default dict }}
         checksum/s3config: {{ $configSecret | toYaml | sha256sum }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/master/master-statefulset.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/master/master-statefulset.yaml
@@ -49,6 +49,10 @@ spec:
       {{- with .Values.master.podAnnotations }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.global.enableSecurity }}
+        {{- $name := include "seaweedfs.name" . }}
+        secret.reloader.stakater.com/reload: "{{ $name }}-ca-cert,{{ $name }}-master-cert,{{ $name }}-volume-cert,{{ $name }}-filer-cert,{{ $name }}-client-cert"
+      {{- end }}
     spec:
       restartPolicy: {{ default .Values.global.restartPolicy .Values.master.restartPolicy }}
       {{- if .Values.master.affinity }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
@@ -41,6 +41,10 @@ spec:
       {{- with .Values.s3.podAnnotations }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.global.enableSecurity }}
+        {{- $name := include "seaweedfs.name" . }}
+        secret.reloader.stakater.com/reload: "{{ $name }}-ca-cert,{{ $name }}-master-cert,{{ $name }}-volume-cert,{{ $name }}-filer-cert,{{ $name }}-client-cert"
+      {{- end }}
     spec:
       restartPolicy: {{ default .Values.global.restartPolicy .Values.s3.restartPolicy }}
       {{- if .Values.s3.affinity }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/volume/volume-statefulset.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/volume/volume-statefulset.yaml
@@ -49,6 +49,10 @@ spec:
       {{- with $volume.podAnnotations }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if $.Values.global.enableSecurity }}
+        {{- $name := include "seaweedfs.name" $ }}
+        secret.reloader.stakater.com/reload: "{{ $name }}-ca-cert,{{ $name }}-master-cert,{{ $name }}-volume-cert,{{ $name }}-filer-cert,{{ $name }}-client-cert"
+      {{- end }}
     spec:
       {{- if $volume.affinity }}
       affinity:

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/worker/worker-deployment.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/worker/worker-deployment.yaml
@@ -44,6 +44,10 @@ spec:
       {{- with .Values.worker.podAnnotations }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.global.enableSecurity }}
+        {{- $name := include "seaweedfs.name" . }}
+        secret.reloader.stakater.com/reload: "{{ $name }}-ca-cert,{{ $name }}-master-cert,{{ $name }}-volume-cert,{{ $name }}-filer-cert,{{ $name }}-client-cert"
+      {{- end }}
     spec:
       restartPolicy: {{ default .Values.global.restartPolicy .Values.worker.restartPolicy }}
       {{- if .Values.worker.affinity }}

--- a/packages/system/seaweedfs/patches/certificate-reload-annotation.patch
+++ b/packages/system/seaweedfs/patches/certificate-reload-annotation.patch
@@ -1,0 +1,84 @@
+diff --git a/packages/system/seaweedfs/charts/seaweedfs/templates/master/master-statefulset.yaml b/packages/system/seaweedfs/charts/seaweedfs/templates/master/master-statefulset.yaml
+--- a/packages/system/seaweedfs/charts/seaweedfs/templates/master/master-statefulset.yaml
++++ b/packages/system/seaweedfs/charts/seaweedfs/templates/master/master-statefulset.yaml
+@@ -48,6 +48,10 @@ spec:
+       {{- with .Values.master.podAnnotations }}
+       {{- toYaml . | nindent 8 }}
+       {{- end }}
++      {{- if .Values.global.enableSecurity }}
++        {{- $name := include "seaweedfs.name" . }}
++        secret.reloader.stakater.com/reload: "{{ $name }}-ca-cert,{{ $name }}-master-cert,{{ $name }}-volume-cert,{{ $name }}-filer-cert,{{ $name }}-client-cert"
++      {{- end }}
+     spec:
+       restartPolicy: {{ default .Values.global.restartPolicy .Values.master.restartPolicy }}
+       {{- if .Values.master.affinity }}
+diff --git a/packages/system/seaweedfs/charts/seaweedfs/templates/filer/filer-statefulset.yaml b/packages/system/seaweedfs/charts/seaweedfs/templates/filer/filer-statefulset.yaml
+--- a/packages/system/seaweedfs/charts/seaweedfs/templates/filer/filer-statefulset.yaml
++++ b/packages/system/seaweedfs/charts/seaweedfs/templates/filer/filer-statefulset.yaml
+@@ -48,6 +48,10 @@ spec:
+       {{- with .Values.filer.podAnnotations }}
+       {{- toYaml . | nindent 8 }}
+       {{- end }}
++      {{- if .Values.global.enableSecurity }}
++        {{- $name := include "seaweedfs.name" . }}
++        secret.reloader.stakater.com/reload: "{{ $name }}-ca-cert,{{ $name }}-master-cert,{{ $name }}-volume-cert,{{ $name }}-filer-cert,{{ $name }}-client-cert"
++      {{- end }}
+       {{- if .Values.filer.s3.existingConfigSecret }}
+         {{- $configSecret := (lookup "v1" "Secret" .Release.Namespace .Values.filer.s3.existingConfigSecret) | default dict }}
+         checksum/s3config: {{ $configSecret | toYaml | sha256sum }}
+diff --git a/packages/system/seaweedfs/charts/seaweedfs/templates/volume/volume-statefulset.yaml b/packages/system/seaweedfs/charts/seaweedfs/templates/volume/volume-statefulset.yaml
+--- a/packages/system/seaweedfs/charts/seaweedfs/templates/volume/volume-statefulset.yaml
++++ b/packages/system/seaweedfs/charts/seaweedfs/templates/volume/volume-statefulset.yaml
+@@ -48,6 +48,10 @@ spec:
+       {{- with $volume.podAnnotations }}
+       {{- toYaml . | nindent 8 }}
+       {{- end }}
++      {{- if $.Values.global.enableSecurity }}
++        {{- $name := include "seaweedfs.name" $ }}
++        secret.reloader.stakater.com/reload: "{{ $name }}-ca-cert,{{ $name }}-master-cert,{{ $name }}-volume-cert,{{ $name }}-filer-cert,{{ $name }}-client-cert"
++      {{- end }}
+     spec:
+       {{- if $volume.affinity }}
+       affinity:
+diff --git a/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml b/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
+--- a/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
++++ b/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
+@@ -40,6 +40,10 @@ spec:
+       {{- with .Values.s3.podAnnotations }}
+       {{- toYaml . | nindent 8 }}
+       {{- end }}
++      {{- if .Values.global.enableSecurity }}
++        {{- $name := include "seaweedfs.name" . }}
++        secret.reloader.stakater.com/reload: "{{ $name }}-ca-cert,{{ $name }}-master-cert,{{ $name }}-volume-cert,{{ $name }}-filer-cert,{{ $name }}-client-cert"
++      {{- end }}
+     spec:
+       restartPolicy: {{ default .Values.global.restartPolicy .Values.s3.restartPolicy }}
+       {{- if .Values.s3.affinity }}
+diff --git a/packages/system/seaweedfs/charts/seaweedfs/templates/admin/admin-statefulset.yaml b/packages/system/seaweedfs/charts/seaweedfs/templates/admin/admin-statefulset.yaml
+--- a/packages/system/seaweedfs/charts/seaweedfs/templates/admin/admin-statefulset.yaml
++++ b/packages/system/seaweedfs/charts/seaweedfs/templates/admin/admin-statefulset.yaml
+@@ -45,6 +45,10 @@ spec:
+       {{- with .Values.admin.podAnnotations }}
+       {{- toYaml . | nindent 8 }}
+       {{- end }}
++      {{- if .Values.global.enableSecurity }}
++        {{- $name := include "seaweedfs.name" . }}
++        secret.reloader.stakater.com/reload: "{{ $name }}-ca-cert,{{ $name }}-master-cert,{{ $name }}-volume-cert,{{ $name }}-filer-cert,{{ $name }}-client-cert"
++      {{- end }}
+     spec:
+       restartPolicy: {{ default .Values.global.restartPolicy .Values.admin.restartPolicy }}
+       {{- if .Values.admin.affinity }}
+diff --git a/packages/system/seaweedfs/charts/seaweedfs/templates/worker/worker-deployment.yaml b/packages/system/seaweedfs/charts/seaweedfs/templates/worker/worker-deployment.yaml
+--- a/packages/system/seaweedfs/charts/seaweedfs/templates/worker/worker-deployment.yaml
++++ b/packages/system/seaweedfs/charts/seaweedfs/templates/worker/worker-deployment.yaml
+@@ -43,6 +43,10 @@ spec:
+       {{- with .Values.worker.podAnnotations }}
+       {{- toYaml . | nindent 8 }}
+       {{- end }}
++      {{- if .Values.global.enableSecurity }}
++        {{- $name := include "seaweedfs.name" . }}
++        secret.reloader.stakater.com/reload: "{{ $name }}-ca-cert,{{ $name }}-master-cert,{{ $name }}-volume-cert,{{ $name }}-filer-cert,{{ $name }}-client-cert"
++      {{- end }}
+     spec:
+       restartPolicy: {{ default .Values.global.restartPolicy .Values.worker.restartPolicy }}
+       {{- if .Values.worker.affinity }}


### PR DESCRIPTION
## Summary
- Fix certificate expiration issue in SeaweedFS when TLS is enabled
- Add `secret.reloader.stakater.com/reload` annotation to trigger pod restart on certificate renewal
- Affects master, filer, volume, s3, admin, worker components

## Test plan
- [ ] Deploy SeaweedFS with `global.enableSecurity=true`
- [ ] Verify annotation is present on pod templates
- [ ] Verify pods restart when certificate secrets are updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic certificate reload support for SeaweedFS deployments when security is enabled. Certificates are now automatically refreshed on updates without requiring manual pod restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->