### PR TITLE
fix(platform): correct cozy-proxy releaseName to avoid conflict with installer

### DIFF
--- a/packages/core/platform/bundles/distro-full.yaml
+++ b/packages/core/platform/bundles/distro-full.yaml
@@ -27,7 +27,7 @@ releases:
   dependsOn: [cilium]
 
 - name: cozy-proxy
-  releaseName: cozystack
+  releaseName: cozy-proxy
   chart: cozy-cozy-proxy
   namespace: cozy-system
   optional: true

--- a/packages/core/platform/bundles/paas-full.yaml
+++ b/packages/core/platform/bundles/paas-full.yaml
@@ -66,7 +66,7 @@ releases:
   dependsOn: [cilium,kubeovn]
 
 - name: cozy-proxy
-  releaseName: cozystack
+  releaseName: cozy-proxy
   chart: cozy-cozy-proxy
   namespace: cozy-system
   dependsOn: [cilium,kubeovn,multus]


### PR DESCRIPTION
## What this PR does

Fixes cozy-proxy `releaseName` from `cozystack` to `cozy-proxy` in paas-full and
distro-full bundles.

The cozy-proxy component was incorrectly configured with `releaseName: cozystack`,
which is the same name used by the installer helm release. During upgrade to v1.0,
the cozy-proxy HelmRelease reconciles and overwrites the installer release, deleting
the cozystack-operator deployment.

### Release note

```release-note
[platform] Fix cozy-proxy releaseName collision with installer that caused operator deletion during v1.0 upgrade
```