### PR TITLE
feat(kubernetes): auto-enable Gateway API support in cert-manager

### DIFF
--- a/packages/apps/kubernetes/templates/helmreleases/cert-manager.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/cert-manager.yaml
@@ -1,3 +1,13 @@
+{{- define "cozystack.defaultCertManagerValues" -}}
+{{- if $.Values.addons.gatewayAPI.enabled }}
+cert-manager:
+  config:
+    apiVersion: controller.config.cert-manager.io/v1alpha1
+    kind: ControllerConfiguration
+    enableGatewayAPI: true
+{{- end }}
+{{- end }}
+
 {{- if .Values.addons.certManager.enabled }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -29,11 +39,8 @@ spec:
     force: true
     remediation:
       retries: -1
-  {{- with .Values.addons.certManager.valuesOverride }}
   values:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-
+    {{- toYaml (deepCopy .Values.addons.certManager.valuesOverride | mergeOverwrite (fromYaml (include "cozystack.defaultCertManagerValues" .))) | nindent 4 }}
   dependsOn:
   {{- if lookup "helm.toolkit.fluxcd.io/v2" "HelmRelease" .Release.Namespace .Release.Name }}
   - name: {{ .Release.Name }}


### PR DESCRIPTION
## Summary
- Automatically enable `enableGatewayAPI` in cert-manager when the Gateway API addon is enabled
- Uses the same `define` + `mergeOverwrite` pattern as Cilium for consistency
- User can still override via `valuesOverride`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved certificate manager configuration handling by enhancing the integration of default settings with custom user overrides in Kubernetes deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->