### PR TITLE
fix(cozystack-basics) Deny resourcequotas deletion for tenant admin

### DIFF
--- a/packages/system/cozystack-basics/templates/clusterroles.yaml
+++ b/packages/system/cozystack-basics/templates/clusterroles.yaml
@@ -181,7 +181,6 @@ rules:
   - persistentvolumes
   - endpoints
   - events
-  - resourcequotas
   verbs:
   - delete
 - apiGroups: ["kubevirt.io"]


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
Fixed cozy:tenant:admin:base ClusterRole to deny deletion of tenant ResourceQuotas for the tenant admin and superadmin
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed resource quota management permissions from tenant admin role to reduce unnecessary administrative access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->