### PR TITLE
fix(e2e): increase HelmRelease readiness timeout for kubernetes test

### DIFF
--- a/hack/e2e-apps/run-kubernetes.sh
+++ b/hack/e2e-apps/run-kubernetes.sh
@@ -221,9 +221,10 @@ fi
   # Wait for all machine deployment replicas to be ready (timeout after 10 minutes)
   kubectl wait machinedeployment kubernetes-${test_name}-md0 -n tenant-test --timeout=10m --for=jsonpath='{.status.v1beta2.readyReplicas}'=2
 
-  for component in cilium coredns csi ingress-nginx vsnap-crd; do
-      kubectl wait hr kubernetes-${test_name}-${component} -n tenant-test --timeout=5m --for=condition=ready
+  for component in cilium coredns csi vsnap-crd; do
+      kubectl wait hr kubernetes-${test_name}-${component} -n tenant-test --timeout=1m --for=condition=ready
     done
+    kubectl wait hr kubernetes-${test_name}-ingress-nginx -n tenant-test --timeout=5m --for=condition=ready
 
   # Clean up by deleting the Kubernetes resource
   kubectl -n tenant-test delete kuberneteses.apps.cozystack.io $test_name


### PR DESCRIPTION
## Summary

- Increase `kubectl wait` timeout for HelmRelease readiness from 1 minute to 5 minutes in the kubernetes E2E test
- The ingress-nginx HelmRelease consistently times out with 1m after migrating from hostNetwork to NodePort Service
- This causes deterministic E2E failures on `kubernetes-latest` across multiple PRs

## Test plan

- [ ] Verify `kubernetes-latest` E2E test passes without ingress-nginx timeout
- [ ] Verify `kubernetes-previous` E2E test still passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Kubernetes component initialization by separating ingress-nginx readiness handling from the standard component batch with an extended timeout duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->