### PR TITLE
[backups] Better selectors for VM strategy

### DIFF
--- a/packages/system/virtual-machine-rd/templates/backupstrategy.yaml
+++ b/packages/system/virtual-machine-rd/templates/backupstrategy.yaml
@@ -5,14 +5,17 @@ metadata:
   name: velero-backup-strategy-for-virtualmachines
 spec:
   template:
-    spec: # see https://velero.io/docs/v1.9/api-types/backup/
+    spec:
+      csiSnapshotTimeout: 10m0s
       includedNamespaces:
       - '{{ printf "{{ .Application.metadata.namespace }}" }}'
-
-      labelSelector:
-        matchLabels:
-          apps.cozystack.io/application.Kind: '{{ printf "{{ .Application.kind }}" }}'
-
+      orLabelSelector:
+      - matchLabels:
+          apps.cozystack.io/application.group: apps.cozystack.io
+          apps.cozystack.io/application.kind: '{{ printf "{{ .Application.kind }}" }}'
+          apps.cozystack.io/application.name: '{{ printf "{{ .Application.metadata.name }}"}}'
+      - matchLabels:
+          app.kubernetes.io/instance: 'virtual-machine-{{ printf "{{ .Application.metadata.name }}"}}' 
       includedResources:
         - helmreleases.helm.toolkit.fluxcd.io
         - virtualmachines.kubevirt.io
@@ -22,14 +25,11 @@ spec:
         - services
         - configmaps
         - secrets
-
       storageLocation: '{{ printf "{{ .Parameters.backupStorageLocationName }}" }}'
-
       volumeSnapshotLocations:
         - '{{ printf "{{ .Parameters.backupStorageLocationName }}" }}'
       snapshotVolumes: true
       snapshotMoveData: true
-
       ttl: 720h0m0s
       itemOperationTimeout: 24h0m0s
 {{- end }}


### PR DESCRIPTION
## What this PR does

This patch adds another label selector for resources being backed up by the default Velero strategy for virtual machines, ensuring that the actual VM and VMI are captured by selector.

### Release note

```release-note
[backups] Refined the label selector in the Velero VM backup strategy to
capture resources previously missed.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded backup scope to include additional virtual machine and storage resources.
  * Added configurable timeout for snapshot operations (10 minutes).
  * Enhanced resource selection logic for more flexible backup filtering.

* **Configuration Changes**
  * Updated backup strategy configuration for improved resource coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->