### PR TITLE
Fixed packages name conversion in migration script

### DIFF
--- a/hack/migrate-to-version-1.0.sh
+++ b/hack/migrate-to-version-1.0.sh
@@ -155,13 +155,13 @@ fi
 if [ -z "$BUNDLE_DISABLE" ]; then
     DISABLED_PACKAGES="[]"
 else
-    DISABLED_PACKAGES=$(echo "$BUNDLE_DISABLE" | sed 's/,/\n/g' | awk 'BEGIN{print}{print "          - "$0}')
+    DISABLED_PACKAGES=$(echo "$BUNDLE_DISABLE" | sed 's/,/\n/g' | awk 'BEGIN{print}{print "          - cozystack."$0}')
 fi
 
 if [ -z "$BUNDLE_ENABLE" ]; then
     ENABLED_PACKAGES="[]"
 else
-    ENABLED_PACKAGES=$(echo "$BUNDLE_ENABLE" | sed 's/,/\n/g' | awk 'BEGIN{print}{print "          - "$0}')
+    ENABLED_PACKAGES=$(echo "$BUNDLE_ENABLE" | sed 's/,/\n/g' | awk 'BEGIN{print}{print "          - cozystack."$0}')
 fi
 
 if [ -z "$EXPOSE_SERVICES" ]; then
@@ -175,7 +175,7 @@ BUNDLE_NAME=$(echo "$BUNDLE_NAME" | sed 's/paas/isp/')
 
 # Extract branding if available
 BRANDING=$(echo "$BRANDING_CM" | jq -r '.data // {} | to_entries[] | "\(.key): \"\(.value)\""')
-if [ -z "$BRANDING" ]; then 
+if [ -z "$BRANDING" ]; then
     BRANDING="{}"
 else
     BRANDING=$(echo "$BRANDING" | awk 'BEGIN{print}{print "          " $0}')


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
Fixed migrate-to-version-1.0.sh script to properly convert packages names.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated migration tooling to improve package configuration handling during version upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->