### PR TITLE
fix(dashboard): backupjobs creation form fixes and category idetifier…

### DIFF
--- a/internal/controller/dashboard/sidebar.go
+++ b/internal/controller/dashboard/sidebar.go
@@ -176,7 +176,7 @@ func (m *Manager) ensureSidebar(ctx context.Context, crd *cozyv1alpha1.Applicati
 
 	// Add hardcoded Backups section
 	menuItems = append(menuItems, map[string]any{
-		"key":   "backups",
+		"key":   "backups-category",
 		"label": "Backups",
 		"children": []any{
 			map[string]any{

--- a/internal/controller/dashboard/static_refactored.go
+++ b/internal/controller/dashboard/static_refactored.go
@@ -516,6 +516,27 @@ func CreateAllCustomFormsOverrides() []*dashboardv1alpha1.CustomFormsOverride {
 				createFormItem("spec.schedule.cron", "Schedule Cron", "text"),
 			},
 		}),
+
+		// BackupJobs form override - backups.cozystack.io/v1alpha1
+		createCustomFormsOverride("default-/backups.cozystack.io/v1alpha1/backupjobs", map[string]any{
+			"formItems": []any{
+				createFormItem("metadata.name", "Name", "text"),
+				createFormItem("metadata.namespace", "Namespace", "text"),
+				createFormItem("spec.planRef.name", "Plan Name (optional)", "text"),
+				createFormItem("spec.applicationRef.apiGroup", "Application API Group", "text"),
+				createFormItem("spec.applicationRef.kind", "Application Kind", "text"),
+				createFormItem("spec.applicationRef.name", "Application Name", "text"),
+				createFormItemWithAPI("spec.backupClassName", "Backup Class", "select", map[string]any{
+					"api": map[string]any{
+						"fetchUrl":       "/api/clusters/{cluster}/k8s/apis/backups.cozystack.io/v1alpha1/backupclasses",
+						"pathToItems":    []any{"items"},
+						"pathToValue":    []any{"metadata", "name"},
+						"pathToLabel":    []any{"metadata", "name"},
+						"clusterNameVar": "clusterName",
+					},
+				}),
+			},
+		}),
 	}
 }
 


### PR DESCRIPTION
… in sidebar

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
- fixed dashboard backupjobs creation form 
- fixed dashboard sidebar backup category id
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated dashboard backups menu structure for improved organization
  * Enhanced backup job management interface with new form configuration including Name, Namespace, Plan Name, Application details, and Backup Class selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->