### PR TITLE
[cozystack-operator] Fix: Preserve existing suspend field in package reconciler

### DIFF
--- a/internal/operator/package_reconciler.go
+++ b/internal/operator/package_reconciler.go
@@ -211,13 +211,13 @@ func (r *PackageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 					Namespace: "cozy-system",
 				},
 				Install: &helmv2.Install{
-				Timeout: &metav1.Duration{Duration: 10 * 60 * 1000000000}, // 10m
+					Timeout: &metav1.Duration{Duration: 10 * 60 * 1000000000}, // 10m
 					Remediation: &helmv2.InstallRemediation{
 						Retries: -1,
 					},
 				},
 				Upgrade: &helmv2.Upgrade{
-				Timeout: &metav1.Duration{Duration: 10 * 60 * 1000000000}, // 10m
+					Timeout: &metav1.Duration{Duration: 10 * 60 * 1000000000}, // 10m
 					Remediation: &helmv2.UpgradeRemediation{
 						Retries: -1,
 					},
@@ -387,6 +387,7 @@ func (r *PackageReconciler) createOrUpdateHelmRelease(ctx context.Context, hr *h
 	}
 	hr.SetAnnotations(annotations)
 
+	hr.Spec.Suspend = existing.Spec.Suspend
 	// Update Spec
 	existing.Spec = hr.Spec
 	existing.SetLabels(hr.GetLabels())
@@ -816,7 +817,7 @@ func (r *PackageReconciler) reconcileNamespaces(ctx context.Context, pkg *cozyv1
 func (r *PackageReconciler) createOrUpdateNamespace(ctx context.Context, namespace *corev1.Namespace) error {
 	// Ensure TypeMeta is set for server-side apply
 	namespace.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace"))
-	
+
 	// Use server-side apply with field manager
 	// This is atomic and avoids race conditions from Get/Create/Update pattern
 	// Labels and annotations will be merged automatically by the server


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Now CozyStack operator removes `suspend` field on all changes, so suspending resource is impossible. This breaks local development for packages using `make apply`

This PR preserves `suspend` field for HelmRelease from existing manifest.

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[cozystack-operator] fix: preserve `suspend` field for `HelmRelease` in package reconciler
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed issue where the suspend state of an existing HelmRelease was not preserved during updates, ensuring manual suspension settings remain intact across reconciliation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->