### PR TITLE
fix(monitoring): add missing dashboards template to extra/monitoring

### DIFF
--- a/packages/extra/monitoring/templates/dashboards.yaml
+++ b/packages/extra/monitoring/templates/dashboards.yaml
@@ -1,0 +1,16 @@
+{{- range (split "\n" (.Files.Get "dashboards.list")) }}
+{{- $parts := split "/" . }}
+{{- if eq (len $parts) 2 }}
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: {{ $parts._0 }}-{{ $parts._1 }}
+spec:
+  folder: {{ $parts._0 }}
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  url: http://grafana-dashboards.cozy-grafana-operator.svc/{{ . }}.json
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary
- Add missing `dashboards.yaml` template to `packages/extra/monitoring`
- The `dashboards.list` file existed but was unused - no template was creating `GrafanaDashboard` resources from it

## Test plan
- [ ] Deploy extra/monitoring and verify GrafanaDashboard resources are created
- [ ] Verify dashboards appear in Grafana UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic Grafana dashboard provisioning through configuration file templates, enabling streamlined monitoring infrastructure setup from simple dashboard list definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->