### PR TITLE
[ci] Cozyreport improvements

### DIFF
--- a/hack/cozyreport.sh
+++ b/hack/cozyreport.sh
@@ -57,23 +57,23 @@ kubectl get hr -A --no-headers | awk '$4 != "True"' | \
   done
 
 echo "Collecting packages..."
-kubectl get packages -A > $REPORT_DIR/kubernetes/packages.txt 2>&1
-kubectl get packages -A --no-headers | awk '$4 != "True"' | \
-  while read NAMESPACE NAME _; do
-    DIR=$REPORT_DIR/kubernetes/packages/$NAMESPACE/$NAME
+kubectl get packages > $REPORT_DIR/kubernetes/packages.txt 2>&1
+kubectl get packages --no-headers | awk '$3 != "True"' | \
+  while read NAME _; do
+    DIR=$REPORT_DIR/kubernetes/packages/$NAME
     mkdir -p $DIR
-    kubectl get package -n $NAMESPACE $NAME -o yaml > $DIR/package.yaml 2>&1
-    kubectl describe package -n $NAMESPACE $NAME > $DIR/describe.txt 2>&1
+    kubectl get package $NAME -o yaml > $DIR/package.yaml 2>&1
+    kubectl describe package $NAME > $DIR/describe.txt 2>&1
   done
 
 echo "Collecting packagesources..."
-kubectl get packagesources -A > $REPORT_DIR/kubernetes/packagesources.txt 2>&1
-kubectl get packagesources -A --no-headers | awk '$4 != "True"' | \
-  while read NAMESPACE NAME _; do
-    DIR=$REPORT_DIR/kubernetes/packagesources/$NAMESPACE/$NAME
+kubectl get packagesources > $REPORT_DIR/kubernetes/packagesources.txt 2>&1
+kubectl get packagesources --no-headers | awk '$3 != "True"' | \
+  while read NAME _; do
+    DIR=$REPORT_DIR/kubernetes/packagesources/$NAME
     mkdir -p $DIR
-    kubectl get packagesource -n $NAMESPACE $NAME -o yaml > $DIR/packagesource.yaml 2>&1
-    kubectl describe packagesource -n $NAMESPACE $NAME > $DIR/describe.txt 2>&1
+    kubectl get packagesource $NAME -o yaml > $DIR/packagesource.yaml 2>&1
+    kubectl describe packagesource $NAME > $DIR/describe.txt 2>&1
   done
 
 echo "Collecting pods..."
@@ -82,7 +82,7 @@ kubectl get pod -A --no-headers | awk '$4 !~ /Running|Succeeded|Completed/' |
   while read NAMESPACE NAME _ STATE _; do
     DIR=$REPORT_DIR/kubernetes/pods/$NAMESPACE/$NAME
     mkdir -p $DIR
-    CONTAINERS=$(kubectl get pod -o jsonpath='{.spec.containers[*].name}' -n $NAMESPACE $NAME)
+    CONTAINERS=$(kubectl get pod -o jsonpath='{.spec.containers[*].name} {.spec.initContainers[*].name}' -n $NAMESPACE $NAME)
     kubectl get pod -n $NAMESPACE $NAME -o yaml > $DIR/pod.yaml 2>&1
     kubectl describe pod -n $NAMESPACE $NAME > $DIR/describe.txt 2>&1
     if [ "$STATE" != "Pending" ]; then


### PR DESCRIPTION
## What this PR does

Previously the debug log collection script that fired when CI failed treated Packages and PackageSources as namespaced resources and as a result of incorrect parsing failed to correctly kubectl describe and kubectl get -oyaml them. Additionally, the script did not read the logs of init containers. These issues are fixed with this patch.

### Release note

```release-note
[ci] Improvements to cozyreport.sh (ci log collection script): fix
retrieval of Package and PackageSource details, consider initContainers
as well as containers, when fetching logs of errored pods.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pod log collection now captures initContainer logs as well as standard container logs for more complete diagnostics.

* **Refactor**
  * Resource queries for Kubernetes packages and package sources consolidated to improve efficiency and reduce redundant calls.
  * Resource path layout simplified to remove per-namespace nesting, streamlining lookups and maintenance.
  * Lookup and retrieval flow optimized for faster, more reliable package/package-source inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->