### PR TITLE
[ci] Choose runner conditional on label

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -153,7 +153,7 @@ jobs:
 
   e2e:
     name: "E2E Tests"
-    runs-on: [oracle-vm-24cpu-96gb-x86-64]
+    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'debug') && 'self-hosted' || 'oracle-vm-24cpu-96gb-x86-64' }}
     #runs-on: [oracle-vm-32cpu-128gb-x86-64]
     permissions:
       contents: read


### PR DESCRIPTION
## What this PR does

This patch adds a conditional for running on a statically defined VM the maintainers have SSH access to if the pull request has a `debug` label. This is useful for debugging failing workflows when the diagnostic info from the pipeline is insufficient.

### Release note

```release-note
[ci] Run builds on a static VM with SSH access if the PR has a debug
label.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains no user-facing changes. Internal workflow adjustments have been made to optimize development infrastructure.

* **Chores**
  * Updated CI/CD pipeline configuration for improved test execution efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->