### PR TITLE
fix(postgres-operator): correct PromQL syntax in CNPGClusterOffline alert

### DIFF
--- a/packages/system/postgres-operator/alerts/cnpg-default-alerts.yaml
+++ b/packages/system/postgres-operator/alerts/cnpg-default-alerts.yaml
@@ -92,7 +92,7 @@ spec:
           potential service disruption and/or data loss.
         runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterOffline.md
       expr: |
-        sum by (namespace, pod) (cnpg_collector_up)) OR on() vector(0) == 0
+        (sum by (namespace, pod) (cnpg_collector_up) OR on() vector(0)) == 0
       for: 5m
       labels:
         severity: critical


### PR DESCRIPTION
## Summary
- Fix invalid PromQL expression in `CNPGClusterOffline` alert rule that causes vmalert pods to crash
- Fix PromQL logic so the alert fires correctly when cluster is offline

## Problem
The `CNPGClusterOffline` alert in `packages/system/postgres-operator/alerts/cnpg-default-alerts.yaml` had two issues:

1. **Syntax error** - Extra closing parenthesis causing vmalert pods to crash:
```promql
sum by (namespace, pod) (cnpg_collector_up)) OR on() vector(0) == 0
                                           ^^-- extra )
```

2. **Logic error** - After removing the extra parenthesis, the expression still had incorrect logic:
```promql
sum by (namespace, pod) (cnpg_collector_up) OR on() vector(0) == 0
```
This evaluates as `cnpg_collector_up OR (vector(0) == 0)` which fires when the cluster is **online** (wrong behavior).

## Solution
Fix both issues by properly wrapping the OR expression in parentheses:
```promql
(sum by (namespace, pod) (cnpg_collector_up) OR on() vector(0)) == 0
```

This correctly fires when `cnpg_collector_up` is 0 or absent (cluster actually offline).

## Test plan
- [ ] Verify vmalert pods start successfully after applying the fix
- [ ] Verify the alert rule is properly loaded
- [ ] Verify alert only fires when CNPG cluster is actually offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)