### PR TITLE
fix(migrations): handle missing rabbitmq CRD in migration 34

### DIFF
--- a/packages/core/platform/images/migrations/migrations/34
+++ b/packages/core/platform/images/migrations/migrations/34
@@ -13,6 +13,15 @@
 set -euo pipefail
 
 DEFAULT_VERSION="v3.13"
+
+# Skip if the CRD does not exist (rabbitmq was never installed)
+if ! kubectl api-resources --api-group=apps.cozystack.io -o name 2>/dev/null | grep -q '^rabbitmqs\.'; then
+  echo "CRD rabbitmqs.apps.cozystack.io not found, skipping migration"
+  kubectl create configmap -n cozy-system cozystack-version \
+    --from-literal=version=35 --dry-run=client -o yaml | kubectl apply -f-
+  exit 0
+fi
+
 RABBITMQS=$(kubectl get rabbitmqs.apps.cozystack.io -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}')
 for resource in $RABBITMQS; do
   NS="${resource%%/*}"


### PR DESCRIPTION
## Summary

- Migration 34 fails with `error: the server doesn't have a resource type "rabbitmqs"` when `rabbitmqs.apps.cozystack.io` CRD does not exist on the cluster
- This happens when RabbitMQ was never installed — the CRD is not present, `kubectl get` fails, and `set -euo pipefail` terminates the migration job
- Added a CRD existence check before listing resources; if CRD is absent, the migration stamps the version and exits cleanly

## Test plan

- [ ] Deploy a cluster without RabbitMQ installed and run migration 34 — should skip gracefully
- [ ] Deploy a cluster with RabbitMQ instances without `spec.version` set — should patch them to `v3.13`
- [ ] Deploy a cluster with RabbitMQ instances already having `spec.version` — should skip patching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Migration 34 with improved error handling for missing system prerequisites, ensuring migration processes complete gracefully and update configuration appropriately during platform upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->