### PR TITLE
feat(seaweedfs): add WORM BucketClass with Object Lock parameters

### DIFF
--- a/packages/extra/seaweedfs/templates/client/cosi-bucket-class.yaml
+++ b/packages/extra/seaweedfs/templates/client/cosi-bucket-class.yaml
@@ -15,7 +15,7 @@ driverName: {{ .Release.Namespace }}.seaweedfs.objectstorage.k8s.io
 deletionPolicy: Retain
 parameters:
   objectLockEnabled: "true"
-  objectLockRetentionMode: COMPLIANCE
+  objectLockRetentionMode: "COMPLIANCE"
   objectLockRetentionDays: "365"
 ---
 kind: BucketAccessClass

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-bucket-class.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-bucket-class.yaml
@@ -15,7 +15,7 @@ driverName: {{ .Values.cosi.driverName }}
 deletionPolicy: Retain
 parameters:
   objectLockEnabled: "true"
-  objectLockRetentionMode: COMPLIANCE
+  objectLockRetentionMode: "COMPLIANCE"
   objectLockRetentionDays: "365"
 ---
 kind: BucketAccessClass


### PR DESCRIPTION
## Summary

- Add WORM-enabled BucketClass with `-worm` suffix to both extra and system seaweedfs COSI templates
- Uses `deletionPolicy: Retain` and configures Object Lock with COMPLIANCE mode and 365-day default retention
- Parameters consumed by the seaweedfs-cosi-driver Object Lock support

## Test plan

- [x] `helm template` renders correctly with `-worm` BucketClass
- [ ] Verify COSI driver creates Object Lock-enabled buckets with WORM BucketClass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a WORM bucket class with object-lock enabled, providing immutable storage and a 365-day compliance-mode retention policy for regulatory and data-protection use cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->