### PR TITLE
[platform] Fix VM MAC address not preserved during migration

### DIFF
--- a/packages/apps/vm-instance/templates/vm.yaml
+++ b/packages/apps/vm-instance/templates/vm.yaml
@@ -34,6 +34,12 @@ spec:
     metadata:
       annotations:
         kubevirt.io/allow-pod-bridge-network-live-migration: "true"
+        {{- $ovnIPName := printf "%s.%s" (include "virtual-machine.fullname" .) .Release.Namespace }}
+        {{- $ovnIP := lookup "kubeovn.io/v1" "IP" "" $ovnIPName }}
+        {{- if $ovnIP }}
+        ovn.kubernetes.io/mac_address: {{ $ovnIP.spec.macAddress | quote }}
+        ovn.kubernetes.io/ip_address: {{ $ovnIP.spec.ipAddress | quote }}
+        {{- end }}
       labels:
         {{- include "virtual-machine.labels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
## What this PR does

During the virtual-machine → vm-instance migration (script 29), VM MAC addresses
are not preserved. Kube-OVN reads MAC exclusively from the pod annotation
`ovn.kubernetes.io/mac_address`, not from the IP resource `spec.macAddress`.
Without the annotation, migrated VMs get a new random MAC, breaking OS-level
network config that matches by MAC (e.g. netplan).

This adds a Helm `lookup` for the Kube-OVN IP resource in the vm-instance chart
template. When the resource exists, its `macAddress` and `ipAddress` are
automatically injected as pod annotations. This approach is reliable across
HelmRelease reconciliations — unlike postRenderers, the annotations cannot be
accidentally lost.

Fixes #2166

### Release note

```release-note
[platform] Fix VM MAC address not preserved during virtual-machine → vm-instance migration, causing network loss on VMs with MAC-based netplan config
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * VM templates now automatically populate network annotations (MAC and IP) from kubeovn IP records when available. This streamlines VM network setup on deployment, reduces manual annotation steps, and lowers risk of misconfiguration by ensuring VMs receive the correct address and MAC information from associated network records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->