### PR TITLE
[dashboard] Add startupProbe to prevent container restarts on slow hardware

### DIFF
--- a/packages/system/dashboard/templates/web.yaml
+++ b/packages/system/dashboard/templates/web.yaml
@@ -63,6 +63,13 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 2
+          startupProbe:
+            httpGet:
+              path: /healthcheck
+              port: 64231
+              scheme: HTTP
+            failureThreshold: 30
+            periodSeconds: 2
           name: bff
           ports:
             - containerPort: 64231
@@ -183,6 +190,13 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 2
+          startupProbe:
+            httpGet:
+              path: /healthcheck
+              port: 8080
+              scheme: HTTP
+            failureThreshold: 30
+            periodSeconds: 2
           name: web
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## What this PR does

Adds `startupProbe` to both `bff` and `web` containers in the dashboard deployment. On slow hardware, kubelet kills containers because the `livenessProbe` only allows ~33 seconds for startup. The `startupProbe` gives containers up to 60 seconds to start before `livenessProbe` kicks in.

### Release note

```release-note
[dashboard] Add startupProbe to bff and web containers to prevent restarts on slow hardware
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added health monitoring during service startup for core application services. Services now perform health checks to verify proper initialization and readiness before handling requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->