### PR TITLE
[dashboard] Hide Ingresses/Services/Secrets tabs when no selectors defined

### DIFF
--- a/internal/controller/dashboard/factory.go
+++ b/internal/controller/dashboard/factory.go
@@ -583,17 +583,13 @@ type factoryFlags struct {
 }
 
 // factoryFeatureFlags determines which tabs to show based on whether the
-// ApplicationDefinition has non-empty resource selectors (Include or Exclude).
+// ApplicationDefinition has non-empty Include resource selectors.
 // Workloads tab is always shown.
 func factoryFeatureFlags(crd *cozyv1alpha1.ApplicationDefinition) factoryFlags {
 	return factoryFlags{
 		Workloads: true,
-		Ingresses: hasSelectors(crd.Spec.Ingresses),
-		Services:  hasSelectors(crd.Spec.Services),
-		Secrets:   hasSelectors(crd.Spec.Secrets),
+		Ingresses: len(crd.Spec.Ingresses.Include) > 0,
+		Services:  len(crd.Spec.Services.Include) > 0,
+		Secrets:   len(crd.Spec.Secrets.Include) > 0,
 	}
-}
-
-func hasSelectors(res cozyv1alpha1.ApplicationDefinitionResources) bool {
-	return len(res.Include) > 0 || len(res.Exclude) > 0
 }


### PR DESCRIPTION
## What this PR does

Hide Ingresses, Services, and Secrets tabs in the dashboard when the
ApplicationDefinition has no resource selectors (Include/Exclude) for
the corresponding type. Previously all tabs were always hardcoded as visible.

### Release note

```release-note
[dashboard] Hide Ingresses/Services/Secrets tabs when ApplicationDefinition has no resource selectors defined
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard tab visibility refined: Workloads tab remains always visible; Ingresses, Services, and Secrets tabs now appear only when corresponding resource selectors are configured, reducing clutter and showing relevant tabs based on configured resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->