### PR TITLE
fix(dashboard): fix External IPs factory EnrichedTable rendering

### DIFF
--- a/internal/controller/dashboard/static_refactored.go
+++ b/internal/controller/dashboard/static_refactored.go
@@ -1924,12 +1924,12 @@ func CreateAllFactories() []*dashboardv1alpha1.Factory {
 				map[string]any{
 					"type": "EnrichedTable",
 					"data": map[string]any{
-						"id":                   "external-ips-table",
-						"fetchUrl":             "/api/clusters/{2}/k8s/api/v1/namespaces/{3}/services",
-						"clusterNamePartOfUrl": "{2}",
-						"baseprefix":           "/openapi-ui",
-						"customizationId":      "factory-details-v1.services",
-						"pathToItems":          []any{"items"},
+						"id":              "external-ips-table",
+						"fetchUrl":        "/api/clusters/{2}/k8s/api/v1/namespaces/{3}/services",
+						"cluster":         "{2}",
+						"baseprefix":      "/openapi-ui",
+						"customizationId": "factory-details-v1.services",
+						"pathToItems":     ".items",
 						"fieldSelector": map[string]any{
 							"spec.type": "LoadBalancer",
 						},


### PR DESCRIPTION
## Summary

- Fix External IPs page showing empty rows in the dashboard by correcting EnrichedTable properties in the `external-ips` factory
- Replace `clusterNamePartOfUrl` with `cluster` and change `pathToItems` from array format to dot-path string to match convention used by all other EnrichedTable instances

## Test plan

- [ ] Open Administration → External IPs in dashboard for a tenant with LoadBalancer services
- [ ] Verify table columns (Name, ClusterIP, LoadbalancerIP, Created) are rendered
- [ ] Verify service data is displayed correctly in the rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration handling for the external-ips dashboard tab to ensure cluster names display correctly and service items are consistently listed, improving stability and data presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->