### PR TITLE
feat(cluster-autoscaler): enable enforce-node-group-min-size by default

### DIFF
--- a/packages/system/cluster-autoscaler/values.yaml
+++ b/packages/system/cluster-autoscaler/values.yaml
@@ -1,1 +1,3 @@
-cluster-autoscaler: {}
+cluster-autoscaler:
+  extraArgs:
+    enforce-node-group-min-size: true


### PR DESCRIPTION
## Summary
- Enable `enforce-node-group-min-size` option for the system cluster-autoscaler chart
- This ensures node groups are always scaled up to their configured minimum size, even when current workload doesn't require it

## Test plan
- [ ] Deploy cluster-autoscaler with updated values and verify the flag is passed to the container
- [ ] Verify node groups scale up to min-size when below minimum

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster-autoscaler configuration to enforce node group minimum size constraints during scaling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->