### PR TITLE
feat(keycloak): allow custom Ingress hostname via values

### DIFF
--- a/packages/system/keycloak/templates/ingress.yaml
+++ b/packages/system/keycloak/templates/ingress.yaml
@@ -1,4 +1,5 @@
 {{- $host := index .Values._cluster "root-host" }}
+{{- $ingressHost := .Values.ingress.host | default (printf "keycloak.%s" $host) }}
 {{- $solver := (index .Values._cluster "solver") | default "http01" }}
 {{- $clusterIssuer := (index .Values._cluster "issuer-name") | default "letsencrypt-prod" }}
 {{- $exposeIngress := (index .Values._cluster "expose-ingress") | default "tenant-root" }}
@@ -19,10 +20,10 @@ spec:
   ingressClassName: {{ $exposeIngress }}
   tls:
   - hosts:
-      - keycloak.{{ $host }}
+      - {{ $ingressHost }}
     secretName: web-tls
   rules:
-  - host: keycloak.{{ $host }}
+  - host: {{ $ingressHost }}
     http:
       paths:
       - path: /

--- a/packages/system/keycloak/templates/sts.yaml
+++ b/packages/system/keycloak/templates/sts.yaml
@@ -1,4 +1,5 @@
 {{- $host := index .Values._cluster "root-host" }}
+{{- $ingressHost := .Values.ingress.host | default (printf "keycloak.%s" $host) }}
 {{- $clusterDomain := (index .Values._cluster "cluster-domain") | default "cozy.local" }}
 
 {{- $existingPassword := lookup "v1" "Secret" "cozy-keycloak" (printf "%s-credentials" .Release.Name) }}
@@ -120,7 +121,7 @@ spec:
             - name: KC_FEATURES
               value: "docker"
             - name: KC_HOSTNAME
-              value: https://keycloak.{{ $host }}
+              value: https://{{ $ingressHost }}
             - name: JAVA_OPTS_APPEND
               value: "-Djgroups.dns.query=keycloak-headless.cozy-keycloak.svc.{{ $clusterDomain }}"
           ports:

--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -1,6 +1,10 @@
 image: quay.io/keycloak/keycloak:26.0.4
 
 ingress:
+  # Custom hostname for the Keycloak Ingress.
+  # If set, this value will be used as the Ingress hostname (e.g., "auth.example.com").
+  # If left empty, defaults to "keycloak.<root-host>" based on the cluster root-host setting.
+  host: ""
   annotations:
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-expires: "86400"


### PR DESCRIPTION
## What this PR does

Add `ingress.host` field to cozy-keycloak values, allowing users to override the default
`keycloak.<root-host>` Ingress hostname. The custom hostname is applied to both the Ingress
resource and the `KC_HOSTNAME` environment variable in the StatefulSet. When left empty,
behavior is unchanged (backward compatible).

### Release note

```release-note
[system] Add `ingress.host` option to cozy-keycloak for custom Ingress hostname override
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keycloak ingress hostname is now configurable and automatically defaults to "keycloak.<root-host>" when not explicitly specified.

* **Chores**
  * Refactored hostname configuration across Keycloak templates to use dynamic variable resolution instead of hard-coded values for improved consistency and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->