### PR TITLE
fix(kubernetes): set explicit MTU for Cilium in tenant clusters

### DIFF
--- a/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
@@ -3,6 +3,7 @@ cilium:
   k8sServiceHost: {{ .Release.Name }}.{{ .Release.Namespace }}.svc
   k8sServicePort: 6443
   routingMode: tunnel
+  MTU: 1350
   enableIPv4Masquerade: true
   ipv4NativeRoutingCIDR: ""
   {{- if $.Values.addons.gatewayAPI.enabled }}


### PR DESCRIPTION
## Summary

- Set explicit MTU 1350 for Cilium in KubeVirt-based tenant Kubernetes clusters to prevent packet drops caused by VXLAN encapsulation overhead

## Problem

Cilium's MTU auto-detection does not account for VXLAN overhead when running inside KubeVirt VMs. The VM network interface inherits MTU 1400 from the parent cluster's OVN/Geneve overlay (1500 - 100 Geneve overhead). Cilium detects this MTU and applies it to all tunnel interfaces without subtracting the 50-byte VXLAN encapsulation overhead.

This results in:
- Large packets (> 1350 bytes) being silently dropped when crossing VXLAN tunnels between nodes
- Intermittent connectivity issues for services in tenant clusters (TLS handshakes, HTTP responses with data)
- HTTP 499 errors and timeouts observed under load

## Fix

Explicitly set `MTU: 1350` (1400 - 50 VXLAN overhead) in the default Cilium values for tenant clusters. This value can still be overridden via `addons.cilium.valuesOverride` if needed.

## Test plan

- [ ] Deploy a tenant Kubernetes cluster and verify Cilium interfaces use MTU 1350
- [ ] Verify large packet connectivity from pods inside the tenant cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cilium network transmission settings in the Kubernetes deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->