### PR TITLE
fix(installer): add keep annotation to Namespace and update migration script

### DIFF
--- a/packages/core/installer/templates/cozystack-operator.yaml
+++ b/packages/core/installer/templates/cozystack-operator.yaml
@@ -10,6 +10,8 @@ metadata:
   labels:
     cozystack.io/system: "true"
     pod-security.kubernetes.io/enforce: privileged
+  annotations:
+    helm.sh/resource-policy: keep
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
## What this PR does

Adds `helm.sh/resource-policy: keep` annotation to the `cozy-system` Namespace resource
in the installer helm chart. This prevents Helm from deleting the namespace (and all
HelmReleases within it) when the installer release is removed.

Also updates the v1.0 migration script to annotate the `cozy-system` namespace and
`cozystack-version` ConfigMap with the same policy before generating the Package resource.

### Release note

```release-note
[platform] Add helm.sh/resource-policy=keep annotation to cozy-system Namespace in installer chart to prevent namespace deletion on HelmRelease removal. Update migration script to protect namespace and cozystack-version ConfigMap before migration.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced migration process with an interactive step to safeguard critical resources during system upgrades.
  * Added resource protection mechanisms to prevent unintended removal during Helm operations.
  * Improved control flow in the upgrade script with explicit user confirmation prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->