### PR TITLE
fix(migration): suspend cozy-proxy if it conflicts with installer release

### DIFF
--- a/hack/migrate-to-version-1.0.sh
+++ b/hack/migrate-to-version-1.0.sh
@@ -56,6 +56,30 @@ else
 fi
 echo ""
 
+# Step 1: Check for cozy-proxy HelmRelease with conflicting releaseName
+# In v0.41.x, cozy-proxy was incorrectly configured with releaseName "cozystack",
+# which conflicts with the installer helm release name. If not suspended, cozy-proxy
+# HelmRelease will overwrite the installer release and delete cozystack-operator.
+COZY_PROXY_RELEASE_NAME=$(kubectl get hr -n "$NAMESPACE" cozy-proxy -o jsonpath='{.spec.releaseName}' 2>/dev/null || true)
+if [ "$COZY_PROXY_RELEASE_NAME" = "cozystack" ]; then
+    echo "WARNING: HelmRelease cozy-proxy has releaseName 'cozystack', which conflicts"
+    echo "with the installer release. It must be suspended before proceeding, otherwise"
+    echo "it will overwrite the installer and delete cozystack-operator."
+    echo ""
+    read -p "Suspend HelmRelease cozy-proxy? (y/N) " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        kubectl -n "$NAMESPACE" patch hr cozy-proxy --type=merge --field-manager=flux-client-side-apply -p '{"spec":{"suspend":true}}'
+        echo "HelmRelease cozy-proxy suspended."
+    else
+        echo "ERROR: Cannot proceed with conflicting cozy-proxy HelmRelease active."
+        echo "Please suspend it manually:"
+        echo "  kubectl -n $NAMESPACE patch hr cozy-proxy --type=merge -p '{\"spec\":{\"suspend\":true}}'"
+        exit 1
+    fi
+    echo ""
+fi
+
 # Read ConfigMap cozystack
 echo "Reading ConfigMap cozystack..."
 COZYSTACK_CM=$(kubectl get configmap -n "$NAMESPACE" cozystack -o json 2>/dev/null || echo "{}")


### PR DESCRIPTION
## What this PR does

Adds a check in the migration script to detect and suspend the `cozy-proxy`
HelmRelease if it has `releaseName: cozystack`, which conflicts with the installer
release and causes cozystack-operator deletion during upgrade from v0.41 to v1.0.

### Release note

```release-note
[platform] Fix migration script to handle cozy-proxy releaseName conflict during v0.41→v1.0 upgrade.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the version 1.0 migration process with automatic conflict detection and interactive guidance, prompting users to resolve issues during the upgrade for a smoother migration experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->