### PR TITLE
fix(cozystack-basics) Preserve existing HelmRelease values during reconciliations

### DIFF
--- a/packages/system/cozystack-basics/templates/tenant-root.yaml
+++ b/packages/system/cozystack-basics/templates/tenant-root.yaml
@@ -23,7 +23,6 @@ spec:
     namespace: cozy-system
   interval: 1m0s
   timeout: 5m0s
-  values:
-    _cluster:
-      oidc-enabled: {{ .Values.oidcEnabled | quote }}
-      root-host: {{ .Values.rootHost | quote }}
+  valuesFrom:
+    - kind: Secret
+      name: cozystack-values


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Bug: Changes to Tenant `tenant-root` will be dropped on next force (or upgrade) reconciliation of `cosystack-basics` HelmRelease. This may lead to data loss and outage of service

This PR fixes such behavior preserving values, applied by the user

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[cozystack-basics] Preserve existing `HelmRelease` values of `tenant-root` during reconciliations
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cluster configuration to preserve existing settings during updates instead of overwriting them. The system now properly merges new configuration with prior values, ensuring no settings are unexpectedly lost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->