### PR TITLE
[dashboard] fix: restore stock-instance sidebars for namespace-level pages

### DIFF
--- a/internal/controller/dashboard/manager.go
+++ b/internal/controller/dashboard/manager.go
@@ -307,6 +307,10 @@ func (m *Manager) buildExpectedResourceSet(crds []cozyv1alpha1.ApplicationDefini
 			"stock-project-builtin-table",
 			"stock-project-crd-form",
 			"stock-project-crd-table",
+			"stock-instance-api-form",
+			"stock-instance-api-table",
+			"stock-instance-builtin-form",
+			"stock-instance-builtin-table",
 		}
 		for _, sidebarID := range stockSidebars {
 			expected["Sidebar"][sidebarID] = true

--- a/internal/controller/dashboard/sidebar.go
+++ b/internal/controller/dashboard/sidebar.go
@@ -243,6 +243,11 @@ func (m *Manager) ensureSidebar(ctx context.Context, crd *cozyv1alpha1.Applicati
 		"stock-project-builtin-table",
 		"stock-project-crd-form",
 		"stock-project-crd-table",
+		// stock-instance sidebars (namespace-level pages after namespace is selected)
+		"stock-instance-api-form",
+		"stock-instance-api-table",
+		"stock-instance-builtin-form",
+		"stock-instance-builtin-table",
 	}
 
 	// Add details sidebars for all CRDs with dashboard config


### PR DESCRIPTION
## What this PR does

Restores `stock-instance-api-form`, `stock-instance-api-table`,
`stock-instance-builtin-form`, and `stock-instance-builtin-table` sidebar
resources that were removed in #2106, and adds them back to the orphan
cleanup allowlist.

PR #2106 removed these sidebars to fix broken URLs on the main page before
namespace selection (`default//api-table/...`). However, `stock-instance-*`
sidebars are required by the frontend for namespace-level api-table/api-form
pages. Without them and with `CUSTOMIZATION_SIDEBAR_FALLBACK_ID=""`, the
frontend cannot find a sidebar for pages like Backup Plans and renders an
empty page where no interaction is possible.

The broken-URL bug is already fully fixed by `CUSTOMIZATION_SIDEBAR_FALLBACK_ID=""`
in `web.yaml`. Re-adding `stock-instance-*` does not reintroduce it, since
these sidebars are only shown when the user is on a namespace-level page
where the `{namespace}` placeholder is filled.

### Release note

```release-note
[dashboard] fix empty page on Backup Plans and other namespace-level api-table pages
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new dashboard sidebar resources for stock instances: API form, API table, built-in form, and built-in table views. These enable expanded dashboard customization options for managing stock instance configurations and data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->