### PR TITLE
[tenant,rbac] Use shared clusterroles

### DIFF
--- a/hack/e2e-apps/mongodb.bats
+++ b/hack/e2e-apps/mongodb.bats
@@ -13,7 +13,7 @@ spec:
   size: 10Gi
   replicas: 1
   storageClass: ""
-  resourcesPreset: "nano"
+  resourcesPreset: "small"
   users:
     testuser:
       password: xai7Wepo

--- a/packages/apps/tenant/templates/tenant.yaml
+++ b/packages/apps/tenant/templates/tenant.yaml
@@ -5,38 +5,6 @@ metadata:
   name: {{ include "tenant.name" . }}
   namespace: {{ include "tenant.name" . }}
 ---
-# == default role ==
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ include "tenant.name" . }}
-  namespace: {{ include "tenant.name" . }}
-rules:
-- apiGroups: [""]
-  resources: ["pods", "services", "persistentvolumes", "endpoints", "events", "resourcequotas"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["networking.k8s.io"]
-  resources: ["ingresses"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["roles"]
-  verbs: ["get"]
-- apiGroups: ["apps.cozystack.io"]
-  resources: ['*']
-  verbs: ['*']
-- apiGroups:
-  - cozystack.io
-  resources:
-  - workloadmonitors
-  - workloads
-  verbs: ["get", "list", "watch"]
-- apiGroups:
-  - core.cozystack.io
-  resources:
-  - tenantmodules
-  - tenantsecrets
-  verbs: ["get", "list", "watch"]
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -62,60 +30,11 @@ subjects:
   name: {{ include "tenant.name" . }}
   namespace: {{ include "tenant.name" . }}
 roleRef:
-  kind: Role
-  name: {{ include "tenant.name" . }}
+  kind: ClusterRole
+  name: cozy-tenant
   apiGroup: rbac.authorization.k8s.io
 ---
-# == view role ==
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ include "tenant.name" . }}-view
-  namespace: {{ include "tenant.name" . }}
-rules:
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - roles
-    verbs:
-      - get
-  - apiGroups:
-      - apps.cozystack.io
-    resources:
-      - "*"
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - services
-      - persistentvolumes
-      - endpoints
-      - events
-      - resourcequotas
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-    - cozystack.io
-    resources:
-    - workloadmonitors
-    - workloads
-    verbs: ["get", "list", "watch"]
----
+# == view role binding ==
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -124,76 +43,11 @@ metadata:
 subjects:
 {{ include "cozy-lib.rbac.subjectsForTenantAndAccessLevel" (list "view" (include "tenant.name" .)) | nindent 2 }}
 roleRef:
-  kind: Role
-  name: {{ include "tenant.name" . }}-view
+  kind: ClusterRole
+  name: cozy-tenant-view
   apiGroup: rbac.authorization.k8s.io
-
 ---
-# == use role ==
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ include "tenant.name" . }}-use
-  namespace: {{ include "tenant.name" . }}
-rules:
-  - apiGroups: [rbac.authorization.k8s.io]
-    resources:
-    - roles
-    verbs:
-    - get
-  - apiGroups: ["apps.cozystack.io"]
-    resources:
-    - "*"
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups: [""]
-    resources:
-      - pods
-      - services
-      - persistentvolumes
-      - endpoints
-      - events
-      - resourcequotas
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups: ["networking.k8s.io"]
-    resources:
-    - ingresses
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups: ["subresources.kubevirt.io"]
-    resources:
-    - virtualmachineinstances/console
-    - virtualmachineinstances/vnc
-    verbs:
-    - get
-    - list
-  - apiGroups: ["subresources.kubevirt.io"]
-    resources:
-      - virtualmachineinstances/portforward
-    verbs:
-      - get
-      - update
-  - apiGroups:
-    - cozystack.io
-    resources:
-    - workloadmonitors
-    - workloads
-    verbs: ["get", "list", "watch"]
-  - apiGroups:
-    - core.cozystack.io
-    resources:
-    - tenantmodules
-    - tenantsecrets
-    verbs: ["get", "list", "watch"]
----
+# == use role binding ==
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -202,97 +56,11 @@ metadata:
 subjects:
 {{ include "cozy-lib.rbac.subjectsForTenantAndAccessLevel" (list "use" (include "tenant.name" .)) | nindent 2 }}
 roleRef:
-  kind: Role
-  name: {{ include "tenant.name" . }}-use
+  kind: ClusterRole
+  name: cozy-tenant-use
   apiGroup: rbac.authorization.k8s.io
 ---
-# == admin role ==
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ include "tenant.name" . }}-admin
-  namespace: {{ include "tenant.name" . }}
-rules:
-  - apiGroups: [rbac.authorization.k8s.io]
-    resources:
-    - roles
-    verbs:
-    - get
-  - apiGroups: [""]
-    resources:
-      - pods
-      - services
-      - persistentvolumes
-      - endpoints
-      - events
-      - resourcequotas
-    verbs:
-    - get
-    - list
-    - watch
-    - delete
-  - apiGroups: ["kubevirt.io"]
-    resources:
-    - virtualmachines
-    verbs:
-    - get
-    - list
-  - apiGroups: ["subresources.kubevirt.io"]
-    resources:
-    - virtualmachineinstances/console
-    - virtualmachineinstances/vnc
-    verbs:
-    - get
-    - list
-  - apiGroups: ["subresources.kubevirt.io"]
-    resources:
-      - virtualmachineinstances/portforward
-    verbs:
-      - get
-      - update
-  - apiGroups: ["apps.cozystack.io"]
-    resources:
-    - buckets
-    - clickhouses
-    - ferretdb
-    - foos
-    - httpcaches
-    - kafkas
-    - kuberneteses
-    - mysqls
-    - natses
-    - postgreses
-    - rabbitmqs
-    - redises
-    - seaweedfses
-    - tcpbalancers
-    - virtualmachines
-    - vmdisks
-    - vminstances
-    - infos
-    - virtualprivateclouds
-    verbs:
-    - get
-    - list
-    - watch
-    - create
-    - update
-    - patch
-    - delete
-  - apiGroups:
-    - cozystack.io
-    resources:
-    - workloadmonitors
-    - workloads
-    verbs: ["get", "list", "watch"]
-  - apiGroups:
-    - core.cozystack.io
-    resources:
-    - tenantmodules
-    - tenantsecrets
-    verbs: ["get", "list", "watch"]
----
+# == admin role binding ==
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -301,72 +69,11 @@ metadata:
 subjects:
 {{ include "cozy-lib.rbac.subjectsForTenantAndAccessLevel" (list "admin" (include "tenant.name" .)) | nindent 2 }}
 roleRef:
-  kind: Role
-  name: {{ include "tenant.name" . }}-admin
+  kind: ClusterRole
+  name: cozy-tenant-admin
   apiGroup: rbac.authorization.k8s.io
 ---
-# == super admin role ==
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ include "tenant.name" . }}-super-admin
-  namespace: {{ include "tenant.name" . }}
-rules:
-  - apiGroups: [rbac.authorization.k8s.io]
-    resources:
-    - roles
-    verbs:
-    - get
-  - apiGroups: [""]
-    resources:
-      - pods
-      - services
-      - persistentvolumes
-      - endpoints
-      - events
-      - resourcequotas
-    verbs:
-    - get
-    - list
-    - watch
-    - delete
-  - apiGroups: ["kubevirt.io"]
-    resources:
-    - virtualmachines
-    verbs:
-    - '*'
-  - apiGroups: ["subresources.kubevirt.io"]
-    resources:
-    - virtualmachineinstances/console
-    - virtualmachineinstances/vnc
-    verbs:
-    - get
-    - list
-  - apiGroups: ["subresources.kubevirt.io"]
-    resources:
-      - virtualmachineinstances/portforward
-    verbs:
-      - get
-      - update
-  - apiGroups: ["apps.cozystack.io"]
-    resources:
-    - '*'
-    verbs:
-    - '*'
-  - apiGroups:
-    - cozystack.io
-    resources:
-    - workloadmonitors
-    - workloads
-    verbs: ["get", "list", "watch"]
-  - apiGroups:
-    - core.cozystack.io
-    resources:
-    - tenantmodules
-    - tenantsecrets
-    verbs: ["get", "list", "watch"]
----
+# == super admin role binding ==
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -375,25 +82,11 @@ metadata:
 subjects:
 {{ include "cozy-lib.rbac.subjectsForTenantAndAccessLevel" (list "super-admin" (include "tenant.name" .) ) | nindent 2 }}
 roleRef:
-  kind: Role
-  name: {{ include "tenant.name" . }}-super-admin
+  kind: ClusterRole
+  name: cozy-tenant-super-admin
   apiGroup: rbac.authorization.k8s.io
 ---
-# == dashboard role ==
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ include "tenant.name" . }}
-  namespace: cozy-public
-rules:
-- apiGroups: ["source.toolkit.fluxcd.io"]
-  resources: ["helmrepositories"]
-  verbs: ["get", "list"]
-- apiGroups: ["source.toolkit.fluxcd.io"]
-  resources: ["helmcharts"]
-  verbs: ["get", "list"]
----
+# == dashboard role binding ==
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -417,5 +110,5 @@ subjects:
   namespace: {{ include "tenant.name" . }}
 roleRef:
   kind: Role
-  name: {{ include "tenant.name" . }}
+  name: cozy-tenant-dashboard
   apiGroup: rbac.authorization.k8s.io

--- a/packages/system/cozystack-basics/templates/clusterroles.yaml
+++ b/packages/system/cozystack-basics/templates/clusterroles.yaml
@@ -1,0 +1,248 @@
+---
+# == default cluster role ==
+# Used by tenant ServiceAccounts
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cozy-tenant
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.cozystack.io/aggregate-to-tenant: "true"
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cozy-tenant-base
+  labels:
+    rbac.cozystack.io/aggregate-to-tenant: "true"
+rules:
+- apiGroups: [""]
+  resources: ["pods", "services", "persistentvolumes", "endpoints", "events", "resourcequotas"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles"]
+  verbs: ["get"]
+- apiGroups: ["apps.cozystack.io"]
+  resources: ['*']
+  verbs: ['*']
+- apiGroups:
+  - cozystack.io
+  resources:
+  - workloadmonitors
+  - workloads
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - core.cozystack.io
+  resources:
+  - tenantmodules
+  - tenantsecrets
+  verbs: ["get", "list", "watch"]
+---
+# == view cluster role ==
+# Aggregates all roles labeled for view access
+# Also aggregated into use, admin, and super-admin
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cozy-tenant-view
+  labels:
+    rbac.cozystack.io/aggregate-to-tenant-use: "true"
+    rbac.cozystack.io/aggregate-to-tenant-admin: "true"
+    rbac.cozystack.io/aggregate-to-tenant-super-admin: "true"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.cozystack.io/aggregate-to-tenant-view: "true"
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cozy-tenant-view-base
+  labels:
+    rbac.cozystack.io/aggregate-to-tenant-view: "true"
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - get
+- apiGroups:
+  - apps.cozystack.io
+  resources:
+  - "*"
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - persistentvolumes
+  - endpoints
+  - events
+  - resourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cozystack.io
+  resources:
+  - workloadmonitors
+  - workloads
+  verbs: ["get", "list", "watch"]
+---
+# == use cluster role ==
+# Aggregates view + all roles labeled for use access
+# Also aggregated into admin and super-admin
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cozy-tenant-use
+  labels:
+    rbac.cozystack.io/aggregate-to-tenant-admin: "true"
+    rbac.cozystack.io/aggregate-to-tenant-super-admin: "true"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.cozystack.io/aggregate-to-tenant-use: "true"
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cozy-tenant-use-base
+  labels:
+    rbac.cozystack.io/aggregate-to-tenant-use: "true"
+rules:
+- apiGroups: ["subresources.kubevirt.io"]
+  resources:
+  - virtualmachineinstances/console
+  - virtualmachineinstances/vnc
+  verbs:
+  - get
+  - list
+- apiGroups: ["subresources.kubevirt.io"]
+  resources:
+  - virtualmachineinstances/portforward
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - core.cozystack.io
+  resources:
+  - tenantmodules
+  - tenantsecrets
+  verbs: ["get", "list", "watch"]
+---
+# == admin cluster role ==
+# Aggregates use + all roles labeled for admin access
+# Also aggregated into super-admin
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cozy-tenant-admin
+  labels:
+    rbac.cozystack.io/aggregate-to-tenant-super-admin: "true"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.cozystack.io/aggregate-to-tenant-admin: "true"
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cozy-tenant-admin-base
+  labels:
+    rbac.cozystack.io/aggregate-to-tenant-admin: "true"
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  - services
+  - persistentvolumes
+  - endpoints
+  - events
+  - resourcequotas
+  verbs:
+  - delete
+- apiGroups: ["kubevirt.io"]
+  resources:
+  - virtualmachines
+  verbs:
+  - get
+  - list
+- apiGroups: ["apps.cozystack.io"]
+  resources:
+  - buckets
+  - clickhouses
+  - ferretdb
+  - foos
+  - httpcaches
+  - kafkas
+  - kuberneteses
+  - mysqls
+  - natses
+  - postgreses
+  - rabbitmqs
+  - redises
+  - seaweedfses
+  - tcpbalancers
+  - virtualmachines
+  - vmdisks
+  - vminstances
+  - infos
+  - virtualprivateclouds
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+---
+# == super admin cluster role ==
+# Aggregates admin + all roles labeled for super-admin access
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cozy-tenant-super-admin
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.cozystack.io/aggregate-to-tenant-super-admin: "true"
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cozy-tenant-super-admin-base
+  labels:
+    rbac.cozystack.io/aggregate-to-tenant-super-admin: "true"
+rules:
+- apiGroups: ["kubevirt.io"]
+  resources:
+  - virtualmachines
+  verbs:
+  - '*'
+- apiGroups: ["apps.cozystack.io"]
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/packages/system/cozystack-basics/templates/dashboard-role.yaml
+++ b/packages/system/cozystack-basics/templates/dashboard-role.yaml
@@ -1,0 +1,15 @@
+---
+# == dashboard role ==
+# Single namespaced role for tenant dashboard access to helm resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cozy-tenant-dashboard
+  namespace: cozy-public
+rules:
+- apiGroups: ["source.toolkit.fluxcd.io"]
+  resources: ["helmrepositories"]
+  verbs: ["get", "list"]
+- apiGroups: ["source.toolkit.fluxcd.io"]
+  resources: ["helmcharts"]
+  verbs: ["get", "list"]


### PR DESCRIPTION
## What this PR does

Previously a namespaced role was created per tenant and access level. Since these roles are all identical, it's sufficient to create a cluster role per access level and just create namespaced rolebindings to these cluster roles per tenant. This will enable aggregation rules. E.g. if a new API group is installed, such as backups.cozystack.io, a new clusterrole can be created for managing this API group with a label like rbac.cozystack.io/aggregate-to-admin. Smart use of aggregation rules will enable automatic granting of access rights not just to admin, but to super-admin too, and there will be no need to update every single tenant.

### Release note

```release-note
[tenant,rbac] Use ClusterRoles with aggregationRules instead of roles
per every tenant.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Converted namespace-scoped roles to cluster-scoped roles for improved access management across the platform.
  * Reorganized role hierarchy using aggregation rules for simplified permission management.

* **New Features**
  * Added dashboard-specific role with permissions for Helm repository and chart access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->