### PR TITLE
[keycloak] Add storageclass support for CNPG cluster

### DIFF
--- a/packages/system/keycloak/templates/db.yaml
+++ b/packages/system/keycloak/templates/db.yaml
@@ -7,7 +7,7 @@ spec:
   storage:
     size: 20Gi
     {{- if .Values.storageClass.enable }}
-    storageClass: keycloak-db-retain
+    storageClass: {{ .Values.storageClass.name | default "keycloak-db-retain" }}
     {{- end }}
   {{- if .Values._cluster.scheduling }}
   {{- $rawConstraints := get .Values._cluster.scheduling "globalAppTopologySpreadConstraints" }}

--- a/packages/system/keycloak/templates/storageclass.yaml
+++ b/packages/system/keycloak/templates/storageclass.yaml
@@ -2,8 +2,8 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: keycloak-db-retain
-provisioner: {{ required ".Values.storageClass.provisioner is required when storageClass.enable is true" .Values.storageClass.provisioner }}
+  name: {{ .Values.storageClass.name | default "keycloak-db-retain" }}
+provisioner: {{ required ".Values.storageClass.provisioner is required when storageClass.enable is true" .Values.storageClass.provisioner | quote }}
 reclaimPolicy: Retain
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true

--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -13,6 +13,7 @@ ingress:
 
 storageClass:
   enable: false
+  name: ""
   provisioner: ""
 
 resources:


### PR DESCRIPTION
## What this PR does
This PR adds optional storageClass with `reclaimPolicy: Retain` to be used for CNPG cluster to prevent PV deletion in case of CNPG cluster deletion. This is crucial to prevent data loss.

### Release note

```release-note
[keycloak] Add storageclass support for CNPG cluster
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keycloak database now supports configurable storage classes, allowing users to define custom storage provisioners, retention policies, and volume expansion settings to meet their infrastructure requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->