### PR TITLE
[linstor] fix: whitelist CDI pods in RWX block validation

### DIFF
--- a/packages/system/linstor/images/linstor-csi/patches/001-rwx-validation.diff
+++ b/packages/system/linstor/images/linstor-csi/patches/001-rwx-validation.diff
@@ -104,7 +104,7 @@ new file mode 100644
 index 00000000..9fe82768
 --- /dev/null
 +++ b/pkg/utils/rwx_validation.go
-@@ -0,0 +1,289 @@
+@@ -0,0 +1,298 @@
 +/*
 +CSI Driver for Linstor
 +Copyright © 2018 LINBIT USA, LLC
@@ -142,9 +142,17 @@ index 00000000..9fe82768
 +// KubeVirtHotplugDiskLabel is the label that KubeVirt adds to hotplug disk pods.
 +const KubeVirtHotplugDiskLabel = "kubevirt.io"
 +
++// CDIAppLabelKey is the standard Kubernetes app label key.
++const CDIAppLabelKey = "app"
++
 +// CDIAppLabelValue is the value of the "app" label on CDI (Containerized Data Importer) worker pods.
-+// CDI creates source pods during host-assisted PVC cloning that need to mount the source PVC.
 +const CDIAppLabelValue = "containerized-data-importer"
++
++// CDIManagedByKey is the standard Kubernetes managed-by label key.
++const CDIManagedByKey = "app.kubernetes.io/managed-by"
++
++// CDIManagedByValue is the value of the managed-by label set by the CDI operator.
++const CDIManagedByValue = "cdi-operator"
 +
 +// PodGVR is the GroupVersionResource for pods.
 +var PodGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
@@ -392,14 +400,15 @@ index 00000000..9fe82768
 +		return false
 +	}
 +
-+	return labels["app"] == CDIAppLabelValue
++	return labels[CDIAppLabelKey] == CDIAppLabelValue &&
++		labels[CDIManagedByKey] == CDIManagedByValue
 +}
 diff --git a/pkg/utils/rwx_validation_test.go b/pkg/utils/rwx_validation_test.go
 new file mode 100644
 index 00000000..d75690f9
 --- /dev/null
 +++ b/pkg/utils/rwx_validation_test.go
-@@ -0,0 +1,400 @@
+@@ -0,0 +1,401 @@
 +/*
 +CSI Driver for Linstor
 +Copyright © 2018 LINBIT USA, LLC
@@ -738,7 +747,8 @@ index 00000000..d75690f9
 +				"name":      name,
 +				"namespace": namespace,
 +				"labels": map[string]interface{}{
-+					"app": CDIAppLabelValue,
++					CDIAppLabelKey:  CDIAppLabelValue,
++					CDIManagedByKey: CDIManagedByValue,
 +				},
 +			},
 +			"spec": map[string]interface{}{


### PR DESCRIPTION
## What this PR does

Fixes a deadlock when multiple VMDisks are cloned from the same golden image simultaneously.

**Root cause:** The LINSTOR CSI RWX block validation (Cozystack-specific patch) rejects concurrent volume attachment for pods without the `vm.kubevirt.io/name` label. When CDI creates multiple source pods for parallel host-assisted PVC cloning, all attach requests are denied because CDI pods lack that label, causing a deadlock where no clone can proceed.

**Fix:** Add CDI pod detection (by `app: containerized-data-importer` label) to the validation logic and skip VM ownership checks for CDI worker pods. This allows concurrent PVC-to-PVC copy cloning while preserving the `allow-two-primaries` safety checks for non-CDI, non-KubeVirt pods.

The copy clone strategy is preserved (not switched to snapshot) because copy places cloned data on the correct storage nodes immediately via LINSTOR placement policy, unlike snapshot which keeps data co-located with the source golden image.

### Release note

```release-note
[linstor] Fix deadlock when multiple VMDisks are cloned from the same golden image concurrently by whitelisting CDI worker pods in RWX block validation.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RWX block volume validation to enforce proper attachment rules, including exemptions for ephemeral CDI-style pods.
  * Added an opt-out flag to disable RWX validation via driver configuration.

* **Tests**
  * Expanded test coverage for RWX validation, covering CDI scenarios, hotplug attachments, coexistence cases, and edge conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->