### PR TITLE
feat(seaweedfs): add WORM BucketClass with Object Lock parameters

### DIFF
--- a/packages/extra/seaweedfs/templates/client/cosi-bucket-class.yaml
+++ b/packages/extra/seaweedfs/templates/client/cosi-bucket-class.yaml
@@ -7,6 +7,17 @@ metadata:
 driverName: {{ .Release.Namespace }}.seaweedfs.objectstorage.k8s.io
 deletionPolicy: Delete
 ---
+kind: BucketClass
+apiVersion: objectstorage.k8s.io/v1alpha1
+metadata:
+  name: {{ .Release.Namespace }}-worm
+driverName: {{ .Release.Namespace }}.seaweedfs.objectstorage.k8s.io
+deletionPolicy: Retain
+parameters:
+  objectLockEnabled: "true"
+  objectLockRetentionMode: COMPLIANCE
+  objectLockRetentionDays: "365"
+---
 kind: BucketAccessClass
 apiVersion: objectstorage.k8s.io/v1alpha1
 metadata:

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-bucket-class.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-bucket-class.yaml
@@ -7,6 +7,17 @@ metadata:
 driverName: {{ .Values.cosi.driverName }}
 deletionPolicy: Delete
 ---
+kind: BucketClass
+apiVersion: objectstorage.k8s.io/v1alpha1
+metadata:
+  name: {{ .Values.cosi.bucketClassName }}-worm
+driverName: {{ .Values.cosi.driverName }}
+deletionPolicy: Retain
+parameters:
+  objectLockEnabled: "true"
+  objectLockRetentionMode: COMPLIANCE
+  objectLockRetentionDays: "365"
+---
 kind: BucketAccessClass
 apiVersion: objectstorage.k8s.io/v1alpha1
 metadata:


### PR DESCRIPTION
## Summary

- Add WORM-enabled BucketClass with `-worm` suffix to both extra and system seaweedfs COSI templates
- Uses `deletionPolicy: Retain` and configures Object Lock with COMPLIANCE mode and 365-day default retention
- Parameters consumed by the seaweedfs-cosi-driver Object Lock support

## Test plan

- [x] `helm template` renders correctly with `-worm` BucketClass
- [ ] Verify COSI driver creates Object Lock-enabled buckets with WORM BucketClass