### PR TITLE
[kamaji] Revert premature update to post-edge-26.2.4

### DIFF
--- a/packages/system/kamaji/charts/kamaji-crds/hack/kamaji.clastix.io_datastores_spec.yaml
+++ b/packages/system/kamaji/charts/kamaji-crds/hack/kamaji.clastix.io_datastores_spec.yaml
@@ -11,10 +11,6 @@ versions:
         jsonPath: .spec.driver
         name: Driver
         type: string
-      - description: DataStore validated and ready for use
-        jsonPath: .status.ready
-        name: Ready
-        type: boolean
       - description: Age
         jsonPath: .metadata.creationTimestamp
         name: Age
@@ -276,83 +272,18 @@ versions:
                 rule: '(self.driver != "etcd" && has(self.basicAuth)) ? ((has(self.basicAuth.password.secretReference) || has(self.basicAuth.password.content))) : true'
               - message: When driver is not etcd, either tlsConfig or basicAuth must be provided
                 rule: '(self.driver != "etcd") ? (has(self.tlsConfig) || has(self.basicAuth)) : true'
-              - message: driver is immutable and cannot be changed after creation
-                rule: oldSelf == null || self.driver == oldSelf.driver
           status:
             description: DataStoreStatus defines the observed state of DataStore.
             properties:
-              conditions:
-                description: Conditions contains the validation conditions for the given Datastore.
-                items:
-                  description: Condition contains details for one aspect of the current state of this API Resource.
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                        - "True"
-                        - "False"
-                        - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                    - lastTransitionTime
-                    - message
-                    - reason
-                    - status
-                    - type
-                  type: object
-                type: array
               observedGeneration:
                 description: ObservedGeneration represents the .metadata.generation that was last reconciled.
                 format: int64
                 type: integer
-              ready:
-                description: |-
-                  Ready returns if the DataStore is accepted and ready to get used:
-                  Kamaji will ensure certificates are available, or correctly referenced.
-                type: boolean
               usedBy:
                 description: List of the Tenant Control Planes, namespaced named, using this data store.
                 items:
                   type: string
                 type: array
-            required:
-              - ready
             type: object
         type: object
     served: true

--- a/packages/system/kamaji/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
+++ b/packages/system/kamaji/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
@@ -6896,6 +6896,9 @@ versions:
                           type: object
                         type: array
                     type: object
+                    x-kubernetes-validations:
+                      - message: parentRefs must not specify port or sectionName, these are set automatically by Kamaji
+                        rule: '!has(self.parentRefs) || size(self.parentRefs) == 0 || self.parentRefs.all(ref, !has(ref.port) && !has(ref.sectionName))'
                   ingress:
                     description: Defining the options for an Optional Ingress which will expose API Server of the Tenant Control Plane
                     properties:

--- a/packages/system/kamaji/charts/kamaji/controller-gen/validating-webhook.yaml
+++ b/packages/system/kamaji/charts/kamaji/controller-gen/validating-webhook.yaml
@@ -25,6 +25,46 @@
     service:
       name: '{{ include "kamaji.webhookServiceName" . }}'
       namespace: '{{ .Release.Namespace }}'
+      path: /validate-kamaji-clastix-io-v1alpha1-datastore
+  failurePolicy: Fail
+  name: vdatastore.kb.io
+  rules:
+    - apiGroups:
+        - kamaji.clastix.io
+      apiVersions:
+        - v1alpha1
+      operations:
+        - CREATE
+        - UPDATE
+        - DELETE
+      resources:
+        - datastores
+  sideEffects: None
+- admissionReviewVersions:
+    - v1
+  clientConfig:
+    service:
+      name: '{{ include "kamaji.webhookServiceName" . }}'
+      namespace: '{{ .Release.Namespace }}'
+      path: /validate--v1-secret
+  failurePolicy: Ignore
+  name: vdatastoresecrets.kb.io
+  rules:
+    - apiGroups:
+        - ""
+      apiVersions:
+        - v1
+      operations:
+        - DELETE
+      resources:
+        - secrets
+  sideEffects: None
+- admissionReviewVersions:
+    - v1
+  clientConfig:
+    service:
+      name: '{{ include "kamaji.webhookServiceName" . }}'
+      namespace: '{{ .Release.Namespace }}'
       path: /validate-kamaji-clastix-io-v1alpha1-tenantcontrolplane
   failurePolicy: Fail
   name: vtenantcontrolplane.kb.io

--- a/packages/system/kamaji/charts/kamaji/crds/kamaji.clastix.io_datastores.yaml
+++ b/packages/system/kamaji/charts/kamaji/crds/kamaji.clastix.io_datastores.yaml
@@ -20,10 +20,6 @@ spec:
           jsonPath: .spec.driver
           name: Driver
           type: string
-        - description: DataStore validated and ready for use
-          jsonPath: .status.ready
-          name: Ready
-          type: boolean
         - description: Age
           jsonPath: .metadata.creationTimestamp
           name: Age
@@ -285,83 +281,18 @@ spec:
                   rule: '(self.driver != "etcd" && has(self.basicAuth)) ? ((has(self.basicAuth.password.secretReference) || has(self.basicAuth.password.content))) : true'
                 - message: When driver is not etcd, either tlsConfig or basicAuth must be provided
                   rule: '(self.driver != "etcd") ? (has(self.tlsConfig) || has(self.basicAuth)) : true'
-                - message: driver is immutable and cannot be changed after creation
-                  rule: oldSelf == null || self.driver == oldSelf.driver
             status:
               description: DataStoreStatus defines the observed state of DataStore.
               properties:
-                conditions:
-                  description: Conditions contains the validation conditions for the given Datastore.
-                  items:
-                    description: Condition contains details for one aspect of the current state of this API Resource.
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
                 observedGeneration:
                   description: ObservedGeneration represents the .metadata.generation that was last reconciled.
                   format: int64
                   type: integer
-                ready:
-                  description: |-
-                    Ready returns if the DataStore is accepted and ready to get used:
-                    Kamaji will ensure certificates are available, or correctly referenced.
-                  type: boolean
                 usedBy:
                   description: List of the Tenant Control Planes, namespaced named, using this data store.
                   items:
                     type: string
                   type: array
-              required:
-                - ready
               type: object
           type: object
       served: true

--- a/packages/system/kamaji/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/packages/system/kamaji/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -6904,6 +6904,9 @@ spec:
                             type: object
                           type: array
                       type: object
+                      x-kubernetes-validations:
+                        - message: parentRefs must not specify port or sectionName, these are set automatically by Kamaji
+                          rule: '!has(self.parentRefs) || size(self.parentRefs) == 0 || self.parentRefs.all(ref, !has(ref.port) && !has(ref.sectionName))'
                     ingress:
                       description: Defining the options for an Optional Ingress which will expose API Server of the Tenant Control Plane
                       properties:

--- a/packages/system/kamaji/images/kamaji/Dockerfile
+++ b/packages/system/kamaji/images/kamaji/Dockerfile
@@ -1,13 +1,13 @@
 # Build the manager binary
 FROM golang:1.26 AS builder
 
-ARG VERSION=309d9889e8eefe40b4c6c6843ad9683959f02e5e
+ARG VERSION=edge-26.2.4
 ARG TARGETOS
 ARG TARGETARCH
 
 WORKDIR /workspace
 
-RUN curl -sSL https://github.com/clastix/kamaji/archive/${VERSION}.tar.gz | tar -xzvf- --strip=1
+RUN curl -sSL https://github.com/clastix/kamaji/archive/refs/tags/${VERSION}.tar.gz | tar -xzvf- --strip=1
 
 COPY patches /patches
 RUN git apply /patches/*.diff

--- a/packages/system/kamaji/images/kamaji/patches/disable-datastore-check.diff
+++ b/packages/system/kamaji/images/kamaji/patches/disable-datastore-check.diff
@@ -1,0 +1,30 @@
+diff --git a/cmd/manager/cmd.go b/cmd/manager/cmd.go
+--- a/cmd/manager/cmd.go
++++ b/cmd/manager/cmd.go
+@@ -4,7 +4,6 @@
+ package manager
+
+ import (
+-	"context"
+ 	"flag"
+ 	"fmt"
+ 	"io"
+@@ -34,7 +33,6 @@
+ 	"github.com/clastix/kamaji/controllers/soot"
+ 	"github.com/clastix/kamaji/internal"
+ 	"github.com/clastix/kamaji/internal/builders/controlplane"
+-	datastoreutils "github.com/clastix/kamaji/internal/datastore/utils"
+ 	"github.com/clastix/kamaji/internal/utilities"
+ 	"github.com/clastix/kamaji/internal/webhook"
+ 	"github.com/clastix/kamaji/internal/webhook/handlers"
+@@ -85,10 +83,6 @@
+
+ 			if webhookCABundle, err = os.ReadFile(webhookCAPath); err != nil {
+ 				return fmt.Errorf("unable to read webhook CA: %w", err)
+-			}
+-
+-			if err = datastoreutils.CheckExists(context.Background(), scheme, datastore); err != nil {
+-				return err
+ 			}
+
+ 			if controllerReconcileTimeout.Seconds() == 0 {


### PR DESCRIPTION
## What this PR does

Reverts #2079 — the Kamaji update was merged prematurely while marked with `do-not-merge` label. The upstream commit (`309d9889`) has not been released as an edge tag yet.

### Release note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified DataStore status reporting by removing redundant readiness metadata
  * Enhanced TenantControlPlane validation to enforce proper Gateway configuration
  * Improved webhook validation for DataStore and Secret resources
  * Streamlined service initialization process
  * Updated container image build configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->