### PR TITLE
[apps] Add readonly BucketAccessClass for SeaweedFS COSI

### DIFF
--- a/packages/extra/seaweedfs/templates/client/cosi-bucket-class.yaml
+++ b/packages/extra/seaweedfs/templates/client/cosi-bucket-class.yaml
@@ -13,6 +13,8 @@ metadata:
   name: {{ .Release.Namespace }}
 driverName: {{ .Release.Namespace }}.seaweedfs.objectstorage.k8s.io
 authenticationType: KEY
+parameters:
+  accessPolicy: readwrite
 ---
 kind: BucketAccessClass
 apiVersion: objectstorage.k8s.io/v1alpha1

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-bucket-class.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-bucket-class.yaml
@@ -13,6 +13,8 @@ metadata:
   name: {{ .Values.cosi.bucketClassName }}
 driverName: {{ .Values.cosi.driverName }}
 authenticationType: KEY
+parameters:
+  accessPolicy: readwrite
 ---
 kind: BucketAccessClass
 apiVersion: objectstorage.k8s.io/v1alpha1


### PR DESCRIPTION
## What this PR does

Adds a second `BucketAccessClass` with `-ro` suffix and `accessPolicy: readonly`
parameter to both SeaweedFS chart templates (extra and system). This enables
COSI consumers to request read-only bucket access.

Depends on: seaweedfs/seaweedfs-cosi-driver#3

### Release note

```release-note
[apps] Add readonly BucketAccessClass (`-ro` suffix) for SeaweedFS COSI driver
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added readonly bucket access class for SeaweedFS object storage integration
  * Introduced readwrite access policy configuration for existing bucket classes, enabling more granular access control options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->