### PR TITLE
[platform] Fix cozystack-values secret race

### DIFF
--- a/packages/system/cozystack-basics/templates/cozystack-values-secret.yaml
+++ b/packages/system/cozystack-basics/templates/cozystack-values-secret.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: tenant-root
   labels:
     reconcile.fluxcd.io/watch: Enabled
+    internal.cozystack.io/managed-by-cozystack: ""
 type: Opaque
 stringData:
   values.yaml: |


### PR DESCRIPTION
## What this PR does

The cozystack-values secret is created as part of the cozystack-basics chart and is required by cozystack to install properly, however there is a race condition between it and the lineage-controller-webhook, where it may be blocked from being created if the mutating webhook configuration is already set up. By adding a system label to this secret it is dropped from consideration by the webhook.

### Release note

```release-note
[platform] Resolve race condition between the system cozystack-values
secret and the lineage webhook by adding a label that causes the webhook
to ignore this secret.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system manifest metadata configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->