### PR TITLE
[dashboard] Add storageClass dropdown for stateful apps

### DIFF
--- a/internal/controller/dashboard/customformsoverride.go
+++ b/internal/controller/dashboard/customformsoverride.go
@@ -214,6 +214,34 @@ func applyListInputOverrides(schema map[string]any, kind string, openAPIProps ma
 				"keysToLabel": []any{"metadata", "name"},
 			},
 		}
+
+	case "ClickHouse", "Harbor", "HTTPCache", "Kubernetes", "MariaDB", "MongoDB",
+		"NATS", "OpenBAO", "Postgres", "Qdrant", "RabbitMQ", "Redis", "VMDisk":
+		specProps := ensureSchemaPath(schema, "spec")
+		specProps["storageClass"] = storageClassListInput()
+
+	case "FoundationDB":
+		storageProps := ensureSchemaPath(schema, "spec", "storage")
+		storageProps["storageClass"] = storageClassListInput()
+
+	case "Kafka":
+		kafkaProps := ensureSchemaPath(schema, "spec", "kafka")
+		kafkaProps["storageClass"] = storageClassListInput()
+		zkProps := ensureSchemaPath(schema, "spec", "zookeeper")
+		zkProps["storageClass"] = storageClassListInput()
+	}
+}
+
+// storageClassListInput returns a listInput field config for a storageClass dropdown
+// backed by the cluster's available StorageClasses.
+func storageClassListInput() map[string]any {
+	return map[string]any{
+		"type": "listInput",
+		"customProps": map[string]any{
+			"valueUri":    "/api/clusters/{cluster}/k8s/apis/storage.k8s.io/v1/storageclasses",
+			"keysToValue": []any{"metadata", "name"},
+			"keysToLabel": []any{"metadata", "name"},
+		},
 	}
 }
 

--- a/internal/controller/dashboard/customformsoverride_test.go
+++ b/internal/controller/dashboard/customformsoverride_test.go
@@ -232,6 +232,72 @@ func TestApplyListInputOverrides_VMInstance(t *testing.T) {
 	}
 }
 
+func TestApplyListInputOverrides_StorageClassSimple(t *testing.T) {
+	for _, kind := range []string{
+		"ClickHouse", "Harbor", "HTTPCache", "Kubernetes", "MariaDB", "MongoDB",
+		"NATS", "OpenBAO", "Postgres", "Qdrant", "RabbitMQ", "Redis", "VMDisk",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			schema := map[string]any{}
+			applyListInputOverrides(schema, kind, map[string]any{})
+
+			specProps := schema["properties"].(map[string]any)["spec"].(map[string]any)["properties"].(map[string]any)
+			sc, ok := specProps["storageClass"].(map[string]any)
+			if !ok {
+				t.Fatalf("storageClass not found in spec.properties for kind %s", kind)
+			}
+			assertStorageClassListInput(t, sc)
+		})
+	}
+}
+
+func TestApplyListInputOverrides_StorageClassFoundationDB(t *testing.T) {
+	schema := map[string]any{}
+	applyListInputOverrides(schema, "FoundationDB", map[string]any{})
+
+	storageProps := schema["properties"].(map[string]any)["spec"].(map[string]any)["properties"].(map[string]any)["storage"].(map[string]any)["properties"].(map[string]any)
+	sc, ok := storageProps["storageClass"].(map[string]any)
+	if !ok {
+		t.Fatal("storageClass not found in spec.storage.properties")
+	}
+	assertStorageClassListInput(t, sc)
+}
+
+func TestApplyListInputOverrides_StorageClassKafka(t *testing.T) {
+	schema := map[string]any{}
+	applyListInputOverrides(schema, "Kafka", map[string]any{})
+
+	specProps := schema["properties"].(map[string]any)["spec"].(map[string]any)["properties"].(map[string]any)
+
+	kafkaSC, ok := specProps["kafka"].(map[string]any)["properties"].(map[string]any)["storageClass"].(map[string]any)
+	if !ok {
+		t.Fatal("storageClass not found in spec.kafka.properties")
+	}
+	assertStorageClassListInput(t, kafkaSC)
+
+	zkSC, ok := specProps["zookeeper"].(map[string]any)["properties"].(map[string]any)["storageClass"].(map[string]any)
+	if !ok {
+		t.Fatal("storageClass not found in spec.zookeeper.properties")
+	}
+	assertStorageClassListInput(t, zkSC)
+}
+
+// assertStorageClassListInput verifies that a field is a correctly configured storageClass listInput.
+func assertStorageClassListInput(t *testing.T, field map[string]any) {
+	t.Helper()
+	if field["type"] != "listInput" {
+		t.Errorf("expected type listInput, got %v", field["type"])
+	}
+	customProps, ok := field["customProps"].(map[string]any)
+	if !ok {
+		t.Fatal("customProps not found")
+	}
+	expectedURI := "/api/clusters/{cluster}/k8s/apis/storage.k8s.io/v1/storageclasses"
+	if customProps["valueUri"] != expectedURI {
+		t.Errorf("expected valueUri %s, got %v", expectedURI, customProps["valueUri"])
+	}
+}
+
 func TestApplyListInputOverrides_UnknownKind(t *testing.T) {
 	schema := map[string]any{}
 	applyListInputOverrides(schema, "SomeOtherKind", map[string]any{})


### PR DESCRIPTION
## What this PR does

Replaces the plain text input for `storageClass` fields with an
API-backed dropdown listing available StorageClasses from the cluster.
Follows the same pattern as the `instanceType` dropdown for VMInstance.

Affected applications:
- **Top-level `spec.storageClass`**: ClickHouse, Harbor, HTTPCache,
  Kubernetes, MariaDB, MongoDB, NATS, OpenBAO, Postgres, Qdrant,
  RabbitMQ, Redis, VMDisk
- **Nested `spec.storage.storageClass`**: FoundationDB
- **Nested `spec.kafka.storageClass` / `spec.zookeeper.storageClass`**: Kafka

### Release note

```release-note
[dashboard] storageClass fields in stateful app forms now render as a
dropdown populated with available StorageClasses from the cluster,
instead of a free-text input.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Storage class selection dropdowns now available in configuration forms for multiple database, messaging, and storage services.

* **Tests**
  * Added comprehensive test coverage for storage class configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->