### PR TITLE
fix(platform): adopt tenant-root into cozystack-basics during migration

### DIFF
--- a/packages/core/platform/images/migrations/migrations/31
+++ b/packages/core/platform/images/migrations/migrations/31
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Migration 31 --> 32
+# Adopt tenant-root resources into cozystack-basics Helm release.
+#
+# In v0.41.x tenant-root Namespace and HelmRelease were applied via
+# kubectl apply (no Helm tracking). In v1.0 they are managed by the
+# cozystack-basics Helm release. Without Helm ownership annotations
+# the install of cozystack-basics fails because the resources already
+# exist. This migration adds the required annotations and labels so
+# Helm can adopt them.
+
+set -euo pipefail
+
+RELEASE_NAME="cozystack-basics"
+RELEASE_NS="cozy-system"
+
+# Adopt Namespace tenant-root
+if kubectl get namespace tenant-root >/dev/null 2>&1; then
+  echo "Adopting Namespace tenant-root into $RELEASE_NAME"
+  kubectl annotate namespace tenant-root \
+    meta.helm.sh/release-name="$RELEASE_NAME" \
+    meta.helm.sh/release-namespace="$RELEASE_NS" \
+    --overwrite
+  kubectl label namespace tenant-root \
+    app.kubernetes.io/managed-by=Helm \
+    --overwrite
+fi
+
+# Adopt HelmRelease tenant-root
+if kubectl get helmrelease -n tenant-root tenant-root >/dev/null 2>&1; then
+  echo "Adopting HelmRelease tenant-root into $RELEASE_NAME"
+  kubectl annotate helmrelease -n tenant-root tenant-root \
+    meta.helm.sh/release-name="$RELEASE_NAME" \
+    meta.helm.sh/release-namespace="$RELEASE_NS" \
+    helm.sh/resource-policy=keep \
+    --overwrite
+  kubectl label helmrelease -n tenant-root tenant-root \
+    app.kubernetes.io/managed-by=Helm \
+    sharding.fluxcd.io/key=tenants \
+    --overwrite
+fi
+
+# Stamp version
+kubectl create configmap -n cozy-system cozystack-version \
+  --from-literal=version=32 --dry-run=client -o yaml | kubectl apply -f-

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -6,7 +6,7 @@ sourceRef:
 migrations:
   enabled: false
   image: ghcr.io/cozystack/cozystack/platform-migrations:v1.0.0-beta.5@sha256:e7a9e0f0adc33e0be007af42f50ed3af064aa965ad628e48cc6c7943f31f239d
-  targetVersion: 31
+  targetVersion: 32
 # Bundle deployment configuration
 bundles:
   system:


### PR DESCRIPTION
## What this PR does

Adds migration 31 to adopt existing `tenant-root` Namespace and HelmRelease
into the `cozystack-basics` Helm release during upgrade from v0.41.x to v1.0.

In v0.41.x these resources were applied via `kubectl apply` (from the platform
chart `apps.yaml`) with no Helm release tracking. In v1.0 they are created by
the `cozystack-basics` chart. Without Helm ownership annotations, `helm install`
of `cozystack-basics` fails because the resources already exist.

The migration adds:
- `meta.helm.sh/release-name` and `meta.helm.sh/release-namespace` annotations
  for Helm adoption
- `app.kubernetes.io/managed-by: Helm` label
- `helm.sh/resource-policy: keep` annotation on the HelmRelease to prevent
  accidental deletion
- `sharding.fluxcd.io/key: tenants` label required by flux sharding in v1.0

This follows the same pattern as migrations 22 and 27 (CRD adoption).

Related: #2063

### Release note

```release-note
[platform] adopt tenant-root resources into cozystack-basics Helm release during migration
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added migration to version 32 with support for adopting tenant-root resources into the cozystack-basics Helm release.
  * Includes enhanced error handling and validation checks for the migration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->