### PR TITLE
Add clustersecret-operator system package

### DIFF
--- a/packages/core/platform/sources/clustersecret-operator.yaml
+++ b/packages/core/platform/sources/clustersecret-operator.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cozystack.io/v1alpha1
+kind: PackageSource
+metadata:
+  name: cozystack.clustersecret-operator
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: cozystack-packages
+    namespace: cozy-system
+    path: /
+  variants:
+  - name: default
+    dependsOn:
+    - cozystack.networking
+    components:
+    - name: clustersecret-operator
+      path: system/clustersecret-operator
+      install:
+        namespace: cozy-clustersecret-operator
+        releaseName: clustersecret-operator

--- a/packages/system/clustersecret-operator/.helmignore
+++ b/packages/system/clustersecret-operator/.helmignore
@@ -1,0 +1,3 @@
+images
+hack
+.gitkeep

--- a/packages/system/clustersecret-operator/Chart.yaml
+++ b/packages/system/clustersecret-operator/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: cozy-clustersecret-operator
+version: 0.0.0 # Placeholder, the actual version will be automatically set during the build process

--- a/packages/system/clustersecret-operator/Makefile
+++ b/packages/system/clustersecret-operator/Makefile
@@ -1,0 +1,11 @@
+export NAME=clustersecret-operator
+export NAMESPACE=cozy-clustersecret-operator
+
+export REPO_NAME=clustersecret-operator
+export REPO_URL=https://sap.github.io/clustersecret-operator-helm
+export CHART_NAME=clustersecret-operator
+export CHART_VERSION=^0.3
+
+include ../../../hack/package.mk
+
+update: clean clustersecret-operator-update

--- a/packages/system/clustersecret-operator/charts/clustersecret-operator/.helmignore
+++ b/packages/system/clustersecret-operator/charts/clustersecret-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/packages/system/clustersecret-operator/charts/clustersecret-operator/Chart.yaml
+++ b/packages/system/clustersecret-operator/charts/clustersecret-operator/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: v0.3.68
+description: A Helm chart for https://github.com/sap/clustersecret-operator
+name: clustersecret-operator
+type: application
+version: 0.3.68

--- a/packages/system/clustersecret-operator/charts/clustersecret-operator/README.md
+++ b/packages/system/clustersecret-operator/charts/clustersecret-operator/README.md
@@ -1,0 +1,74 @@
+# clustersecret-operator
+
+![Version: 0.3.68](https://img.shields.io/badge/Version-0.3.68-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.68](https://img.shields.io/badge/AppVersion-v0.3.68-informational?style=flat-square)
+
+A Helm chart for https://github.com/sap/clustersecret-operator
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| fullnameOverride | string | `""` | Override full name |
+| nameOverride | string | `""` | Override name |
+| global.image.tag | string | `""` | Image tag (defauls to .Chart.AppVersion) |
+| global.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| global.imagePullSecrets | list | `[]` | Image pull secrets |
+| global.affinity | object | `{}` | Affinity settings |
+| global.nodeSelector | object | `{}` | Node selector |
+| global.topologySpreadConstraints | list | `[]` | Topology spread constraints (if unspecified, default constraints for hostname and zone will be generated) |
+| global.defaultHostNameSpreadPolicy | string | `"ScheduleAnyway"` | Default topology spread policy for hostname |
+| global.defaultZoneSpreadPolicy | string | `"ScheduleAnyway"` | Default topology spread policy for zone |
+| global.tolerations | list | `[]` | Tolerations |
+| global.priorityClassName | string | `""` | Priority class |
+| global.podSecurityContext | object | `{}` | Pod security context |
+| global.podAnnotations | object | `{}` | Additional pod annotations |
+| global.podLabels | object | `{}` | Additional pod labels |
+| global.securityContext | object | `{}` | Container security context |
+| global.logLevel | int | `0` | Log level |
+| controller.replicaCount | int | `1` | Replica count |
+| controller.image.repository | string | `"ghcr.io/sap/clustersecret-operator/controller"` | Image repository |
+| controller.image.tag | string | `""` | Image tag (defauls to .Chart.AppVersion) |
+| controller.image.pullPolicy | string | `""` | Image pull policy |
+| controller.imagePullSecrets | list | `[]` | Image pull secrets |
+| controller.affinity | object | `{}` | Affinity settings |
+| controller.nodeSelector | object | `{}` | Node selector |
+| controller.topologySpreadConstraints | list | `[]` | Topology spread constraints (if unspecified, default constraints for hostname and zone will be generated) |
+| controller.defaultHostNameSpreadPolicy | string | `""` | Default topology spread policy for hostname |
+| controller.defaultZoneSpreadPolicy | string | `""` | Default topology spread policy for zone |
+| controller.tolerations | list | `[]` | Tolerations |
+| controller.priorityClassName | string | `""` | Priority class |
+| controller.podSecurityContext | object | `{}` | Pod security context |
+| controller.podAnnotations | object | `{}` | Additional pod annotations |
+| controller.podLabels | object | `{}` | Additional pod labels |
+| controller.securityContext | object | `{}` | Container security context |
+| controller.resources.limits.memory | string | `"200Mi"` | Memory limit |
+| controller.resources.limits.cpu | float | `0.1` | CPU limit |
+| controller.resources.requests.memory | string | `"20Mi"` | Memory request |
+| controller.resources.requests.cpu | float | `0.01` | CPU request |
+| controller.logLevel | int | `0` | Log level |
+| webhook.replicaCount | int | `1` | Replica count |
+| webhook.image.repository | string | `"ghcr.io/sap/clustersecret-operator/webhook"` | Image repository |
+| webhook.image.tag | string | `""` | Image tag (defauls to .Chart.AppVersion) |
+| webhook.image.pullPolicy | string | `""` | Image pull policy |
+| webhook.imagePullSecrets | list | `[]` | Image pull secrets |
+| webhook.affinity | object | `{}` | Affinity settings |
+| webhook.nodeSelector | object | `{}` | Node selector |
+| webhook.topologySpreadConstraints | list | `[]` | Topology spread constraints (if unspecified, default constraints for hostname and zone will be generated) |
+| webhook.defaultHostNameSpreadPolicy | string | `""` | Default topology spread policy for hostname |
+| webhook.defaultZoneSpreadPolicy | string | `""` | Default topology spread policy for zone |
+| webhook.tolerations | list | `[]` | Tolerations |
+| webhook.priorityClassName | string | `""` | Priority class |
+| webhook.podSecurityContext | object | `{}` | Pod security context |
+| webhook.podAnnotations | object | `{}` | Additional pod annotations |
+| webhook.podLabels | object | `{}` | Additional pod labels |
+| webhook.securityContext | object | `{}` | Container security context |
+| webhook.resources.limits.memory | string | `"100Mi"` | Memory limit |
+| webhook.resources.limits.cpu | float | `0.1` | CPU limit |
+| webhook.resources.requests.memory | string | `"20Mi"` | Memory request |
+| webhook.resources.requests.cpu | float | `0.01` | CPU request |
+| webhook.service.type | string | `"ClusterIP"` | Service type |
+| webhook.service.port | int | `443` | Service port |
+| webhook.logLevel | int | `0` | Log level |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)

--- a/packages/system/clustersecret-operator/charts/clustersecret-operator/crds/clustersecrets.yaml
+++ b/packages/system/clustersecret-operator/charts/clustersecret-operator/crds/clustersecrets.yaml
@@ -1,0 +1,106 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clustersecrets.core.cs.sap.com
+spec:
+  scope: Cluster
+  names:
+    plural: clustersecrets
+    singular: clustersecret
+    kind: ClusterSecret
+  group: core.cs.sap.com
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
+      - name: State
+        type: string
+        jsonPath: .status.state
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: ["spec"]
+          properties:
+            spec:
+              type: object
+              required: ["template"]
+              properties:
+                namespaceSelector:
+                  type: object
+                  anyOf:
+                  - required: ["matchLabels"]
+                  - required: ["matchExpressions"]
+                  properties:
+                    matchLabels:
+                      type: object
+                      additionalProperties:
+                        type: string
+                      nullable: true
+                    matchExpressions:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                            enum: ["In","NotIn","Exists","DoesNotExist"]
+                          values:
+                            type: array
+                            items:
+                              type: string
+                template:
+                  type: object
+                  required: ["type"]
+                  properties:
+                    type:
+                      type: string
+                      minLength: 1
+                    data:
+                      type: object
+                      additionalProperties:
+                        type: string
+                      nullable: true
+                    stringData:
+                      type: object
+                      additionalProperties:
+                        type: string
+                      nullable: true
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  type: integer
+                state:
+                  type: string
+                  enum: ["Ready","Processing","Deleting","Error"]
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: ["type","status"]
+                    properties:
+                      type:
+                        type: string
+                        enum: ["Ready"]
+                      status:
+                        type: string
+                        enum: ["True","False","Unknown"]
+                      lastUpdateTime:
+                        type: string
+                        format: datetime
+                      lastTransitionTime:
+                        type: string
+                        format: datetime
+                      reason:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string

--- a/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/_helpers-controller.tpl
+++ b/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/_helpers-controller.tpl
@@ -1,0 +1,13 @@
+{{- define "clustersecret-operator.controller.fullname" -}}
+{{ include "clustersecret-operator.fullname" . }}-controller
+{{- end }}
+
+{{- define "clustersecret-operator.controller.labels" -}}
+{{ include "clustersecret-operator.labels" . }}
+app.kubernetes.io/component: controller
+{{- end }}
+
+{{- define "clustersecret-operator.controller.selectorLabels" -}}
+{{ include "clustersecret-operator.selectorLabels" . }}
+app.kubernetes.io/component: controller
+{{- end }}

--- a/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/_helpers-webhook.tpl
+++ b/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/_helpers-webhook.tpl
@@ -1,0 +1,13 @@
+{{- define "clustersecret-operator.webhook.fullname" -}}
+{{ include "clustersecret-operator.fullname" . }}-webhook
+{{- end }}
+
+{{- define "clustersecret-operator.webhook.labels" -}}
+{{ include "clustersecret-operator.labels" . }}
+app.kubernetes.io/component: webhook
+{{- end }}
+
+{{- define "clustersecret-operator.webhook.selectorLabels" -}}
+{{ include "clustersecret-operator.selectorLabels" . }}
+app.kubernetes.io/component: webhook
+{{- end }}

--- a/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/_helpers.tpl
+++ b/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "clustersecret-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "clustersecret-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "clustersecret-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "clustersecret-operator.labels" -}}
+helm.sh/chart: {{ include "clustersecret-operator.chart" . }}
+{{ include "clustersecret-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "clustersecret-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "clustersecret-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/controller-deployment.yaml
+++ b/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/controller-deployment.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "clustersecret-operator.controller.fullname" . }}
+  labels:
+    {{- include "clustersecret-operator.controller.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.controller.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "clustersecret-operator.controller.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.controller.podAnnotations | default .Values.global.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "clustersecret-operator.controller.selectorLabels" . | nindent 8 }}
+        {{- with .Values.controller.podLabels | default .Values.global.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.controller.imagePullSecrets | default .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.controller.podSecurityContext | default .Values.global.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.nodeSelector | default .Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.affinity | default .Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.topologySpreadConstraints | default .Values.global.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- range . }}
+      - {{ toYaml . | nindent 8 | trim }}
+        {{- if not .labelSelector }}
+        labelSelector:
+          matchLabels:
+            {{- include "clustersecret-operator.controller.selectorLabels" $ | nindent 12 }}
+        {{- end }}
+      {{- end }}
+      {{- else }}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        nodeTaintsPolicy: Honor
+        whenUnsatisfiable: {{ .Values.controller.defaultHostNameSpreadPolicy | default .Values.global.defaultHostNameSpreadPolicy }}
+        labelSelector:
+          matchLabels:
+            {{- include "clustersecret-operator.controller.selectorLabels" . | nindent 12 }}
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        nodeTaintsPolicy: Honor
+        whenUnsatisfiable: {{ .Values.controller.defaultZoneSpreadPolicy | default .Values.global.defaultZoneSpreadPolicy }}
+        labelSelector:
+          matchLabels:
+            {{- include "clustersecret-operator.controller.selectorLabels" . | nindent 12 }}
+      {{- end }}
+      {{- with .Values.controller.tolerations | default .Values.global.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.controller.priorityClassName | default .Values.global.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      serviceAccountName: {{ include "clustersecret-operator.controller.fullname" . }}
+      automountServiceAccountToken: true
+      containers:
+      - name: controller
+        image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Values.global.image.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.controller.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        {{- with .Values.controller.securityContext | default .Values.global.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.controller.resources | nindent 12 }}
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        args:
+        - "--lease_namespace={{ .Release.Namespace }}"
+        - "--lease_name={{ include "clustersecret-operator.controller.fullname" . }}"
+        - "--lease_id=$(POD_NAME)"
+        - "--v={{ .Values.controller.logLevel | default .Values.global.logLevel | default 0 }}"

--- a/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/controller-pdb.yaml
+++ b/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/controller-pdb.yaml
@@ -1,0 +1,13 @@
+{{- if ge (int .Values.controller.replicaCount) 2 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "clustersecret-operator.controller.fullname" . }}
+  labels:
+    {{- include "clustersecret-operator.controller.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      {{- include "clustersecret-operator.controller.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/controller-rbac.yaml
+++ b/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/controller-rbac.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "clustersecret-operator.controller.fullname" . }}
+  labels:
+    {{- include "clustersecret-operator.controller.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "clustersecret-operator.controller.fullname" . }}
+  labels:
+    {{- include "clustersecret-operator.controller.labels" . | nindent 4 }}
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["create"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  resourceNames: ["{{ include "clustersecret-operator.controller.fullname" . }}"]
+  verbs: ["get","list","watch","update","patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "clustersecret-operator.controller.fullname" . }}
+  labels:
+    {{- include "clustersecret-operator.controller.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "clustersecret-operator.controller.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "clustersecret-operator.controller.fullname" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "clustersecret-operator.controller.fullname" . }}
+  labels:
+    {{- include "clustersecret-operator.controller.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get","list","watch","create","update","patch","delete"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get","list","watch"]
+- apiGroups: ["core.cs.sap.com"]
+  resources: ["clustersecrets","clustersecrets/status"]
+  verbs:  ["get","list","watch","update"]
+- apiGroups: ["","events.k8s.io"]
+  resources: ["events"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "clustersecret-operator.controller.fullname" . }}
+  labels:
+    {{- include "clustersecret-operator.controller.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "clustersecret-operator.controller.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "clustersecret-operator.controller.fullname" . }}

--- a/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/tests/rbac.yaml
+++ b/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/tests/rbac.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "clustersecret-operator.fullname" . }}-test
+  labels:
+    {{- include "clustersecret-operator.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: "-1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "clustersecret-operator.fullname" . }}-test
+  labels:
+    {{- include "clustersecret-operator.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: "-1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+- apiGroups:
+  - core.cs.sap.com
+  resources:
+  - clustersecrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "clustersecret-operator.fullname" . }}-test
+  labels:
+    {{- include "clustersecret-operator.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: "-1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "clustersecret-operator.fullname" . }}-test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "clustersecret-operator.fullname" . }}-test

--- a/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/tests/test-1.yaml
+++ b/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/tests/test-1.yaml
@@ -1,0 +1,44 @@
+{{- $clusterSecretName := printf "%s-test-1-%s" (include "clustersecret-operator.fullname" .) (randAlphaNum 10 | lower) }}
+---
+apiVersion: core.cs.sap.com/v1alpha1
+kind: ClusterSecret
+metadata:
+  name: {{ $clusterSecretName }}
+  labels:
+    {{- include "clustersecret-operator.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  template:
+    type: Opaque
+    data:
+      mykey: bXl2YWx1ZQ==
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "clustersecret-operator.fullname" . }}-test-1
+  labels:
+    {{- include "clustersecret-operator.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  containers:
+  - name: kubectl
+    image: ghcr.io/sap/kubectl-container:{{ .Capabilities.KubeVersion.Version }}
+    command:
+    - bash
+    - -ec
+    - |
+        kubectl wait clustersecrets.core.cs.sap.com/{{ $clusterSecretName }} --for condition=Ready --timeout 30s
+        kubectl -n default get secret {{ $clusterSecretName }}
+  serviceAccountName: {{ include "clustersecret-operator.fullname" . }}-test
+  terminationGracePeriodSeconds: 3
+  restartPolicy: Never

--- a/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/webhook-admission.yaml
+++ b/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/webhook-admission.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clustersecret-operator.webhook.fullname" . }}
+  labels:
+    {{- include "clustersecret-operator.webhook.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.webhook.service.type }}
+  ports:
+    - port: {{ .Values.webhook.service.port }}
+      targetPort: 1443
+      protocol: TCP
+      name: https
+  selector:
+    {{- include "clustersecret-operator.webhook.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "clustersecret-operator.webhook.fullname" . }}-tls
+  labels:
+    {{- include "clustersecret-operator.webhook.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- $data := (lookup "v1" "Secret" .Release.Namespace (printf "%s-tls" (include "clustersecret-operator.webhook.fullname" .))).data }}
+  {{- $caCert := "" }}
+  {{- if $data }}
+  {{ $data | toYaml | nindent 2 }}
+  {{- $caCert = index $data "ca.crt" }}
+  {{- else }}
+  {{- $cn := printf "%s.%s.svc" (include "clustersecret-operator.webhook.fullname" .) .Release.Namespace }}
+  {{- $ca := genCA (printf "%s-ca" (include "clustersecret-operator.webhook.fullname" .)) 36500 }}
+  {{- $cert := genSignedCert $cn (list "127.0.0.1") (list $cn "localhost") 36500 $ca }}
+  ca.crt: {{ $ca.Cert | b64enc }}
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
+  {{- $caCert = $ca.Cert | b64enc }}
+  {{- end }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: clustersecret-operator
+  labels:
+    {{- include "clustersecret-operator.webhook.labels" . | nindent 4 }}
+webhooks:
+- name: clustersecret-operator.cs.sap.com
+  admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: {{ $caCert }}
+    service:
+      name: {{ include "clustersecret-operator.webhook.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /validation
+      port: {{ .Values.webhook.service.port }}
+  rules:
+  - apiGroups:
+    - core.cs.sap.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - clustersecrets
+    scope: Cluster
+  matchPolicy: Exact
+  sideEffects: None
+  timeoutSeconds: 10
+  failurePolicy: Fail
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: clustersecret-operator
+  labels:
+    {{- include "clustersecret-operator.webhook.labels" . | nindent 4 }}
+webhooks:
+- name: clustersecret-operator.cs.sap.com
+  admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: {{ $caCert }}
+    service:
+      name: {{ include "clustersecret-operator.webhook.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /mutation
+      port: {{ .Values.webhook.service.port }}
+  rules:
+  - apiGroups:
+    - core.cs.sap.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - clustersecrets
+    scope: Cluster
+  matchPolicy: Exact
+  sideEffects: None
+  timeoutSeconds: 10
+  failurePolicy: Fail

--- a/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/webhook-deployment.yaml
+++ b/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/webhook-deployment.yaml
@@ -1,0 +1,109 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "clustersecret-operator.webhook.fullname" . }}
+  labels:
+    {{- include "clustersecret-operator.webhook.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.webhook.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "clustersecret-operator.webhook.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.webhook.podAnnotations | default .Values.global.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "clustersecret-operator.webhook.selectorLabels" . | nindent 8 }}
+        {{- with .Values.webhook.podLabels | default .Values.global.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.webhook.imagePullSecrets | default .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.webhook.podSecurityContext | default .Values.global.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhook.nodeSelector | default .Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhook.affinity | default .Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhook.topologySpreadConstraints | default .Values.global.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- range . }}
+      - {{ toYaml . | nindent 8 | trim }}
+        {{- if not .labelSelector }}
+        labelSelector:
+          matchLabels:
+            {{- include "clustersecret-operator.webhook.selectorLabels" $ | nindent 12 }}
+        {{- end }}
+      {{- end }}
+      {{- else }}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        nodeTaintsPolicy: Honor
+        whenUnsatisfiable: {{ .Values.webhook.defaultHostNameSpreadPolicy | default .Values.global.defaultHostNameSpreadPolicy }}
+        labelSelector:
+          matchLabels:
+            {{- include "clustersecret-operator.webhook.selectorLabels" . | nindent 12 }}
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        nodeTaintsPolicy: Honor
+        whenUnsatisfiable: {{ .Values.webhook.defaultZoneSpreadPolicy | default .Values.global.defaultZoneSpreadPolicy }}
+        labelSelector:
+          matchLabels:
+            {{- include "clustersecret-operator.webhook.selectorLabels" . | nindent 12 }}
+      {{- end }}
+      {{- with .Values.webhook.tolerations | default .Values.global.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.webhook.priorityClassName | default .Values.global.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      serviceAccountName: {{ include "clustersecret-operator.webhook.fullname" . }}
+      automountServiceAccountToken: true
+      containers:
+      - name: webhook
+        image: {{ .Values.webhook.image.repository }}:{{ .Values.webhook.image.tag | default .Values.global.image.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.webhook.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        {{- with .Values.webhook.securityContext | default .Values.global.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.webhook.resources | nindent 12 }}
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        args:
+        - "--bind_address=:1443"
+        - "--tls_enabled=true"
+        - "--tls_key_file=/app/etc/ssl/tls.key"
+        - "--tls_cert_file=/app/etc/ssl/tls.crt"
+        - "--v={{ .Values.webhook.logLevel | default .Values.global.logLevel | default 0 }}"
+        volumeMounts:
+        - name: ssl
+          mountPath: /app/etc/ssl
+      volumes:
+      - name: ssl
+        secret:
+          secretName: {{ include "clustersecret-operator.webhook.fullname" . }}-tls
+          items:
+          - key: tls.key
+            path: tls.key
+          - key: tls.crt
+            path: tls.crt

--- a/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/webhook-pdb.yaml
+++ b/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/webhook-pdb.yaml
@@ -1,0 +1,13 @@
+{{- if ge (int .Values.webhook.replicaCount) 2 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "clustersecret-operator.webhook.fullname" . }}
+  labels:
+    {{- include "clustersecret-operator.webhook.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      {{- include "clustersecret-operator.webhook.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/webhook-rbac.yaml
+++ b/packages/system/clustersecret-operator/charts/clustersecret-operator/templates/webhook-rbac.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "clustersecret-operator.webhook.fullname" . }}
+  labels:
+    {{- include "clustersecret-operator.webhook.labels" . | nindent 4 }}

--- a/packages/system/clustersecret-operator/charts/clustersecret-operator/values.yaml
+++ b/packages/system/clustersecret-operator/charts/clustersecret-operator/values.yaml
@@ -1,0 +1,138 @@
+# -- Override full name
+fullnameOverride: ""
+# -- Override name
+nameOverride: ""
+
+global:
+  image:
+    # -- Image tag (defauls to .Chart.AppVersion)
+    tag: ""
+    # -- Image pull policy
+    pullPolicy: IfNotPresent
+  # -- Image pull secrets
+  imagePullSecrets: []
+  # -- Affinity settings
+  affinity: {}
+  # -- Node selector
+  nodeSelector: {}
+  # -- Topology spread constraints (if unspecified, default constraints for hostname and zone will be generated)
+  topologySpreadConstraints: []
+  # -- Default topology spread policy for hostname
+  defaultHostNameSpreadPolicy: ScheduleAnyway
+  # -- Default topology spread policy for zone
+  defaultZoneSpreadPolicy: ScheduleAnyway
+  # -- Tolerations
+  tolerations: []
+  # -- Priority class
+  priorityClassName: ""
+  # -- Pod security context
+  podSecurityContext: {}
+  # -- Additional pod annotations
+  podAnnotations: {}
+  # -- Additional pod labels
+  podLabels: {}
+  # -- Container security context
+  securityContext: {}
+  # -- Log level
+  logLevel: 0
+
+controller:
+  # -- Replica count
+  replicaCount: 1
+  image:
+    # -- Image repository
+    repository: ghcr.io/sap/clustersecret-operator/controller
+    # -- Image tag (defauls to .Chart.AppVersion)
+    tag: ""
+    # -- Image pull policy
+    pullPolicy: ""
+  # -- Image pull secrets
+  imagePullSecrets: []
+  # -- Affinity settings
+  affinity: {}
+  # -- Node selector
+  nodeSelector: {}
+  # -- Topology spread constraints (if unspecified, default constraints for hostname and zone will be generated)
+  topologySpreadConstraints: []
+  # -- Default topology spread policy for hostname
+  defaultHostNameSpreadPolicy: ""
+  # -- Default topology spread policy for zone
+  defaultZoneSpreadPolicy: ""
+  # -- Tolerations
+  tolerations: []
+  # -- Priority class
+  priorityClassName: ""
+  # -- Pod security context
+  podSecurityContext: {}
+  # -- Additional pod annotations
+  podAnnotations: {}
+  # -- Additional pod labels
+  podLabels: {}
+  # -- Container security context
+  securityContext: {}
+  resources:
+    limits:
+      # -- Memory limit
+      memory: 200Mi
+      # -- CPU limit
+      cpu: 0.1
+    requests:
+      # -- Memory request
+      memory: 20Mi
+      # -- CPU request
+      cpu: 0.01
+  # -- Log level
+  logLevel: 0
+
+webhook:
+  # -- Replica count
+  replicaCount: 1
+  image:
+    # -- Image repository
+    repository: ghcr.io/sap/clustersecret-operator/webhook
+    # -- Image tag (defauls to .Chart.AppVersion)
+    tag: ""
+    # -- Image pull policy
+    pullPolicy: ""
+  # -- Image pull secrets
+  imagePullSecrets: []
+  # -- Affinity settings
+  affinity: {}
+  # -- Node selector
+  nodeSelector: {}
+  # -- Topology spread constraints (if unspecified, default constraints for hostname and zone will be generated)
+  topologySpreadConstraints: []
+  # -- Default topology spread policy for hostname
+  defaultHostNameSpreadPolicy: ""
+  # -- Default topology spread policy for zone
+  defaultZoneSpreadPolicy: ""
+  # -- Tolerations
+  tolerations: []
+  # -- Priority class
+  priorityClassName: ""
+  # -- Pod security context
+  podSecurityContext: {}
+  # -- Additional pod annotations
+  podAnnotations: {}
+  # -- Additional pod labels
+  podLabels: {}
+  # -- Container security context
+  securityContext: {}
+  resources:
+    limits:
+      # -- Memory limit
+      memory: 100Mi
+      # -- CPU limit
+      cpu: 0.1
+    requests:
+      # -- Memory request
+      memory: 20Mi
+      # -- CPU request
+      cpu: 0.01
+  service:
+    # -- Service type
+    type: ClusterIP
+    # -- Service port
+    port: 443
+  # -- Log level
+  logLevel: 0

--- a/packages/system/clustersecret-operator/values.yaml
+++ b/packages/system/clustersecret-operator/values.yaml
@@ -1,0 +1,1 @@
+clustersecret-operator: {}


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Adds system package for [clustersecret-operator](https://github.com/sap/clustersecret-operator) using Helm Chart v0.3.68

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[clustersecret-operator] add option to deploy clustersecret-operator v0.3.68
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ClusterSecret operator for managing cluster-scoped secrets across multiple namespaces
  * Secrets can be distributed to selected namespaces using namespace selectors
  * Supports template-based secret creation with customizable data
  * Includes validation webhooks and admission control for ClusterSecret resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->