### PR TITLE
[keycloak] fix liveness probe path to avoid redirect warning

### DIFF
--- a/packages/system/keycloak/templates/sts.yaml
+++ b/packages/system/keycloak/templates/sts.yaml
@@ -132,7 +132,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /health/live
               port: http
             initialDelaySeconds: 120
             timeoutSeconds: 5


### PR DESCRIPTION
## What this PR does

Fix the liveness probe in the Keycloak StatefulSet to use `/health/live`
instead of `/`, which was returning a 302 redirect to the admin console.
This caused kubelet to continuously log "Probe terminated redirects" warnings
after the Keycloak upgrade.

The `/health/live` endpoint on port 8080 returns 200 OK and is the correct
health check endpoint for Keycloak 24+.

### Release note

```release-note
[keycloak] Fix liveness probe path from `/` to `/health/live` to eliminate kubelet redirect warnings after upgrade
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated health check endpoint configuration for enhanced service monitoring and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->