### PR TITLE
fix(build): fix platform migrations image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ build: build-deps
 	make -C packages/system/grafana-operator image
 	make -C packages/core/testing image
 	make -C packages/core/talos image
+	make -C packages/core/platform image
 	make -C packages/core/installer image
 	make manifests
 

--- a/packages/core/platform/Makefile
+++ b/packages/core/platform/Makefile
@@ -18,12 +18,12 @@ diff:
 image: image-migrations
 
 image-migrations:
-	docker buildx build --file images/migrations/Dockerfile . \
+	docker buildx build images/migrations \
 		--tag $(REGISTRY)/platform-migrations:$(call settag,$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/platform-migrations:latest \
 		--cache-to type=inline \
 		--metadata-file images/migrations.json \
 		$(BUILDX_ARGS)
-	IMAGE="$(REGISTRY)/platform-migrations:$(call settag,$(TAG))@$$(yq --exit-status '.["containerimage.digest"]' images/migrations.json --output-format json --raw-output)" \
+	IMAGE="$(REGISTRY)/platform-migrations:$(call settag,$(TAG))@$$(yq -e -o json -r '.["containerimage.digest"]' images/migrations.json)" \
 		yq --inplace '.migrations.image = strenv(IMAGE)' values.yaml
 	rm -f images/migrations.json


### PR DESCRIPTION
## Summary
- Fix docker build context for migrations image (was using wrong context path)
- Fix yq flags for compatibility with Mike Farah's yq v4 (`-r` instead of `--raw-output`)
- Add platform image to main build target

## Test plan
- [ ] Run `make -C packages/core/platform image`
- [ ] Verify migrations image builds successfully
- [ ] Verify values.yaml is updated with correct image digest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline to include additional image build step
  * Improved Docker build process with optimized context handling and updated tooling flags

<!-- end of auto-generated comment: release notes by coderabbit.ai -->