### PR TITLE
docs(changelogs): add missing changelogs for v0.40.5-v0.40.7 and v0.41.4-v0.41.9

### DIFF
--- a/docs/changelogs/v0.40.5.md
+++ b/docs/changelogs/v0.40.5.md
@@ -1,0 +1,15 @@
+<!--
+https://github.com/cozystack/cozystack/releases/tag/v0.40.5
+-->
+
+## Improvements
+
+* **[dashboard] Improve dashboard session params**: Improved session parameter handling in the dashboard for better user experience and more reliable session management ([**@lllamnyp**](https://github.com/lllamnyp) in #1913, #1919).
+
+## Dependencies
+
+* **Update cozyhr to v1.6.1**: Updated cozyhr to v1.6.1, which fixes a critical bug causing helm-controller v0.37.0+ to unexpectedly uninstall HelmReleases after cozyhr apply by correcting history snapshot fields for helm-controller compatibility ([**@kvaps**](https://github.com/kvaps) in cozystack/cozyhr#10).
+
+---
+
+**Full Changelog**: [v0.40.4...v0.40.5](https://github.com/cozystack/cozystack/compare/v0.40.4...v0.40.5)

--- a/docs/changelogs/v0.40.6.md
+++ b/docs/changelogs/v0.40.6.md
@@ -1,0 +1,11 @@
+<!--
+https://github.com/cozystack/cozystack/releases/tag/v0.40.6
+-->
+
+## Fixes
+
+* **[kubernetes] Fix manifests for kubernetes deployment**: Fixed incorrect manifests that prevented proper Kubernetes deployment, restoring correct application behavior ([**@IvanHunters**](https://github.com/IvanHunters) in #1943, #1944).
+
+---
+
+**Full Changelog**: [v0.40.5...v0.40.6](https://github.com/cozystack/cozystack/compare/v0.40.5...v0.40.6)

--- a/docs/changelogs/v0.40.7.md
+++ b/docs/changelogs/v0.40.7.md
@@ -1,0 +1,11 @@
+<!--
+https://github.com/cozystack/cozystack/releases/tag/v0.40.7
+-->
+
+## Security
+
+* **[dashboard] Verify JWT token**: Added JWT token verification to the dashboard, ensuring that authentication tokens are properly validated before granting access. This prevents unauthorized access through forged or expired tokens ([**@lllamnyp**](https://github.com/lllamnyp) in #1980, #1984).
+
+---
+
+**Full Changelog**: [v0.40.6...v0.40.7](https://github.com/cozystack/cozystack/compare/v0.40.6...v0.40.7)

--- a/docs/changelogs/v0.41.4.md
+++ b/docs/changelogs/v0.41.4.md
@@ -1,0 +1,11 @@
+<!--
+https://github.com/cozystack/cozystack/releases/tag/v0.41.4
+-->
+
+## Dependencies
+
+* **Update cozyhr to v1.6.1**: Updated cozyhr to v1.6.1, which fixes a critical bug causing helm-controller v0.37.0+ to unexpectedly uninstall HelmReleases after cozyhr apply by correcting history snapshot fields for helm-controller compatibility ([**@kvaps**](https://github.com/kvaps) in cozystack/cozyhr#10).
+
+---
+
+**Full Changelog**: [v0.41.3...v0.41.4](https://github.com/cozystack/cozystack/compare/v0.41.3...v0.41.4)

--- a/docs/changelogs/v0.41.5.md
+++ b/docs/changelogs/v0.41.5.md
@@ -1,0 +1,21 @@
+<!--
+https://github.com/cozystack/cozystack/releases/tag/v0.41.5
+-->
+
+## Features and Improvements
+
+* **[dashboard] Add "Edit" button to all resources**: Added an "Edit" button across all resource views in the dashboard, allowing users to modify resource configurations directly from the UI ([**@sircthulhu**](https://github.com/sircthulhu) in #1928, #1931).
+
+* **[dashboard] Add resource quota usage to tenant details page**: Added resource quota usage display to the tenant details page, giving administrators visibility into how much of allocated resources each tenant is consuming ([**@sircthulhu**](https://github.com/sircthulhu) in #1929, #1932).
+
+* **[branding] Separate values for keycloak**: Separated Keycloak branding values into dedicated configuration, allowing more granular customization of Keycloak appearance without affecting other branding settings ([**@nbykov0**](https://github.com/nbykov0) in #1946).
+
+* **Add instance profile label to workload monitor**: Added instance profile metadata labels to the workload monitor, enabling better resource tracking and monitoring by instance profile type ([**@matthieu-robin**](https://github.com/matthieu-robin) in #1954, #1957).
+
+## Fixes
+
+* **[kubernetes] Fix manifests for kubernetes deployment**: Fixed incorrect manifests that prevented proper Kubernetes deployment, restoring correct application behavior ([**@IvanHunters**](https://github.com/IvanHunters) in #1943, #1945).
+
+---
+
+**Full Changelog**: [v0.41.4...v0.41.5](https://github.com/cozystack/cozystack/compare/v0.41.4...v0.41.5)

--- a/docs/changelogs/v0.41.6.md
+++ b/docs/changelogs/v0.41.6.md
@@ -1,0 +1,17 @@
+<!--
+https://github.com/cozystack/cozystack/releases/tag/v0.41.6
+-->
+
+## Improvements
+
+* **[vm] Allow changing field external after creation**: Users can now modify the external network field on virtual machines after initial creation, providing more flexibility in VM networking configuration without requiring recreation ([**@sircthulhu**](https://github.com/sircthulhu) in #1956, #1962).
+
+* **[branding] Separate values for keycloak**: Separated Keycloak branding values into dedicated configuration for more granular customization of Keycloak appearance ([**@nbykov0**](https://github.com/nbykov0) in #1947, #1963).
+
+## Fixes
+
+* **[kubernetes] Fix coredns serviceaccount to match kubernetes bootstrap RBAC**: Configured the CoreDNS chart to create a `kube-dns` ServiceAccount matching the Kubernetes bootstrap ClusterRoleBinding, fixing RBAC errors (`Failed to watch`) when CoreDNS pods restart ([**@mattia-eleuteri**](https://github.com/mattia-eleuteri) in #1958, #1978).
+
+---
+
+**Full Changelog**: [v0.41.5...v0.41.6](https://github.com/cozystack/cozystack/compare/v0.41.5...v0.41.6)

--- a/docs/changelogs/v0.41.7.md
+++ b/docs/changelogs/v0.41.7.md
@@ -1,0 +1,15 @@
+<!--
+https://github.com/cozystack/cozystack/releases/tag/v0.41.7
+-->
+
+## Security
+
+* **[dashboard] Verify JWT token**: Added JWT token verification to the dashboard, ensuring that authentication tokens are properly validated before granting access. This prevents unauthorized access through forged or expired tokens ([**@lllamnyp**](https://github.com/lllamnyp) in #1980, #1983).
+
+## Fixes
+
+* **[postgres-operator] Correct PromQL syntax in CNPGClusterOffline alert**: Fixed incorrect PromQL syntax in the `CNPGClusterOffline` alert rule for CloudNativePG, ensuring the alert fires correctly when all instances of a PostgreSQL cluster are offline ([**@mattia-eleuteri**](https://github.com/mattia-eleuteri) in #1981, #1989).
+
+---
+
+**Full Changelog**: [v0.41.6...v0.41.7](https://github.com/cozystack/cozystack/compare/v0.41.6...v0.41.7)

--- a/docs/changelogs/v0.41.8.md
+++ b/docs/changelogs/v0.41.8.md
@@ -1,0 +1,17 @@
+<!--
+https://github.com/cozystack/cozystack/releases/tag/v0.41.8
+-->
+
+## Features and Improvements
+
+* **[kubernetes] Auto-enable Gateway API support in cert-manager**: cert-manager now automatically enables `enableGatewayAPI` when the Gateway API addon is active in the Kubernetes application. Users no longer need to manually configure this setting, and the option can still be overridden via `valuesOverride` ([**@kvaps**](https://github.com/kvaps) in #1997, #2012).
+
+* **[vm] Allow switching between instancetype and custom resources**: Users can now switch virtual machines between instancetype-based and custom resource configurations after creation. The upgrade hook atomically patches VM resources, providing more flexibility in adjusting VM sizing without recreation ([**@sircthulhu**](https://github.com/sircthulhu) in #2008, #2013).
+
+## Fixes
+
+* **[dashboard] Add startupProbe to prevent container restarts on slow hardware**: Added `startupProbe` to both `bff` and `web` containers in the dashboard deployment. On slow hardware, kubelet was killing containers because the `livenessProbe` only allowed ~33 seconds for startup. The `startupProbe` gives containers up to 60 seconds to start before `livenessProbe` kicks in ([**@kvaps**](https://github.com/kvaps) in #1996, #2014).
+
+---
+
+**Full Changelog**: [v0.41.7...v0.41.8](https://github.com/cozystack/cozystack/compare/v0.41.7...v0.41.8)

--- a/docs/changelogs/v0.41.9.md
+++ b/docs/changelogs/v0.41.9.md
@@ -1,0 +1,15 @@
+<!--
+https://github.com/cozystack/cozystack/releases/tag/v0.41.9
+-->
+
+## Fixes
+
+* **[cozystack-basics] Deny resourcequotas deletion for tenant admin**: Prevented tenant administrators from deleting resource quotas, ensuring that resource limits set by platform administrators cannot be bypassed by tenant-level users ([**@myasnikovdaniil**](https://github.com/myasnikovdaniil) in #2076).
+
+## Dependencies
+
+* **Update Kube-OVN to v1.15.3**: Updated Kube-OVN CNI to v1.15.3 with latest bug fixes and improvements ([**@kvaps**](https://github.com/kvaps)).
+
+---
+
+**Full Changelog**: [v0.41.8...v0.41.9](https://github.com/cozystack/cozystack/compare/v0.41.8...v0.41.9)


### PR DESCRIPTION
## What this PR does

Add 9 missing patch release changelogs:
- **v0.40.x**: v0.40.5, v0.40.6, v0.40.7
- **v0.41.x**: v0.41.4, v0.41.5, v0.41.6, v0.41.7, v0.41.8, v0.41.9

All PR authors were verified via `gh pr view` (not from commit authors).
Format matches existing changelog files in the repository.

### Release note

```release-note
[docs] Add missing changelogs for v0.40.5-v0.40.7 and v0.41.4-v0.41.9
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard: Added edit functionality for resource views and resource quota visibility on tenant details.
  * VM management: Enable external field modification and instance type switching post-creation.
  * Kubernetes: Auto-enable Gateway API support in cert-manager.
  * Branding: Separated Keycloak configuration for enhanced customization.

* **Security**
  * Dashboard: Implemented JWT token verification for authentication validation.

* **Bug Fixes**
  * Fixed Kubernetes deployment manifests and CoreDNS RBAC issues.
  * Improved dashboard stability with startup probes.
  * Corrected alert accuracy and restricted unauthorized quota deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->