### PR TITLE
[tenant] Allow egress to virt-handler for VM metrics scraping

### DIFF
--- a/packages/apps/tenant/templates/networkpolicy.yaml
+++ b/packages/apps/tenant/templates/networkpolicy.yaml
@@ -207,6 +207,27 @@ spec:
   - toEndpoints:
       - matchLabels:
           "k8s:io.kubernetes.pod.namespace": cozy-kubevirt-cdi
+{{- if .Values.monitoring }}
+---
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: {{ include "tenant.name" . }}-egress-virt-handler
+spec:
+  endpointSelector:
+    matchLabels:
+      "k8s:io.kubernetes.pod.namespace": "{{ include "tenant.name" . }}"
+      "k8s:app.kubernetes.io/name": "vmagent"
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        "k8s:kubevirt.io": "virt-handler"
+        "k8s:io.kubernetes.pod.namespace": "cozy-kubevirt"
+    toPorts:
+    - ports:
+      - port: "8443"
+        protocol: TCP
+{{- end }}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy


### PR DESCRIPTION
## Summary

- Adds a `CiliumClusterwideNetworkPolicy` allowing egress from tenant pods to `virt-handler` in `cozy-kubevirt` namespace on port 8443/TCP
- Conditional on `.Values.monitoring` being enabled

## Problem

Tenant vmagent cannot scrape KubeVirt VM metrics from `virt-handler` because no network policy allows the traffic.

Relates to #2194

## Test plan

- [ ] `helm template` tenant with `monitoring: true` — virt-handler policy present
- [ ] `helm template` tenant with `monitoring: false` — virt-handler policy absent
- [ ] Deploy and verify vmagent can scrape kubevirt_vmi_* metrics

```release-note
Allow tenant egress to virt-handler for VM metrics scraping
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a network egress policy that, when monitoring is enabled, allows tenant namespaces to reach the virt-handler service on TCP port 8443, improving connectivity for monitoring-related traffic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->