### PR TITLE
[keycloak] Enable injecting themes

### DIFF
--- a/packages/system/keycloak/templates/sts.yaml
+++ b/packages/system/keycloak/templates/sts.yaml
@@ -1,3 +1,7 @@
+{{- define "keycloak.theme.sanitizedName" -}}
+{{- regexReplaceAll "-+" (regexReplaceAll "[^a-z0-9-]" (. | lower) "-") "-" | trimPrefix "-" | trimSuffix "-" -}}
+{{- end -}}
+
 {{- $host := index .Values._cluster "root-host" }}
 {{- $ingressHost := .Values.ingress.host | default (printf "keycloak.%s" $host) }}
 {{- $clusterDomain := (index .Values._cluster "cluster-domain") | default "cozy.local" }}
@@ -39,14 +43,43 @@ spec:
         app: keycloak-ha
     spec:
       restartPolicy: Always
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         fsGroup: 1000
       {{- if .Values.themes }}
+      {{- $themeNames := list }}
+      {{- range .Values.themes }}
+      {{- if not .name }}{{ fail "theme entry missing required field: name" }}{{- end }}
+      {{- if not .image }}{{ fail "theme entry missing required field: image" }}{{- end }}
+      {{- $sanitized := include "keycloak.theme.sanitizedName" .name }}
+      {{- if not $sanitized }}{{ fail (printf "theme name %q produces empty container name after sanitization" .name) }}{{- end }}
+      {{- if gt (len (printf "theme-%s" $sanitized)) 63 }}{{ fail (printf "theme name %q produces container name exceeding 63 characters" .name) }}{{- end }}
+      {{- if has $sanitized $themeNames }}{{ fail (printf "duplicate theme name after sanitization: %s (from %s)" $sanitized .name) }}{{- end }}
+      {{- $themeNames = append $themeNames $sanitized }}
+      {{- end }}
       initContainers:
         {{- range .Values.themes }}
-        - name: theme-{{ .name }}
-          image: {{ .image }}
-          command: ["sh", "-c", "cp -r /themes/* /opt/keycloak/themes/"]
+        - name: theme-{{ include "keycloak.theme.sanitizedName" .name }}
+          image: "{{ .image }}"
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-c", "[ -d /themes ] && cp -r /themes/. /opt/keycloak/themes/ || { echo 'ERROR: /themes directory not found in image'; exit 1; }"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           volumeMounts:
             - name: themes
               mountPath: /opt/keycloak/themes
@@ -174,6 +207,7 @@ spec:
       {{- if .Values.themes }}
       volumes:
         - name: themes
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: 256Mi
       {{- end }}
       terminationGracePeriodSeconds: 60

--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -18,3 +18,9 @@ resources:
 themes: []
 # - name: my-theme
 #   image: my-registry/my-keycloak-theme:v1.0
+# Theme images must contain theme files under /themes/ directory.
+# Each theme is copied into Keycloak's /opt/keycloak/themes/ via init container.
+# If multiple themes contain files with the same path, later entries take precedence.
+
+imagePullSecrets: []
+# - name: my-registry-secret


### PR DESCRIPTION
## What this PR does

This patch lets Cozystack admins specify initContainers that will run `cp -r /themes/ /opt/keycloak/themes/` on startup, effectively providing an interface for operators to inject custom themes into the keycloak deployment to customize the UI.

### Release note

```release-note
[keycloak] Enable injection of user-provided themes for Keycloak via
initContainers.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom Keycloak themes through configuration, allowing users to customize the appearance of the authentication interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->