### PR TITLE
[platform] preserve tenant-root HelmRelease during migration

### DIFF
--- a/packages/system/cozystack-basics/templates/tenant-root.yaml
+++ b/packages/system/cozystack-basics/templates/tenant-root.yaml
@@ -4,6 +4,11 @@ kind: Namespace
 metadata:
   name: tenant-root
 ---
+{{- $existingValues := dict }}
+{{- $existing := lookup "helm.toolkit.fluxcd.io/v2" "HelmRelease" "tenant-root" "tenant-root" }}
+{{- if and $existing $existing.spec $existing.spec.values }}
+{{- $existingValues = omit $existing.spec.values "_cluster" }}
+{{- end }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -24,6 +29,9 @@ spec:
   interval: 1m0s
   timeout: 5m0s
   values:
-    _cluster:
-      oidc-enabled: {{ .Values.oidcEnabled | quote }}
-      root-host: {{ .Values.rootHost | quote }}
+    {{- $clusterValues := dict
+        "oidc-enabled" (.Values.oidcEnabled | toString)
+        "root-host" (.Values.rootHost | toString)
+    }}
+    {{- $mergedValues := merge (dict "_cluster" $clusterValues) $existingValues }}
+    {{- $mergedValues | toYaml | nindent 4 }}


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

1. During migration from 0.41.5 to 1.0.0-beta5 I have experienced deletion of `tenant-root` helmrelease (and namespace created by this release), which can lead to loss of data and outage of service.
2. After migration it is possible to lose data and tenant services during next reconciliation of `cozystack-basics`

This PR fixes this behavior by adding safety annotation to HelmRelease and lookup for saving current parameters

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[platform] preserve tenant-root HelmRelease during migration
```