### PR TITLE
fix(bootbox): auto-create bootbox-application as dependency

### DIFF
--- a/packages/core/platform/sources/bootbox-application.yaml
+++ b/packages/core/platform/sources/bootbox-application.yaml
@@ -17,11 +17,6 @@ spec:
         - name: cozy-lib
           path: library/cozy-lib
       components:
-        - name: bootbox-system
-          path: system/bootbox
-          install:
-            releaseName: bootbox-application
-            namespace: cozy-system
         - name: bootbox
           path: extra/bootbox
           libraries: ["cozy-lib"]

--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -149,7 +149,10 @@
 {{include "cozystack.platform.package.optional.default" (list "cozystack.telepresence" $) }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.external-dns" $) }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.external-secrets-operator" $) }}
-{{include "cozystack.platform.package.optional.default" (list "cozystack.bootbox" $) }}
+{{- if has "cozystack.bootbox" (default (list) .Values.bundles.enabledPackages) }}
+{{include "cozystack.platform.package.default" (list "cozystack.bootbox-application" $) }}
+{{include "cozystack.platform.package.default" (list "cozystack.bootbox" $) }}
+{{- end }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.hetzner-robotlb" $) }}
 
 {{- end }}


### PR DESCRIPTION
## Summary
- Remove duplicate `bootbox-system` component from `bootbox-application` PackageSource (was duplicating system/bootbox installation)
- Auto-create `cozystack.bootbox-application` Package when bootbox is enabled in `bundles.enabledPackages`
- This ensures `bootbox-rd` (ApplicationDefinition) is properly installed as a dependency before `cozystack.bootbox`

## Test plan
- [ ] Enable bootbox in `bundles.enabledPackages`
- [ ] Verify both `cozystack.bootbox-application` and `cozystack.bootbox` Packages are created
- [ ] Verify `bootbox-rd` (ApplicationDefinition) is installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bootbox installation process to be optional and configurable. Bootbox is no longer automatically installed by default and must now be explicitly enabled through configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->