### PR TITLE
[backups] Add kubevirt plugin to velero

### DIFF
--- a/packages/system/velero/values.yaml
+++ b/packages/system/velero/values.yaml
@@ -9,6 +9,13 @@ velero:
       volumeMounts:
         - mountPath: /target
           name: plugins
+    - image: quay.io/kubevirt/kubevirt-velero-plugin:v0.8.0
+      name: kubevirt-kubevirt-velero-plugin
+      imagePullPolicy: IfNotPresent
+      volumeMounts:
+      - mountPath: /target
+        name: plugins
+
   deployNodeAgent: true
   configuration:
     # defaultVolumesToFsBackup: true


### PR DESCRIPTION
## What this PR does

This patch installs the kubevirt-velero-plugin, so that backing up a kubevirt resource such as a VMI will automatically include related items, such as datavolumes, and, eventually, all the way down to pods and volumes.

### Release note

```release-note
[backups] Include the kubevirt-velero-plugin with the Velero package.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added KubeVirt plugin integration: Velero now provides comprehensive backup and restore support for KubeVirt-managed virtual machines and associated resources. The plugin is automatically installed and configured during deployment, enabling unified disaster recovery for both containerized applications and virtualized workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->