### PR TITLE
[backups] Install backupstrategy controller by default

### DIFF
--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -131,7 +131,7 @@
 {{include "cozystack.platform.package.default" (list "cozystack.monitoring-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.etcd-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.cozystack-basics" $) }}
-{{include "cozystack.platform.package.optional.default" (list "cozystack.backupstrategy-controller" $) }}
+{{include "cozystack.platform.package.default" (list "cozystack.backupstrategy-controller" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.backup-controller" $) }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.velero" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.vertical-pod-autoscaler" $) }}


### PR DESCRIPTION
## What this PR does

Enables the installation of the backupstrategy controller by default.

### Release note

```release-note
[backups] Install the backupstrategy controller by default.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Backup strategy component is now included by default in all system installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->