### PR TITLE
[monitoring] Add inlineScrapeConfig support to tenant vmagent

### DIFF
--- a/packages/extra/monitoring/values.yaml
+++ b/packages/extra/monitoring/values.yaml
@@ -178,3 +178,7 @@ vmagent:
     urls:
       - http://vminsert-shortterm:8480/insert/0/prometheus
       - http://vminsert-longterm:8480/insert/0/prometheus
+  ## inlineScrapeConfig: |
+  ##   - job_name: "custom"
+  ##     static_configs:
+  ##       - targets: ["my-service:9090"]

--- a/packages/system/monitoring/templates/vm/vmagent.yaml
+++ b/packages/system/monitoring/templates/vm/vmagent.yaml
@@ -21,6 +21,10 @@ spec:
 
   scrapeInterval: 30s
   selectAllByDefault: false
+  {{- with .Values.vmagent.inlineScrapeConfig }}
+  inlineScrapeConfig: |
+    {{- . | nindent 4 }}
+  {{- end }}
   podScrapeNamespaceSelector:
     matchLabels:
       namespace.cozystack.io/monitoring: {{ .Release.Namespace }}

--- a/packages/system/monitoring/values.yaml
+++ b/packages/system/monitoring/values.yaml
@@ -80,3 +80,7 @@ vmagent:
     urls:
       - http://vminsert-shortterm:8480/insert/0/prometheus
       - http://vminsert-longterm:8480/insert/0/prometheus
+  ## inlineScrapeConfig: |
+  ##   - job_name: "custom"
+  ##     static_configs:
+  ##       - targets: ["my-service:9090"]


### PR DESCRIPTION
## Summary

- Adds `inlineScrapeConfig` support to the tenant `VMAgent` resource in `packages/system/monitoring/templates/vm/vmagent.yaml`
- Adds commented usage example in both `packages/system/monitoring/values.yaml` and `packages/extra/monitoring/values.yaml`

## Problem

The tenant VMAgent resource does not support custom scrape configurations. Using `additionalScrapeConfigs` (which references a Kubernetes Secret) is not viable because tenant users have no access to create or read Secrets — they can only manage resources under `apps.cozystack.io`. Instead, `inlineScrapeConfig` accepts inline YAML directly through Helm values, which is consistent with tenant permissions.

Relates to #2194

## Usage

```yaml
vmagent:
  inlineScrapeConfig: |
    - job_name: "custom"
      static_configs:
        - targets: ["my-service:9090"]
```

## Test plan

- [ ] `helm template` monitoring with `inlineScrapeConfig` set — block rendered
- [ ] `helm template` monitoring without it — no `inlineScrapeConfig` in output
- [ ] Deploy and verify custom scrape targets are picked up by vmagent

```release-note
Add inlineScrapeConfig support to tenant vmagent
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for including an inline scrape configuration into VMAgent monitoring when provided.

* **Documentation**
  * Added a commented example showing how to supply an inline scrape job and targets.
  * Reordered remote-write URL entries in monitoring configuration for clearer ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->