### PR TITLE
fix(dashboard): updated legacy templating

### DIFF
--- a/internal/controller/dashboard/README.md
+++ b/internal/controller/dashboard/README.md
@@ -156,7 +156,7 @@ menuItems = append(menuItems, map[string]any{
         map[string]any{
             "key":   "{plural}",
             "label": "{ResourceLabel}",
-            "link":  "/openapi-ui/{clusterName}/{namespace}/api-table/{group}/{version}/{plural}",
+            "link":  "/openapi-ui/{cluster}/{namespace}/api-table/{group}/{version}/{plural}",
         },
     },
 }),
@@ -174,7 +174,7 @@ menuItems = append(menuItems, map[string]any{
 
 **Important Notes**:
 - The sidebar tag (`{lowercase-kind}-sidebar`) must match what the Factory uses
-- The link format: `/openapi-ui/{clusterName}/{namespace}/api-table/{group}/{version}/{plural}`
+- The link format: `/openapi-ui/{cluster}/{namespace}/api-table/{group}/{version}/{plural}`
 - All sidebars share the same `keysAndTags` and `menuItems`, so changes affect all sidebar instances
 
 ### Step 4: Verify Integration

--- a/internal/controller/dashboard/sidebar.go
+++ b/internal/controller/dashboard/sidebar.go
@@ -182,17 +182,17 @@ func (m *Manager) ensureSidebar(ctx context.Context, crd *cozyv1alpha1.Applicati
 			map[string]any{
 				"key":   "plans",
 				"label": "Plans",
-				"link":  "/openapi-ui/{clusterName}/{namespace}/api-table/backups.cozystack.io/v1alpha1/plans",
+				"link":  "/openapi-ui/{cluster}/{namespace}/api-table/backups.cozystack.io/v1alpha1/plans",
 			},
 			map[string]any{
 				"key":   "backupjobs",
 				"label": "BackupJobs",
-				"link":  "/openapi-ui/{clusterName}/{namespace}/api-table/backups.cozystack.io/v1alpha1/backupjobs",
+				"link":  "/openapi-ui/{cluster}/{namespace}/api-table/backups.cozystack.io/v1alpha1/backupjobs",
 			},
 			map[string]any{
 				"key":   "backups",
 				"label": "Backups",
-				"link":  "/openapi-ui/{clusterName}/{namespace}/api-table/backups.cozystack.io/v1alpha1/backups",
+				"link":  "/openapi-ui/{cluster}/{namespace}/api-table/backups.cozystack.io/v1alpha1/backups",
 			},
 		},
 	})
@@ -215,7 +215,7 @@ func (m *Manager) ensureSidebar(ctx context.Context, crd *cozyv1alpha1.Applicati
 			map[string]any{
 				"key":   "loadbalancer-services",
 				"label": "External IPs",
-				"link":  "/openapi-ui/{clusterName}/{namespace}/factory/external-ips",
+				"link":  "/openapi-ui/{cluster}/{namespace}/factory/external-ips",
 			},
 			map[string]any{
 				"key":   "tenants",

--- a/internal/controller/dashboard/static_refactored.go
+++ b/internal/controller/dashboard/static_refactored.go
@@ -505,7 +505,7 @@ func CreateAllCustomFormsOverrides() []*dashboardv1alpha1.CustomFormsOverride {
 				createFormItem("spec.applicationRef.name", "Application Name", "text"),
 				createFormItemWithAPI("spec.backupClassName", "Backup Class", "select", map[string]any{
 					"api": map[string]any{
-						"fetchUrl":       "/api/clusters/{clusterName}/k8s/apis/backups.cozystack.io/v1alpha1/backupclasses",
+						"fetchUrl":       "/api/clusters/{cluster}/k8s/apis/backups.cozystack.io/v1alpha1/backupclasses",
 						"pathToItems":    []any{"items"},
 						"pathToValue":    []any{"metadata", "name"},
 						"pathToLabel":    []any{"metadata", "name"},


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
fixed dashboard sidebar links to Backups and External IPs
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized cluster identifier usage across dashboard menu links, administration links, and API request paths for consistent link generation.
* **Bug Fixes**
  * Resolved issues causing incorrect or inconsistent link targets and ensured backup-class options load correctly in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->