### PR TITLE
[cozystack-operator] add secret replication controller for docker auth

### DIFF
--- a/internal/cozyvaluesreplicator/cozyvaluesreplicator.go
+++ b/internal/cozyvaluesreplicator/cozyvaluesreplicator.go
@@ -41,6 +41,10 @@ type SecretReplicatorReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 
+	// ControllerName is the unique name for this controller instance.
+	// Required when multiple SecretReplicatorReconciler instances are registered.
+	ControllerName string
+
 	// Source of truth:
 	SourceNamespace string
 	SecretName      string
@@ -140,7 +144,13 @@ func (r *SecretReplicatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		GenericFunc: func(event.GenericEvent) bool { return false },
 	}
 
+	name := r.ControllerName
+	if name == "" {
+		name = "secret-replicator"
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
+		Named(name).
 		// (b) Watch all Secrets with the chosen name; this also ensures Secret objects are cached.
 		For(&corev1.Secret{}, builder.WithPredicates(secretNameOnly)).
 


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Add `SecretReplicationController` for Docker auth secret to replicate and sync docker auth secret to selected namespaces

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[cozystack-operator] add secret replication controller for docker auth
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Three new CLI flags let operators specify a Docker config secret name, its source namespace, and a label selector to target destination namespaces.
  * When a secret name is provided, the operator will replicate that Docker config secret into namespaces matching the selector, with logging for setup or parsing errors.
  * Replicator controllers are now named per-instance for clearer observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->