### PR TITLE
fix(dashboard): hide sidebar on cluster-level pages when no tenant selected

### DIFF
--- a/internal/controller/dashboard/manager.go
+++ b/internal/controller/dashboard/manager.go
@@ -299,10 +299,6 @@ func (m *Manager) buildExpectedResourceSet(crds []cozyv1alpha1.ApplicationDefini
 
 		// Add other stock sidebars that are created for each CRD
 		stockSidebars := []string{
-			"stock-instance-api-form",
-			"stock-instance-api-table",
-			"stock-instance-builtin-form",
-			"stock-instance-builtin-table",
 			"stock-project-factory-marketplace",
 			"stock-project-factory-workloadmonitor-details",
 			"stock-project-api-form",

--- a/internal/controller/dashboard/sidebar.go
+++ b/internal/controller/dashboard/sidebar.go
@@ -17,8 +17,7 @@ import (
 
 // ensureSidebar creates/updates multiple Sidebar resources that share the same menu:
 //   - The "details" sidebar tied to the current kind (stock-project-factory-<kind>-details)
-//   - The stock-instance sidebars: api-form, api-table, builtin-form, builtin-table
-//   - The stock-project sidebars:  api-form, api-table, builtin-form, builtin-table, crd-form, crd-table
+//   - The stock-project sidebars: api-form, api-table, builtin-form, builtin-table, crd-form, crd-table
 //
 // Menu rules:
 //   - The first section is "Marketplace" with two hardcoded entries:
@@ -228,13 +227,7 @@ func (m *Manager) ensureSidebar(ctx context.Context, crd *cozyv1alpha1.Applicati
 	// 6) Prepare the list of Sidebar IDs to upsert with the SAME content
 	// Create sidebars for ALL CRDs with dashboard config
 	targetIDs := []string{
-		// stock-instance sidebars
-		"stock-instance-api-form",
-		"stock-instance-api-table",
-		"stock-instance-builtin-form",
-		"stock-instance-builtin-table",
-
-		// stock-project sidebars
+		// stock-project sidebars (namespace-level, full menu)
 		"stock-project-factory-marketplace",
 		"stock-project-factory-workloadmonitor-details",
 		"stock-project-factory-kube-service-details",

--- a/packages/system/dashboard/templates/web.yaml
+++ b/packages/system/dashboard/templates/web.yaml
@@ -136,7 +136,7 @@ spec:
             - name: CUSTOMIZATION_NAVIGATION_RESOURCE_PLURAL
               value: navigations
             - name: CUSTOMIZATION_SIDEBAR_FALLBACK_ID
-              value: stock-project-api-table
+              value: ""
             - name: CUSTOMIZATION_BREADCRUMBS_FALLBACK_ID
               value: stock-project-api-table
             - name: INSTANCES_API_GROUP


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

In the current version, the sidebar incorrectly shows namespace-scoped menu items on cluster-level pages (before a tenant is selected). Clicking these items produces broken URLs with double `//` (e.g. `default//api-table/backups.cozystack.io/...`) because the `{namespace}` placeholder resolves to an empty string.

This PR fixes the issue by:
- Removing stock-instance-* sidebar resources that were populated with the same namespace-scoped menu as stock-project-* sidebars
- Clearing the `CUSTOMIZATION_SIDEBAR_FALLBACK_ID` env var so the frontend renders no sidebar when no matching sidebar resource exists
- Removing stock-instance-* from the expected resource set so orphan cleanup removes stale instances on upgrade

Screenshot after changes
<img width="2560" height="1327" alt="dashboard screenshot with no tenant selected" src="https://github.com/user-attachments/assets/e0d795f7-55e9-471b-99b8-593b6fc145d8" />


### Test plan

- [x] On cluster list page (no tenant selected), sidebar is empty
- [x] After selecting a tenant, sidebar shows full menu
- [x] No double `//` in sidebar URLs
- [x] Existing tests pass: `go test ./internal/controller/dashboard/...`

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[dashboard] fix: hide sidebar on cluster-level pages when no tenant selected
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined sidebar resource management by reducing the number of static sidebar configurations generated by the system.
  * Removed sidebar fallback behavior, resulting in simplified sidebar customization defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->