### PR TITLE
fix(dashboard): add FlowSchema to exempt BFF from API throttling

### DIFF
--- a/packages/system/dashboard/templates/flowschema.yaml
+++ b/packages/system/dashboard/templates/flowschema.yaml
@@ -1,0 +1,20 @@
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: FlowSchema
+metadata:
+  name: cozy-dashboard-exempt
+spec:
+  matchingPrecedence: 2
+  priorityLevelConfiguration:
+    name: exempt
+  rules:
+    - subjects:
+        - kind: ServiceAccount
+          serviceAccount:
+            name: incloud-web-web
+            namespace: {{ .Release.Namespace }}
+      resourceRules:
+        - verbs: ["*"]
+          apiGroups: ["*"]
+          resources: ["*"]
+          namespaces: ["*"]
+          clusterScope: true


### PR DESCRIPTION
## Summary
- Add FlowSchema `cozy-dashboard-exempt` to exempt the dashboard BFF service account (`incloud-web-web`) from API Priority and Fairness throttling
- BFF falls under the default `service-accounts` FlowSchema → `workload-low` priority level, which causes 429 responses under load

## Test plan
- [ ] Deploy to a cluster with dashboard enabled
- [ ] Verify FlowSchema is created: `kubectl get flowschema cozy-dashboard-exempt`
- [ ] Verify BFF no longer receives 429 errors under load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new Kubernetes FlowSchema configuration for system resource access management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->