### PR TITLE
[rbac] Use hierarchical naming scheme

### DIFF
--- a/packages/apps/tenant/templates/tenant.yaml
+++ b/packages/apps/tenant/templates/tenant.yaml
@@ -8,7 +8,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "tenant.name" . }}
+  name: cozy:tenant
   namespace: {{ include "tenant.name" . }}
 subjects:
 {{- if ne .Release.Namespace "tenant-root" }}
@@ -31,66 +31,66 @@ subjects:
   namespace: {{ include "tenant.name" . }}
 roleRef:
   kind: ClusterRole
-  name: cozy-tenant
+  name: cozy:tenant
   apiGroup: rbac.authorization.k8s.io
 ---
 # == view role binding ==
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "tenant.name" . }}-view
+  name: cozy:tenant:view
   namespace: {{ include "tenant.name" . }}
 subjects:
 {{ include "cozy-lib.rbac.subjectsForTenantAndAccessLevel" (list "view" (include "tenant.name" .)) | nindent 2 }}
 roleRef:
   kind: ClusterRole
-  name: cozy-tenant-view
+  name: cozy:tenant:view
   apiGroup: rbac.authorization.k8s.io
 ---
 # == use role binding ==
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "tenant.name" . }}-use
+  name: cozy:tenant:use
   namespace: {{ include "tenant.name" . }}
 subjects:
 {{ include "cozy-lib.rbac.subjectsForTenantAndAccessLevel" (list "use" (include "tenant.name" .)) | nindent 2 }}
 roleRef:
   kind: ClusterRole
-  name: cozy-tenant-use
+  name: cozy:tenant:use
   apiGroup: rbac.authorization.k8s.io
 ---
 # == admin role binding ==
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "tenant.name" . }}-admin
+  name: cozy:tenant:admin
   namespace: {{ include "tenant.name" . }}
 subjects:
 {{ include "cozy-lib.rbac.subjectsForTenantAndAccessLevel" (list "admin" (include "tenant.name" .)) | nindent 2 }}
 roleRef:
   kind: ClusterRole
-  name: cozy-tenant-admin
+  name: cozy:tenant:admin
   apiGroup: rbac.authorization.k8s.io
 ---
 # == super admin role binding ==
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "tenant.name" . }}-super-admin
+  name: cozy:tenant:super-admin
   namespace: {{ include "tenant.name" . }}
 subjects:
 {{ include "cozy-lib.rbac.subjectsForTenantAndAccessLevel" (list "super-admin" (include "tenant.name" .) ) | nindent 2 }}
 roleRef:
   kind: ClusterRole
-  name: cozy-tenant-super-admin
+  name: cozy:tenant:super-admin
   apiGroup: rbac.authorization.k8s.io
 ---
 # == dashboard role binding ==
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "tenant.name" . }}
+  name: cozy:{{ include "tenant.name" . }}:dashboard
   namespace: cozy-public
 subjects:
 - kind: Group
@@ -110,5 +110,5 @@ subjects:
   namespace: {{ include "tenant.name" . }}
 roleRef:
   kind: Role
-  name: cozy-tenant-dashboard
+  name: cozy:tenant:dashboard
   apiGroup: rbac.authorization.k8s.io

--- a/packages/system/cozystack-basics/templates/clusterroles.yaml
+++ b/packages/system/cozystack-basics/templates/clusterroles.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cozy-tenant
+  name: cozy:tenant
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -14,7 +14,7 @@ rules: []
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cozy-tenant-base
+  name: cozy:tenant:base
   labels:
     rbac.cozystack.io/aggregate-to-tenant: "true"
 rules:
@@ -49,7 +49,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cozy-tenant-view
+  name: cozy:tenant:view
   labels:
     rbac.cozystack.io/aggregate-to-tenant-use: "true"
     rbac.cozystack.io/aggregate-to-tenant-admin: "true"
@@ -63,7 +63,7 @@ rules: []
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cozy-tenant-view-base
+  name: cozy:tenant:view:base
   labels:
     rbac.cozystack.io/aggregate-to-tenant-view: "true"
 rules:
@@ -115,7 +115,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cozy-tenant-use
+  name: cozy:tenant:use
   labels:
     rbac.cozystack.io/aggregate-to-tenant-admin: "true"
     rbac.cozystack.io/aggregate-to-tenant-super-admin: "true"
@@ -128,7 +128,7 @@ rules: []
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cozy-tenant-use-base
+  name: cozy:tenant:use:base
   labels:
     rbac.cozystack.io/aggregate-to-tenant-use: "true"
 rules:
@@ -158,7 +158,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cozy-tenant-admin
+  name: cozy:tenant:admin
   labels:
     rbac.cozystack.io/aggregate-to-tenant-super-admin: "true"
 aggregationRule:
@@ -170,7 +170,7 @@ rules: []
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cozy-tenant-admin-base
+  name: cozy:tenant:admin:base
   labels:
     rbac.cozystack.io/aggregate-to-tenant-admin: "true"
 rules:
@@ -222,7 +222,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cozy-tenant-super-admin
+  name: cozy:tenant:super-admin
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -232,7 +232,7 @@ rules: []
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cozy-tenant-super-admin-base
+  name: cozy:tenant:super-admin:base
   labels:
     rbac.cozystack.io/aggregate-to-tenant-super-admin: "true"
 rules:

--- a/packages/system/cozystack-basics/templates/dashboard-role.yaml
+++ b/packages/system/cozystack-basics/templates/dashboard-role.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: cozy-tenant-dashboard
+  name: cozy:tenant:dashboard
   namespace: cozy-public
 rules:
 - apiGroups: ["source.toolkit.fluxcd.io"]


### PR DESCRIPTION
## What this PR does

This patch improves the naming conventions used in Cozystack's RBAC resources. It follows the k8s system convention of using colons as separators in RBAC resource names (e.g. system:nodes:<nodename>) and renames some default tenant clusterroles to a scheme like cozy:tenant:admin.

### Release note

```release-note
[rbac] Use a more structured naming convention for Cozystack's RBAC
resources.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized Kubernetes role and binding names to a colon-delimited "cozy:tenant:*" format.
  * Applied naming updates across tenant RBAC, cluster-wide roles, and dashboard role resources.
  * Preserved existing permissions, namespaces, and behavior while improving naming consistency across system configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->