### PR TITLE
[platform] Clean up Helm secrets for removed -rd releases

### DIFF
--- a/packages/core/platform/images/migrations/migrations/23
+++ b/packages/core/platform/images/migrations/migrations/23
@@ -6,6 +6,13 @@ set -euo pipefail
 # Remove old cozystack-resource-definition-crd HelmRelease (renamed to application-definition-crd)
 kubectl delete hr -n cozy-system cozystack-resource-definition-crd --ignore-not-found
 
+kubectl delete secrets -n cozy-system $(
+  kubectl get secrets -n cozy-system \
+    -l owner=helm \
+    -o jsonpath='{range .items[*]}{.metadata.labels.name}{" "}{.metadata.name}{"\n"}{end}' \
+  | awk '$1 ~ /-rd$/ {print $2}'
+) --ignore-not-found
+
 # Stamp version
 kubectl create configmap -n cozy-system cozystack-version \
   --from-literal=version=24 --dry-run=client -o yaml | kubectl apply -f-


### PR DESCRIPTION
## What this PR does

Migration 23 already removes the `cozystack-resource-definition-crd` HelmRelease, but existing Helm release secrets
for `*-rd` applications still reference the deleted `CozystackResourceDefinition` CRD, causing upgrade failures.

This adds a step to delete those stale Helm secrets so that Flux can recreate the releases cleanly.

### Release note

```release-note
[platform] Clean up stale Helm release secrets for *-rd applications during migration
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced system cleanup routine to remove deprecated Kubernetes secrets during version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->