### PR TITLE
fix(monitoring-agents): use global.clusterDomain for FQDN resolution

### DIFF
--- a/packages/apps/kubernetes/templates/helmreleases/monitoring-agents.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/monitoring-agents.yaml
@@ -1,4 +1,5 @@
 {{- $targetTenant := .Values._namespace.monitoring }}
+{{- $clusterDomain := (index .Values._cluster "cluster-domain") | default "cozy.local" }}
 {{- if .Values.addons.monitoringAgents.enabled }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -49,7 +50,7 @@ spec:
         cluster: {{ .Release.Name }}
         tenant: {{ .Release.Namespace }}
       remoteWrite:
-        url: http://vminsert-shortterm.{{ $targetTenant }}.svc:8480/insert/0/prometheus
+        url: http://vminsert-shortterm.{{ $targetTenant }}.svc.{{ $clusterDomain }}:8480/insert/0/prometheus
     fluent-bit:
       readinessProbe:
         httpGet:
@@ -72,7 +73,7 @@ spec:
           [OUTPUT]
               Name http
               Match kube.*
-              Host vlogs-generic.{{ $targetTenant }}.svc
+              Host vlogs-generic.{{ $targetTenant }}.svc.{{ $clusterDomain }}
               port 9428
               compress gzip
               uri /insert/jsonline?_stream_fields=stream,kubernetes_pod_name,kubernetes_container_name,kubernetes_namespace_name&_msg_field=log&_time_field=date

--- a/packages/system/monitoring-agents/values.yaml
+++ b/packages/system/monitoring-agents/values.yaml
@@ -280,8 +280,8 @@ vmagent:
     cluster: cozystack
   remoteWrite:
     urls:
-      - http://vminsert-shortterm.{{ .Values.global.target }}.svc.{{ (index .Values._cluster "cluster-domain") | default "cluster.local" }}:8480/insert/0/prometheus
-      - http://vminsert-longterm.{{ .Values.global.target }}.svc.{{ (index .Values._cluster "cluster-domain") | default "cluster.local" }}:8480/insert/0/prometheus
+      - http://vminsert-shortterm.{{ .Values.global.target }}.svc:8480/insert/0/prometheus
+      - http://vminsert-longterm.{{ .Values.global.target }}.svc:8480/insert/0/prometheus
   extraArgs: {}
 
 fluent-bit:
@@ -344,7 +344,7 @@ fluent-bit:
       [OUTPUT]
           Name http
           Match kube.*
-          Host vlogs-generic.{{ .Values.global.target }}.svc.{{ (index .Values._cluster "cluster-domain") | default "cluster.local" }}
+          Host vlogs-generic.{{ .Values.global.target }}.svc
           port 9428
           compress gzip
           uri /insert/jsonline?_stream_fields=log_source,stream,kubernetes_pod_name,kubernetes_container_name,kubernetes_namespace_name&_msg_field=log&_time_field=date
@@ -355,7 +355,7 @@ fluent-bit:
       [OUTPUT]
           Name http
           Match events.*
-          Host vlogs-generic.{{ .Values.global.target }}.svc.{{ (index .Values._cluster "cluster-domain") | default "cluster.local" }}
+          Host vlogs-generic.{{ .Values.global.target }}.svc
           port 9428
           compress gzip
           uri /insert/jsonline?_stream_fields=log_source,reason,meatdata_namespace,metadata_name&_msg_field=message&_time_field=date
@@ -366,7 +366,7 @@ fluent-bit:
       [OUTPUT]
           Name http
           Match audit.*
-          Host vlogs-generic.{{ .Values.global.target }}.svc.{{ (index .Values._cluster "cluster-domain") | default "cluster.local" }}
+          Host vlogs-generic.{{ .Values.global.target }}.svc
           port 9428
           compress gzip
           uri /insert/jsonline?_stream_fields=log_source,stage,user_username,verb,requestUri&_msg_field=requestURI&_time_field=date


### PR DESCRIPTION
## What this PR does

PR #2075 introduced `_cluster.cluster-domain` references in monitoring-agents `values.yaml` for FQDN resolution in tenant clusters. This broke the fluent-bit subchart because `_cluster` values are not accessible from the Helm subchart context — only `global` values are shared with subcharts.

This PR replaces `_cluster` references with a new `global.clusterDomain` variable:
- Empty by default (management cluster uses short DNS names like `service.namespace.svc`)
- Set to the management cluster domain (e.g. `cozy.local`) for tenant clusters, enabling FQDN resolution for cross-cluster service discovery

Fixes #2084

### Release note

```release-note
[system] Fix monitoring-agents installation failure caused by inaccessible _cluster values in fluent-bit subchart context. Introduce global.clusterDomain for proper FQDN resolution in tenant workload clusters.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Monitoring agent configuration updated to support configurable cluster domain names for greater flexibility.
  * Remote write and log-forwarding endpoints adjusted to align with cluster domain handling, improving compatibility when deploying across different cluster DNS setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->