### PR TITLE
[ci] Fix E2E check blocking docs-only PRs

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -6,8 +6,6 @@ env:
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - 'docs/**/*'
 
 # Cancel in‑flight runs for the same PR when a new push arrives.
 concurrency:
@@ -15,6 +13,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '!docs/**'
+
   build:
     name: Build
     runs-on: [self-hosted]
@@ -22,9 +33,11 @@ jobs:
       contents: read
       packages: write
 
-    # Never run when the PR carries the "release" label.
+    needs: ["detect-changes"]
+    # Never run when the PR carries the "release" label or only docs changed.
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'release')
+      needs.detect-changes.outputs.code == 'true'
+      && !contains(github.event.pull_request.labels.*.name, 'release')
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What this PR does

The `pull-requests.yaml` workflow used `paths-ignore` at the trigger level to skip runs for docs-only changes. This prevented the entire workflow from triggering, so the required "E2E Tests" check was never created — blocking merge for non-admin users.

This PR replaces trigger-level `paths-ignore` with a `detect-changes` job using `dorny/paths-filter@v3`. The workflow now always triggers (so all checks are reported to GitHub), but `build` and downstream jobs are skipped when only `docs/` files change.

| PR type | build | resolve_assets | e2e |
| --- | --- | --- | --- |
| Code PR | runs | skipped | runs |
| Release PR | skipped (label) | runs | runs |
| Docs-only PR | skipped | skipped | skipped |

### Release note

```release-note
[ci] Fix required E2E check blocking merge of docs-only pull requests
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline optimized to skip builds when only documentation changes occur.
  * Added a checks step that detects whether code changed and gates the build accordingly.
  * Build now runs only if code changes are present and the PR is not marked as a release, reducing unnecessary build runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->