### PR TITLE
[monitoring] Fix YAML parse error in monitoring-agents vmagent template

### DIFF
--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -136,7 +136,8 @@
 {{include "cozystack.platform.package.optional.default" (list "cozystack.velero" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.vertical-pod-autoscaler" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.metrics-server" $) }}
-{{include "cozystack.platform.package.default" (list "cozystack.monitoring-agents" $) }}
+{{- $monitoringAgentsComponents := dict "monitoring-agents" (dict "values" (dict "global" (dict "target" "tenant-root"))) -}}
+{{include "cozystack.platform.package" (list "cozystack.monitoring-agents" "default" $ $monitoringAgentsComponents) }}
 {{include "cozystack.platform.package.default" (list "cozystack.goldpinger" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.prometheus-operator-crds" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.grafana-operator" $) }}

--- a/packages/system/monitoring-agents/templates/vmagent.yaml
+++ b/packages/system/monitoring-agents/templates/vmagent.yaml
@@ -10,12 +10,12 @@ spec:
   shardCount: 1
   externalLabels:
     cluster: {{ .Values.vmagent.externalLabels.cluster }}
-    tenant: {{ .Values.vmagent.externalLabels.tenant }}
+    tenant: {{ .Values.global.target }}
   extraArgs:
     {{- toYaml (deepCopy .Values.vmagent.extraArgs | mergeOverwrite (fromYaml (include "monitoring-agents.vmagent.defaultExtraArgs" .))) | nindent 4 }}
   remoteWrite:
   {{- range .Values.vmagent.remoteWrite.urls }}
-  - url: {{ . | quote }}
+  - url: {{ tpl . $ | quote }}
   {{- end }}
 
   scrapeInterval: 30s

--- a/packages/system/monitoring-agents/values.yaml
+++ b/packages/system/monitoring-agents/values.yaml
@@ -1,3 +1,6 @@
+global:
+  target: cozy-monitoring
+
 kube-state-metrics:
   extraArgs:
     - --metric-labels-allowlist=pods=[*],deployments=[*]
@@ -275,11 +278,10 @@ kube-state-metrics:
 vmagent:
   externalLabels:
     cluster: cozystack
-    tenant: '{{ .Release.Namespace }}'
   remoteWrite:
     urls:
-      - 'http://vminsert-shortterm.{{ .Release.Namespace }}.svc:8480/insert/0/prometheus'
-      - 'http://vminsert-longterm.{{ .Release.Namespace }}.svc:8480/insert/0/prometheus'
+      - http://vminsert-shortterm.{{ .Values.global.target }}.svc:8480/insert/0/prometheus
+      - http://vminsert-longterm.{{ .Values.global.target }}.svc:8480/insert/0/prometheus
   extraArgs: {}
 
 fluent-bit:
@@ -342,7 +344,7 @@ fluent-bit:
       [OUTPUT]
           Name http
           Match kube.*
-          Host vlogs-generic.{{ .Release.Namespace }}.svc
+          Host vlogs-generic.{{ .Values.global.target }}.svc
           port 9428
           compress gzip
           uri /insert/jsonline?_stream_fields=log_source,stream,kubernetes_pod_name,kubernetes_container_name,kubernetes_namespace_name&_msg_field=log&_time_field=date
@@ -353,7 +355,7 @@ fluent-bit:
       [OUTPUT]
           Name http
           Match events.*
-          Host vlogs-generic.{{ .Release.Namespace }}.svc
+          Host vlogs-generic.{{ .Values.global.target }}.svc
           port 9428
           compress gzip
           uri /insert/jsonline?_stream_fields=log_source,reason,meatdata_namespace,metadata_name&_msg_field=message&_time_field=date
@@ -364,7 +366,7 @@ fluent-bit:
       [OUTPUT]
           Name http
           Match audit.*
-          Host vlogs-generic.{{ .Release.Namespace }}.svc
+          Host vlogs-generic.{{ .Values.global.target }}.svc
           port 9428
           compress gzip
           uri /insert/jsonline?_stream_fields=log_source,stage,user_username,verb,requestUri&_msg_field=requestURI&_time_field=date
@@ -416,7 +418,7 @@ fluent-bit:
       [FILTER]
           Name modify
           Match *
-          Add tenant {{ .Release.Namespace }}
+          Add tenant {{ .Values.global.target }}
       [FILTER]
           Name modify
           Match *


### PR DESCRIPTION
## What this PR does

Fixes Helm upgrade failure for `monitoring-agents` caused by unrendered `{{ .Release.Namespace }}` template expressions in `values.yaml`.

Introduces `global.target` parameter to control the target namespace for monitoring services (vminsert, vlogs). Default is `cozy-system`, platform bundle passes `tenant-root`. Uses `tpl` in vmagent template to render URLs containing template expressions.

### Release note

```release-note
[monitoring] Fix YAML parse error in monitoring-agents vmagent template
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced monitoring agents configuration to use centralized target-based values, replacing namespace-based identifiers for improved consistency across multiple environments.
  * Updated monitoring component labeling and URL handling to leverage parametrized configuration approach for greater flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->