### PR TITLE
[platform] Make cozystack-api reconciliation always use Deployment

### DIFF
--- a/cmd/cozystack-controller/main.go
+++ b/cmd/cozystack-controller/main.go
@@ -68,7 +68,6 @@ func main() {
 	var disableTelemetry bool
 	var telemetryEndpoint string
 	var telemetryInterval string
-	var reconcileDeployment bool
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -86,8 +85,6 @@ func main() {
 		"Endpoint for sending telemetry data")
 	flag.StringVar(&telemetryInterval, "telemetry-interval", "15m",
 		"Interval between telemetry data collection (e.g. 15m, 1h)")
-	flag.BoolVar(&reconcileDeployment, "reconcile-deployment", false,
-		"If set, the Cozystack API server is assumed to run as a Deployment, else as a DaemonSet.")
 	opts := zap.Options{
 		Development: false,
 	}
@@ -196,14 +193,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	cozyAPIKind := "DaemonSet"
-	if reconcileDeployment {
-		cozyAPIKind = "Deployment"
-	}
 	if err = (&controller.ApplicationDefinitionReconciler{
-		Client:           mgr.GetClient(),
-		Scheme:           mgr.GetScheme(),
-		CozystackAPIKind: cozyAPIKind,
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ApplicationDefinitionReconciler")
 		os.Exit(1)

--- a/internal/controller/applicationdefinition_controller.go
+++ b/internal/controller/applicationdefinition_controller.go
@@ -32,8 +32,6 @@ type ApplicationDefinitionReconciler struct {
 	mu          sync.Mutex
 	lastEvent   time.Time
 	lastHandled time.Time
-
-	CozystackAPIKind string
 }
 
 func (r *ApplicationDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -67,7 +65,7 @@ func (r *ApplicationDefinitionReconciler) SetupWithManager(mgr ctrl.Manager) err
 }
 
 type appDefHashView struct {
-	Name string                                `json:"name"`
+	Name string                                 `json:"name"`
 	Spec cozyv1alpha1.ApplicationDefinitionSpec `json:"spec"`
 }
 
@@ -155,23 +153,13 @@ func (r *ApplicationDefinitionReconciler) getWorkload(
 	ctx context.Context,
 	key types.NamespacedName,
 ) (tpl *corev1.PodTemplateSpec, obj client.Object, patch client.Patch, err error) {
-	if r.CozystackAPIKind == "Deployment" {
-		dep := &appsv1.Deployment{}
-		if err := r.Get(ctx, key, dep); err != nil {
-			return nil, nil, nil, err
-		}
-		obj = dep
-		tpl = &dep.Spec.Template
-		patch = client.MergeFrom(dep.DeepCopy())
-	} else {
-		ds := &appsv1.DaemonSet{}
-		if err := r.Get(ctx, key, ds); err != nil {
-			return nil, nil, nil, err
-		}
-		obj = ds
-		tpl = &ds.Spec.Template
-		patch = client.MergeFrom(ds.DeepCopy())
+	dep := &appsv1.Deployment{}
+	if err := r.Get(ctx, key, dep); err != nil {
+		return nil, nil, nil, err
 	}
+	obj = dep
+	tpl = &dep.Spec.Template
+	patch = client.MergeFrom(dep.DeepCopy())
 	if tpl.Annotations == nil {
 		tpl.Annotations = make(map[string]string)
 	}

--- a/packages/system/cozystack-controller/templates/deployment.yaml
+++ b/packages/system/cozystack-controller/templates/deployment.yaml
@@ -27,6 +27,3 @@ spec:
         {{- if .Values.cozystackController.disableTelemetry }}
         - --disable-telemetry
         {{- end }}
-        {{- if eq .Values.cozystackController.cozystackAPIKind "Deployment" }}
-        - --reconcile-deployment
-        {{- end }}

--- a/packages/system/cozystack-controller/values.yaml
+++ b/packages/system/cozystack-controller/values.yaml
@@ -2,4 +2,3 @@ cozystackController:
   image: ghcr.io/cozystack/cozystack/cozystack-controller:v1.0.0-beta.3@sha256:00b0ba15fef7c3ce8c0801ecb11b1953665a511990e18f51c2ca3ca40127c7aa
   debug: false
   disableTelemetry: false
-  cozystackAPIKind: "DaemonSet"


### PR DESCRIPTION
## What this PR does

This PR removes the `cozystackAPIKind` toggle and makes the controller always reconcile `cozystack-api` as a `Deployment`.

Why:
- `cozystack-api` was switched to `Deployment` in #2041.
- Keeping a DaemonSet/Deployment switch in `cozystack-controller` made reconciliation mode configuration-dependent.
- In CI this could leave `cozystack-api` without the expected restart on `ApplicationDefinition` changes, causing dynamic app resources (for example `tenants`) to be missing temporarily.

Changes:
- Remove `cozystackAPIKind` from `cozystack-controller` chart values.
- Remove conditional `--reconcile-deployment` arg from controller Deployment template.
- Remove `--reconcile-deployment` flag handling from `cmd/cozystack-controller`.
- Simplify `ApplicationDefinitionReconciler` to always patch `cozystack-api` `Deployment` pod template.

### Release note

```release-note
[platform] Remove cozystackAPIKind switch and always reconcile cozystack-api as Deployment
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified the application controller by removing API kind selection logic; the system now uses a unified approach for workload reconciliation.
  * Removed the cozystackAPIKind configuration value, reducing configuration complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->