### PR TITLE
fix(migrations): add migration 25 for v1.0 upgrade cleanup

### DIFF
--- a/hack/migrate-to-version-1.0.sh
+++ b/hack/migrate-to-version-1.0.sh
@@ -94,7 +94,7 @@ else
 fi
 
 # Extract scheduling if available
-SCHEDULING_CONSTRAINTS=$(echo "$SCHEDULING_CM" | jq -r '.data.["globalAppTopologySpreadConstraints"] // ""')
+SCHEDULING_CONSTRAINTS=$(echo "$SCHEDULING_CM" | jq -r '.data["globalAppTopologySpreadConstraints"] // ""')
 if [ -z "$SCHEDULING_CONSTRAINTS" ]; then
     SCHEDULING_CONSTRAINTS='""'
 else

--- a/packages/core/platform/images/migrations/migrations/23
+++ b/packages/core/platform/images/migrations/migrations/23
@@ -6,10 +6,6 @@ set -euo pipefail
 # Remove old cozystack-resource-definition-crd HelmRelease (renamed to application-definition-crd)
 kubectl delete hr -n cozy-system cozystack-resource-definition-crd --ignore-not-found
 
-# Remove legacy installer components
-kubectl delete deploy cozystack -n cozy-system --ignore-not-found
-kubectl delete sts cozystack-assets -n cozy-system --ignore-not-found
-
 # Stamp version
 kubectl create configmap -n cozy-system cozystack-version \
   --from-literal=version=24 --dry-run=client -o yaml | kubectl apply -f-

--- a/packages/core/platform/images/migrations/migrations/25
+++ b/packages/core/platform/images/migrations/migrations/25
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Migration 25 --> 26
+# Remove legacy installer components during upgrade to v1.0
+
+set -euo pipefail
+
+echo "Removing legacy installer components..."
+
+# Delete old cozystack installer deployment
+kubectl delete deploy cozystack -n cozy-system --ignore-not-found
+
+# Delete old cozystack-assets statefulset
+kubectl delete sts cozystack-assets -n cozy-system --ignore-not-found
+
+# Delete old bootbox HelmReleases (will be recreated by new platform chart if enabled)
+kubectl delete hr bootbox -n cozy-system --ignore-not-found
+kubectl delete hr bootbox-rd -n cozy-system --ignore-not-found
+
+echo "Legacy cleanup completed"
+
+# Stamp version
+kubectl create configmap -n cozy-system cozystack-version \
+  --from-literal=version=26 --dry-run=client -o yaml | kubectl apply -f-

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -5,8 +5,8 @@ sourceRef:
   path: /
 migrations:
   enabled: false
-  image: ghcr.io/cozystack/cozystack/platform-migrations:latest
-  targetVersion: 24
+  image: ghcr.io/cozystack/cozystack/platform-migrations:latest@sha256:24507a6004ac46e6690327e9063a7b73b87e60d5c740ec680bffa1d0895ab4c8
+  targetVersion: 26
 # Bundle deployment configuration
 bundles:
   system:


### PR DESCRIPTION
## Summary
- Add migration 25 for v1.0 upgrade cleanup:
  - Remove legacy `cozystack` installer deployment
  - Remove legacy `cozystack-assets` statefulset
  - Remove `bootbox` and `bootbox-rd` HelmReleases (will be recreated by new platform chart if enabled)
- Revert migration 23 to original state (only removes cozystack-resource-definition-crd)
- Update targetVersion from 24 to 26
- Fix jq syntax error in `hack/migrate-to-version-1.0.sh`

Migration 23 was already executed on existing clusters at version 23+, so adding cleanup there would never run. The new migration 25 ensures proper cleanup during v1.0 upgrade.

## Test plan
- [ ] Upgrade from v0.4x to v1.0
- [ ] Verify old `cozystack` deployment is deleted
- [ ] Verify old `cozystack-assets` statefulset is deleted
- [ ] Verify old `bootbox` and `bootbox-rd` HelmReleases are deleted
- [ ] Verify platform installs successfully after migration
- [ ] Run `./hack/migrate-to-version-1.0.sh` without jq errors