### PR TITLE
[system] Fix monitoring-agents FQDN resolution for tenant workload clusters

### DIFF
--- a/packages/system/monitoring-agents/values.yaml
+++ b/packages/system/monitoring-agents/values.yaml
@@ -280,8 +280,8 @@ vmagent:
     cluster: cozystack
   remoteWrite:
     urls:
-      - http://vminsert-shortterm.{{ .Values.global.target }}.svc:8480/insert/0/prometheus
-      - http://vminsert-longterm.{{ .Values.global.target }}.svc:8480/insert/0/prometheus
+      - http://vminsert-shortterm.{{ .Values.global.target }}.svc.{{ (index .Values._cluster "cluster-domain") | default "cluster.local" }}:8480/insert/0/prometheus
+      - http://vminsert-longterm.{{ .Values.global.target }}.svc.{{ (index .Values._cluster "cluster-domain") | default "cluster.local" }}:8480/insert/0/prometheus
   extraArgs: {}
 
 fluent-bit:
@@ -344,7 +344,7 @@ fluent-bit:
       [OUTPUT]
           Name http
           Match kube.*
-          Host vlogs-generic.{{ .Values.global.target }}.svc
+          Host vlogs-generic.{{ .Values.global.target }}.svc.{{ (index .Values._cluster "cluster-domain") | default "cluster.local" }}
           port 9428
           compress gzip
           uri /insert/jsonline?_stream_fields=log_source,stream,kubernetes_pod_name,kubernetes_container_name,kubernetes_namespace_name&_msg_field=log&_time_field=date
@@ -355,7 +355,7 @@ fluent-bit:
       [OUTPUT]
           Name http
           Match events.*
-          Host vlogs-generic.{{ .Values.global.target }}.svc
+          Host vlogs-generic.{{ .Values.global.target }}.svc.{{ (index .Values._cluster "cluster-domain") | default "cluster.local" }}
           port 9428
           compress gzip
           uri /insert/jsonline?_stream_fields=log_source,reason,meatdata_namespace,metadata_name&_msg_field=message&_time_field=date
@@ -366,7 +366,7 @@ fluent-bit:
       [OUTPUT]
           Name http
           Match audit.*
-          Host vlogs-generic.{{ .Values.global.target }}.svc
+          Host vlogs-generic.{{ .Values.global.target }}.svc.{{ (index .Values._cluster "cluster-domain") | default "cluster.local" }}
           port 9428
           compress gzip
           uri /insert/jsonline?_stream_fields=log_source,stage,user_username,verb,requestUri&_msg_field=requestURI&_time_field=date


### PR DESCRIPTION
## What this PR does

Monitoring agents (vmagent, fluent-bit) in tenant workload clusters failed to deliver metrics and logs because service addresses used short DNS names (e.g. `vminsert-longterm.tenant-root.svc`) without the cluster domain suffix. Tenant CoreDNS could not resolve these names across cluster boundaries.

This PR appends the configured cluster domain from `_cluster.cluster-domain` to all vmagent remoteWrite URLs and fluent-bit output hosts, with a fallback to `cluster.local` when not set.

### Release note

```release-note
[system] Fix monitoring-agents endpoints to use FQDN with configured cluster domain, resolving metrics and logs delivery failures in tenant workload clusters.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced monitoring configuration to support customizable cluster-domain values with automatic fallback to cluster.local default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->