### PR TITLE
fix(dashboard): exclude hidden MarketplacePanel resources from sidebar menu

### DIFF
--- a/internal/controller/dashboard/sidebar.go
+++ b/internal/controller/dashboard/sidebar.go
@@ -38,6 +38,23 @@ func (m *Manager) ensureSidebar(ctx context.Context, crd *cozyv1alpha1.Applicati
 	}
 	all = crdList.Items
 
+	// 1b) Fetch all MarketplacePanels to determine which resources are hidden
+	hiddenResources := map[string]bool{}
+	var mpList dashv1alpha1.MarketplacePanelList
+	if err := m.List(ctx, &mpList, &client.ListOptions{}); err == nil {
+		for i := range mpList.Items {
+			mp := &mpList.Items[i]
+			if mp.Spec.Raw != nil {
+				var spec map[string]any
+				if err := json.Unmarshal(mp.Spec.Raw, &spec); err == nil {
+					if hidden, ok := spec["hidden"].(bool); ok && hidden {
+						hiddenResources[mp.Name] = true
+					}
+				}
+			}
+		}
+	}
+
 	// 2) Build category -> []item map (only for CRDs with spec.dashboard != nil)
 	type item struct {
 		Key    string
@@ -62,6 +79,11 @@ func (m *Manager) ensureSidebar(ctx context.Context, crd *cozyv1alpha1.Applicati
 		g, v, kind := pickGVK(def)
 		plural := pickPlural(kind, def)
 		lowerKind := strings.ToLower(kind)
+
+		// Skip resources hidden via MarketplacePanel
+		if hiddenResources[def.Name] {
+			continue
+		}
 
 		// Check if this resource is a module
 		if def.Spec.Dashboard.Module {


### PR DESCRIPTION
## Summary

- Sidebar menu was showing all resources regardless of their MarketplacePanel `hidden` state
- Fetch MarketplacePanels during sidebar reconciliation and skip resources where `hidden=true`
- Hiding a resource from the marketplace now also removes it from the sidebar navigation

## Test plan

- [ ] Set `hidden: true` on a MarketplacePanel (e.g. qdrant)
- [ ] Trigger controller reconciliation
- [ ] Verify the resource is removed from the sidebar menu
- [ ] Set `hidden: false` and verify the resource reappears in the sidebar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar can now hide resources based on MarketplacePanel configuration parsed from panel definitions.
  * Hidden resources are filtered early when assembling sidebar categories, preventing them from contributing to menu items.
  * Listing failures are non-fatal: if configuration fetch fails, no hiding is applied and the dashboard remains functional.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->