### PR TITLE
fix(dashboard): added dropdown for backupClasses

### DIFF
--- a/internal/controller/dashboard/static_refactored.go
+++ b/internal/controller/dashboard/static_refactored.go
@@ -503,18 +503,12 @@ func CreateAllCustomFormsOverrides() []*dashboardv1alpha1.CustomFormsOverride {
 				createFormItem("metadata.namespace", "Namespace", "text"),
 				createFormItem("spec.applicationRef.kind", "Application Kind", "text"),
 				createFormItem("spec.applicationRef.name", "Application Name", "text"),
-				createFormItemWithAPI("spec.backupClassName", "Backup Class", "select", map[string]any{
-					"api": map[string]any{
-						"fetchUrl":       "/api/clusters/{cluster}/k8s/apis/backups.cozystack.io/v1alpha1/backupclasses",
-						"pathToItems":    []any{"items"},
-						"pathToValue":    []any{"metadata", "name"},
-						"pathToLabel":    []any{"metadata", "name"},
-						"clusterNameVar": "clusterName",
-					},
-				}),
 				createFormItem("spec.schedule.type", "Schedule Type", "text"),
 				createFormItem("spec.schedule.cron", "Schedule Cron", "text"),
 			},
+			"schema": createSchema(map[string]any{
+				"backupClassName": listInputScemaItemBackupClass(),
+			}),
 		}),
 
 		// BackupJobs form override - backups.cozystack.io/v1alpha1
@@ -526,16 +520,10 @@ func CreateAllCustomFormsOverrides() []*dashboardv1alpha1.CustomFormsOverride {
 				createFormItem("spec.applicationRef.apiGroup", "Application API Group", "text"),
 				createFormItem("spec.applicationRef.kind", "Application Kind", "text"),
 				createFormItem("spec.applicationRef.name", "Application Name", "text"),
-				createFormItemWithAPI("spec.backupClassName", "Backup Class", "select", map[string]any{
-					"api": map[string]any{
-						"fetchUrl":       "/api/clusters/{cluster}/k8s/apis/backups.cozystack.io/v1alpha1/backupclasses",
-						"pathToItems":    []any{"items"},
-						"pathToValue":    []any{"metadata", "name"},
-						"pathToLabel":    []any{"metadata", "name"},
-						"clusterNameVar": "clusterName",
-					},
-				}),
 			},
+			"schema": createSchema(map[string]any{
+				"backupClassName": listInputScemaItemBackupClass(),
+			}),
 		}),
 	}
 }
@@ -2063,9 +2051,9 @@ func createCustomFormsOverride(customizationId string, spec map[string]any) *das
 		"strategy":        "merge",
 	}
 
-	// Merge caller-provided fields (like formItems) into newSpec
+	// Merge into newSpec caller-provided fields without: customizationId, hidden, strategy
 	for key, value := range spec {
-		if key != "customizationId" && key != "hidden" && key != "schema" && key != "strategy" {
+		if key != "customizationId" && key != "hidden" && key != "strategy" {
 			newSpec[key] = value
 		}
 	}
@@ -2105,6 +2093,28 @@ func createNavigation(name string, spec map[string]any) *dashboardv1alpha1.Navig
 		Spec: dashboardv1alpha1.ArbitrarySpec{
 			JSON: v1.JSON{
 				Raw: jsonData,
+			},
+		},
+	}
+}
+
+func listInputScemaItemBackupClass() map[string]any {
+	return map[string]any{
+		"type": "listInput",
+		"customProps": map[string]any{
+			"valueUri":    "/api/clusters/{cluster}/k8s/apis/backups.cozystack.io/v1alpha1/backupclasses",
+			"keysToValue": []any{"metadata", "name"},
+			"keysToLabel": []any{"metadata", "name"},
+		},
+	}
+}
+
+// backupClassSchema returns the schema for spec.backupClassName as listInput (BackupJob/Plan).
+func createSchema(customProps map[string]any) map[string]any {
+	return map[string]any{
+		"properties": map[string]any{
+			"spec": map[string]any{
+				"properties": customProps,
 			},
 		},
 	}

--- a/packages/system/dashboard/templates/rbac.yaml
+++ b/packages/system/dashboard/templates/rbac.yaml
@@ -12,6 +12,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - backups.cozystack.io
+  resources:
+  - backupclasses
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
- added dropdown for selection backupClasses in Plan/BackupJob creation form
```

<img width="1905" height="662" alt="image" src="https://github.com/user-attachments/assets/9ecad2e5-e4fa-48c6-a020-ab8840df3f37" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated backup class field input handling in dashboard forms with improved schema-based mechanisms.
  * Extended dashboard permissions to enable proper read access to backup class resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->