### PR TITLE
fix(etcd-operator): replace deprecated kube-rbac-proxy image

### DIFF
--- a/packages/system/etcd-operator/charts/etcd-operator/README.md
+++ b/packages/system/etcd-operator/charts/etcd-operator/README.md
@@ -38,8 +38,8 @@
 | kubeRbacProxy.args[2] | string | `"--logtostderr=true"` |  |
 | kubeRbacProxy.args[3] | string | `"--v=0"` |  |
 | kubeRbacProxy.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
-| kubeRbacProxy.image.repository | string | `"gcr.io/kubebuilder/kube-rbac-proxy"` | Image repository |
-| kubeRbacProxy.image.tag | string | `"v0.16.0"` | Version of image |
+| kubeRbacProxy.image.repository | string | `"quay.io/brancz/kube-rbac-proxy"` | Image repository |
+| kubeRbacProxy.image.tag | string | `"v0.18.1"` | Version of image |
 | kubeRbacProxy.livenessProbe | object | `{}` | https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | kubeRbacProxy.readinessProbe | object | `{}` | https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | kubeRbacProxy.resources | object | `{"limits":{"cpu":"250m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"64Mi"}}` | ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |

--- a/packages/system/etcd-operator/charts/etcd-operator/values.yaml
+++ b/packages/system/etcd-operator/charts/etcd-operator/values.yaml
@@ -98,13 +98,13 @@ kubeRbacProxy:
   image:
 
     # -- Image repository
-    repository: gcr.io/kubebuilder/kube-rbac-proxy
+    repository: quay.io/brancz/kube-rbac-proxy
 
     # -- Image pull policy
     pullPolicy: IfNotPresent
 
     # -- Version of image
-    tag: v0.16.0
+    tag: v0.18.1
 
   args:
     - --secure-listen-address=0.0.0.0:8443


### PR DESCRIPTION
## Summary
- Replace deprecated `gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0` with `quay.io/brancz/kube-rbac-proxy:v0.18.1` in the vendored etcd-operator chart
- The GCR-hosted image became unavailable after March 18, 2025

Fixes #2172 #488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated proxy component to v0.18.1 with configuration changes for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->