### PR TITLE
[backups] Create RBAC for backup resources

### DIFF
--- a/packages/system/backup-controller/templates/tenant-clusterroles.yaml
+++ b/packages/system/backup-controller/templates/tenant-clusterroles.yaml
@@ -1,0 +1,44 @@
+---
+# == backup view cluster role ==
+# Aggregated into cozy-tenant-view (and consequently use, admin, super-admin)
+# Provides read-only access to all backup resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cozy:backups:view
+  labels:
+    rbac.cozystack.io/aggregate-to-tenant-view: "true"
+rules:
+- apiGroups: ["backups.cozystack.io"]
+  resources:
+  - plans
+  - backupjobs
+  - restorejobs
+  - backups
+  - backupclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+# == backup admin cluster role ==
+# Aggregated into cozy-tenant-admin (and consequently super-admin)
+# Provides write access to plans, backupjobs, restorejobs
+# Backups and backupclasses remain read-only (inherited from view)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cozy:backups:admin
+  labels:
+    rbac.cozystack.io/aggregate-to-tenant-admin: "true"
+rules:
+- apiGroups: ["backups.cozystack.io"]
+  resources:
+  - plans
+  - backupjobs
+  - restorejobs
+  verbs:
+  - create
+  - update
+  - patch
+  - delete


### PR DESCRIPTION
## What this PR does

This patch adds cluster roles that get deployed with the backup controller and which follow aggregation rules to automatically let users work with resources from the backups.cozystack.io API group as soon as the CRDs and controller are installed.

### Release note

```release-note
[backups] Add RBAC resources to let users work with backups.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two backup-specific roles: a read-only role for backup-related resources and an administrator role with write permissions for backup plans and job operations.

* **Chores**
  * Infrastructure configuration updates to integrate the new backup role definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->