### PR TITLE
fix(seaweedfs): Increase certificate duration to 10 years

### DIFF
--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -183,8 +183,8 @@ seaweedfs:
     ipAddresses: []
     keyAlgorithm: RSA
     keySize: 2048
-    duration: 2160h # 90d
-    renewBefore: 360h # 15d
+    duration: 87600h # 10 years
+    renewBefore: 720h # 30d
 db:
   replicas: 2
   size: 10Gi


### PR DESCRIPTION
## Summary
- Increase TLS certificate duration from 90 days to 10 years
- Adjust renewBefore from 15 to 30 days
- Prevents certificate expiration issues in SeaweedFS

## Test plan
- [ ] Deploy SeaweedFS with `global.enableSecurity=true`
- [ ] Verify certificates are issued with 10 year duration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated certificate configuration for extended validity and renewal periods, allowing certificates to remain valid for 10 years with a 30-day renewal buffer before expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->