### PR TITLE
[system] Fix Keycloak proxy configuration for v26.x

### DIFF
--- a/packages/system/keycloak/templates/sts.yaml
+++ b/packages/system/keycloak/templates/sts.yaml
@@ -82,8 +82,10 @@ spec:
               value: "ispn"
             - name: KC_CACHE_STACK
               value: "kubernetes"
-            - name: KC_PROXY
-              value: "edge"
+            - name: KC_PROXY_HEADERS
+              value: "xforwarded"
+            - name: KC_HTTP_ENABLED
+              value: "true"
             - name: KEYCLOAK_ADMIN
               value: admin
             - name: KEYCLOAK_ADMIN_PASSWORD


### PR DESCRIPTION
## What this PR does

Replace deprecated `KC_PROXY=edge` with `KC_PROXY_HEADERS=xforwarded` and `KC_HTTP_ENABLED=true` in the Keycloak StatefulSet template.

`KC_PROXY` was removed in Keycloak 26.x, causing "Non-secure context detected" warnings and broken cookie handling when running behind a reverse proxy with TLS termination.

### Release note

```release-note
[system] Fix Keycloak proxy headers configuration for compatibility with Keycloak 26.x
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated system configuration to improve proxy header handling and enable direct HTTP support for enhanced compatibility with reverse proxy environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->