### PR TITLE
[tenant] fix: allow egress to vlogs in parent tenants

### DIFF
--- a/packages/apps/tenant/templates/networkpolicy.yaml
+++ b/packages/apps/tenant/templates/networkpolicy.yaml
@@ -46,13 +46,20 @@ spec:
     {{- $parts := splitList "-" .Release.Namespace }}
     {{- range $i, $v := $parts }}
     {{- if ne $i 0 }}
-    - matchLabels:
-        "k8s:app.kubernetes.io/name": "vminsert"
-        "k8s:io.kubernetes.pod.namespace": {{ join "-" (slice $parts 0 (add $i 1)) }}
+    - matchExpressions:
+      - key: "k8s:io.kubernetes.pod.namespace"
+        operator: "In"
+        values:
+        - {{ join "-" (slice $parts 0 (add $i 1)) | quote }}
+      - key: "k8s:app.kubernetes.io/name"
+        operator: "In"
+        values:
+        - "vminsert"
+        - "vlogs"
     {{- end }}
     {{- end }}
     {{- end }}
-  {{- end }}    
+  {{- end }}
   {{- if ne (include "tenant.name" .) "tenant-root" }}
   - toEndpoints:
     {{- if hasPrefix "tenant-" .Release.Namespace }}


### PR DESCRIPTION
## What this PR does

Adds `vlogs` to the tenant egress `CiliumClusterwideNetworkPolicy`, mirroring the existing `vminsert` rule.

Currently, nested Kubernetes clusters can send metrics to parent cluster's `vminsert` (explicitly allowed), but logs to `vlogs` are blocked by Cilium because there's no matching egress rule.

This causes Fluent Bit connection timeouts:
```
[error] [upstream] connection to tcp://10.43.81.27:9428 timed out
[error] [output:http:http.0] no upstream connections available to vlogs-generic.tenant-root.svc:9428
```

Fixes #1970

### Release note

```release-note
[tenant] Fixed log collection from nested Kubernetes clusters by allowing egress traffic to VLogs in parent tenants.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated network policy to support dynamic namespace matching for multi-tenant deployments.
  * Switched to expression-based label matching to allow multiple namespace prefixes.
  * Extended app matching to include both "vminsert" and "vlogs" workloads.
  * Adjusted conditional markers to preserve existing policy structure while enabling the new logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->