### PR TITLE
feat(bucket): add readonly S3 access credentials

### DIFF
--- a/packages/apps/bucket/templates/bucketclaim.yaml
+++ b/packages/apps/bucket/templates/bucketclaim.yaml
@@ -17,3 +17,13 @@ spec:
   bucketClaimName: {{ .Release.Name }}
   credentialsSecretName: {{ .Release.Name }}
   protocol: s3
+---
+apiVersion: objectstorage.k8s.io/v1alpha1
+kind: BucketAccess
+metadata:
+  name: {{ .Release.Name }}-readonly
+spec:
+  bucketAccessClassName: {{ $seaweedfs }}-readonly
+  bucketClaimName: {{ .Release.Name }}
+  credentialsSecretName: {{ .Release.Name }}-readonly
+  protocol: s3

--- a/packages/apps/bucket/templates/dashboard-resourcemap.yaml
+++ b/packages/apps/bucket/templates/dashboard-resourcemap.yaml
@@ -10,6 +10,7 @@ rules:
   resourceNames:
   - {{ .Release.Name }}
   - {{ .Release.Name }}-credentials
+  - {{ .Release.Name }}-readonly
   verbs: ["get", "list", "watch"]
 - apiGroups:
   - networking.k8s.io

--- a/packages/system/bucket-rd/cozyrds/bucket.yaml
+++ b/packages/system/bucket-rd/cozyrds/bucket.yaml
@@ -33,6 +33,7 @@ spec:
       - resourceNames:
           - bucket-{{ .name }}
           - bucket-{{ .name }}-credentials
+          - bucket-{{ .name }}-readonly
   ingresses:
     exclude: []
     include:

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-bucket-class.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-bucket-class.yaml
@@ -13,4 +13,13 @@ metadata:
   name: {{ .Values.cosi.bucketClassName }}
 driverName: {{ .Values.cosi.driverName }}
 authenticationType: KEY
+---
+kind: BucketAccessClass
+apiVersion: objectstorage.k8s.io/v1alpha1
+metadata:
+  name: {{ .Values.cosi.bucketClassName }}-readonly
+driverName: {{ .Values.cosi.driverName }}
+authenticationType: KEY
+parameters:
+  accessPolicy: "readonly"
 {{- end }}


### PR DESCRIPTION
## Summary

- Add a readonly `BucketAccessClass` to the seaweedfs COSI chart with `accessPolicy: "readonly"` parameter
- Each bucket now automatically creates two sets of S3 credentials: readWrite (existing, for UI) and readonly
- Update dashboard RBAC and ApplicationDefinition to expose the readonly credentials secret

## Test plan

- [ ] Verify seaweedfs chart templates render both `BucketAccessClass` resources (readWrite and readonly)
- [ ] Verify bucket app templates render `BucketClaim` + 2 `BucketAccess` (readWrite + readonly)
- [ ] Deploy a bucket and confirm both credential secrets are created by COSI driver
- [ ] Confirm readonly credentials can only read/list objects, not write/delete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced read-only bucket access capabilities. Users can now configure read-only permissions for bucket storage resources, complementing existing access control options. New read-only access classes and configurations provide enhanced security controls and finer-grained permission management. This enables improved data protection while maintaining flexibility for various access requirements across applications and storage infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->