### PR TITLE
[etcd-operator] fix dependencies: add vertical-pod-autoscaler

### DIFF
--- a/packages/core/platform/sources/etcd-operator.yaml
+++ b/packages/core/platform/sources/etcd-operator.yaml
@@ -14,6 +14,7 @@ spec:
     dependsOn:
     - cozystack.networking
     - cozystack.cert-manager
+    - cozystack.vertical-pod-autoscaler
     components:
     - name: etcd-operator
       path: system/etcd-operator


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Etcd operator depends on vertical pod autoscaler in its helm chart. This PR adds vertical pod autoscaler to the operator dependencies

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[etcd-operator] fix dependencies: add vertical-pod-autoscaler
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated etcd-operator configuration with an additional dependency entry to enhance operational capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->