### PR TITLE
[keycloak-operator] Update to v1.32.0

### DIFF
--- a/packages/system/dashboard/templates/keycloakclient.yaml
+++ b/packages/system/dashboard/templates/keycloakclient.yaml
@@ -57,7 +57,6 @@ spec:
     kind: ClusterKeycloakRealm
   secret: $dashboard-client:client-secret-key
   advancedProtocolMappers: true
-  authorizationServicesEnabled: true
   name: dashboard
   clientId: dashboard
   directAccess: true

--- a/packages/system/keycloak-configure/templates/configure-kk.yaml
+++ b/packages/system/keycloak-configure/templates/configure-kk.yaml
@@ -37,6 +37,10 @@ spec:
   displayHtmlName: {{ $brandingConfig.branding }}
   {{- end }}
   {{- end }}
+  sessions:
+    ssoSessionSettings:
+      idleTimeout: 86400
+      maxLifespan: 604800
 
 ---
 

--- a/packages/system/keycloak-operator/Makefile
+++ b/packages/system/keycloak-operator/Makefile
@@ -4,6 +4,17 @@ export NAMESPACE=cozy-keycloak
 include ../../../hack/common-envs.mk
 include ../../../hack/package.mk
 
+image:
+	docker buildx build images/keycloak-operator \
+		--tag $(REGISTRY)/keycloak-operator:$(call settag,$(TAG)) \
+		--cache-from type=registry,ref=$(REGISTRY)/keycloak-operator:latest \
+		--cache-to   type=inline \
+		--metadata-file images/keycloak-operator.json \
+		$(BUILDX_ARGS)
+	TAG="$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/keycloak-operator.json -r)" \
+		yq -i '.keycloak-operator.image.tag = strenv(TAG)' values.yaml
+	rm -f images/keycloak-operator.json
+
 update:
 	rm -rf charts
 	helm repo add epamedp https://epam.github.io/edp-helm-charts/stable

--- a/packages/system/keycloak-operator/charts/keycloak-operator/Chart.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/Chart.yaml
@@ -157,30 +157,29 @@ annotations:
     - apiVersion: v1.edp.epam.com/v1
       kind: KeycloakRealmIdentityProvider
       metadata:
-        name: instagram-test
+        name: github-test
       spec:
         realm: d2-id-k8s-realm-name
-        alias: instagram
+        alias: github
         authenticateByDefault: false
         enabled: true
         firstBrokerLoginFlowAlias: "first broker login"
-        providerId: "instagram"
+        providerId: "github"
         config:
           clientId: "foo"
           clientSecret: "bar"
-          hideOnLoginPage: "true"
           syncMode: "IMPORT"
           useJwksUrl: "true"
         mappers:
           - name: "test3212"
             identityProviderMapper: "oidc-hardcoded-role-idp-mapper"
-            identityProviderAlias: "instagram"
+            identityProviderAlias: "github"
             config:
               role: "role-tr"
               syncMode: "INHERIT"
           - name: "test-33221"
             identityProviderMapper: "hardcoded-attribute-idp-mapper"
-            identityProviderAlias: "instagram"
+            identityProviderAlias: "github"
             config:
               attribute: "foo"
               "attribute.value": "bar"
@@ -272,8 +271,8 @@ annotations:
         secret: secret-name-in-operator-ns
         url: https://keycloak.example.com
   artifacthub.io/images: |
-    - name: keycloak-operator:1.25.0
-      image: epamedp/keycloak-operator:1.25.0
+    - name: keycloak-operator:1.32.0
+      image: epamedp/keycloak-operator:1.32.0
   artifacthub.io/license: Apache-2.0
   artifacthub.io/links: |
     - name: KubeRocketCI Documentation
@@ -283,7 +282,7 @@ annotations:
   artifacthub.io/operator: "true"
   artifacthub.io/operatorCapabilities: Deep Insights
 apiVersion: v2
-appVersion: 1.25.0
+appVersion: 1.32.0
 description: A Helm chart for KubeRocketCI Keycloak Operator
 home: https://docs.kuberocketci.io/
 icon: https://docs.kuberocketci.io/img/logo.svg
@@ -308,4 +307,4 @@ name: keycloak-operator
 sources:
 - https://github.com/epam/edp-keycloak-operator
 type: application
-version: 1.25.0
+version: 1.32.0

--- a/packages/system/keycloak-operator/charts/keycloak-operator/README.md
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/README.md
@@ -1,6 +1,6 @@
 # keycloak-operator
 
-![Version: 1.25.0](https://img.shields.io/badge/Version-1.25.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.25.0](https://img.shields.io/badge/AppVersion-1.25.0-informational?style=flat-square)
+![Version: 1.32.0](https://img.shields.io/badge/Version-1.32.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.32.0](https://img.shields.io/badge/AppVersion-1.32.0-informational?style=flat-square)
 
 A Helm chart for KubeRocketCI Keycloak Operator
 
@@ -16,6 +16,7 @@ _**NOTE:** Operator is platform-independent, which is why there is a unified ins
 
 1. Linux machine or Windows Subsystem for Linux instance with [Helm 3](https://helm.sh/docs/intro/install/) installed;
 2. Cluster admin access to the cluster;
+3. [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster (required for webhook functionality, can be disabled via `enableWebhooks: false`);
 
 ## Installation Using Helm Chart
 
@@ -32,7 +33,7 @@ To install the Keycloak Operator, follow the steps below:
      ```bash
      helm search repo epamedp/keycloak-operator -l
      NAME                           CHART VERSION   APP VERSION     DESCRIPTION
-     epamedp/keycloak-operator      1.24.0          1.24.0          A Helm chart for KRCI Keycloak Operator
+     epamedp/keycloak-operator      1.31.0          1.31.0          A Helm chart for KRCI Keycloak Operator
      ```
 
     _**NOTE:** It is highly recommended to use the latest stable version._
@@ -129,14 +130,21 @@ Development versions are also available from the [snapshot helm chart repository
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity for pod assignment |
 | annotations | object | `{}` | Annotations to be added to the Deployment |
+| clusterDomain | string | `"cluster.local"` | Cluster domain for constructing service DNS names |
 | clusterReconciliationEnabled | bool | `false` | If clusterReconciliationEnabled is true, the operator reconciles all Keycloak instances in the cluster;  otherwise, it only reconciles instances in the same namespace by default, and cluster-scoped resources are ignored. |
+| containerSecurityContext | object | `{"allowPrivilegeEscalation":false}` | Container Security Context Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
+| enableOwnerRef | bool | `true` | If set to true, the operator will set the owner reference for all resources that have Keycloak or KeycloakRealm as reference. This is legacy behavior and not recommended for use. In the future, this will be set to false by default. |
+| enableWebhooks | bool | `true` | If set to true, enables webhook resources (ValidatingWebhookConfiguration, Service, and Certificate). Webhooks require cert-manager to be installed in the cluster. |
 | extraVolumeMounts | list | `[]` | Additional volumeMounts to be added to the container |
 | extraVolumes | list | `[]` | Additional volumes to be added to the pod |
+| image.registry | string | `""` | KubeRocketCI keycloak-operator Docker image registry. |
 | image.repository | string | `"epamedp/keycloak-operator"` | KubeRocketCI keycloak-operator Docker image name. The released image can be found on [Dockerhub](https://hub.docker.com/r/epamedp/keycloak-operator) |
 | image.tag | string | `nil` | KubeRocketCI keycloak-operator Docker image tag. The released image can be found on [Dockerhub](https://hub.docker.com/r/epamedp/keycloak-operator/tags) |
 | imagePullPolicy | string | `"IfNotPresent"` | If defined, a imagePullPolicy applied to the deployment |
 | imagePullSecrets | list | `[]` | If defined, imagePullSecrets are applied to deployment |
 | name | string | `"keycloak-operator"` | Application name string |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
+| podLabels | object | `{}` | Labels to be added to the pod |
 | resources | object | `{"limits":{"memory":"192Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | Resource limits and requests for the pod |
+| securityContext | object | `{"runAsNonRoot":true}` | Deployment Security Context Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | tolerations | list | `[]` | Node tolerations for server scheduling to nodes with taints |

--- a/packages/system/keycloak-operator/charts/keycloak-operator/README.md.gotmpl
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/README.md.gotmpl
@@ -17,6 +17,7 @@ _**NOTE:** Operator is platform-independent, which is why there is a unified ins
 
 1. Linux machine or Windows Subsystem for Linux instance with [Helm 3](https://helm.sh/docs/intro/install/) installed;
 2. Cluster admin access to the cluster;
+3. [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster (required for webhook functionality, can be disabled via `enableWebhooks: false`);
 
 ## Installation Using Helm Chart
 
@@ -33,7 +34,7 @@ To install the Keycloak Operator, follow the steps below:
      ```bash
      helm search repo epamedp/keycloak-operator -l
      NAME                           CHART VERSION   APP VERSION     DESCRIPTION
-     epamedp/keycloak-operator      1.24.0          1.24.0          A Helm chart for KRCI Keycloak Operator
+     epamedp/keycloak-operator      1.31.0          1.31.0          A Helm chart for KRCI Keycloak Operator
      ```
 
     _**NOTE:** It is highly recommended to use the latest stable version._

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/clusterkeycloakrealm.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/clusterkeycloakrealm.yaml
@@ -7,3 +7,25 @@ spec:
   realmName: realm-sample1234
   authenticationFlows:
     browserFlow: browserFlow-sample
+  login:
+    userRegistration: true
+    forgotPassword: true
+    rememberMe: true
+    emailAsUsername: false
+    loginWithEmail: true
+    duplicateEmails: false
+    verifyEmail: true
+    editUsername: false
+  sessions:
+    ssoLoginSettings:
+      accessCodeLifespanLogin: 1800      # 30 minutes
+      accessCodeLifespanUserAction: 300  # 5 minutes
+    ssoSessionSettings:
+      idleTimeout: 1800                  # 30 minutes
+      idleTimeoutRememberMe: 604800      # 7 days
+      maxLifespan: 36000                 # 10 hours
+      maxLifespanRememberMe: 2592000     # 30 days
+    ssoOfflineSessionSettings:
+      idleTimeout: 2592000               # 30 days
+      maxLifespan: 5184000               # 60 days
+      maxLifespanEnabled: true

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakclient.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakclient.yaml
@@ -14,11 +14,16 @@ spec:
   webUrl: https://argocd.example.com
   adminUrl: https://admin.example.com
   homeUrl: /home/
-  defaultClientScopes:
-    - groups
   redirectUris:
     - /url1/*
     - /url2/*
+  clientRolesV2:
+    - name: roleA
+      description: "Role A"
+      associatedClientRoles:
+        - roleB
+    - name: roleB
+      description: "Role B"
 
 ---
 

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakclientscope.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakclientscope.yaml
@@ -8,6 +8,7 @@ spec:
     name: keycloakrealm-sample
     kind: KeycloakRealm
   description: "Group Membership"
+  type: default
   protocol: openid-connect
   protocolMappers:
     - name: groups

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakorganizationorganization.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakorganizationorganization.yaml
@@ -1,0 +1,45 @@
+# Organization with identity provider configuration
+apiVersion: v1.edp.epam.com/v1alpha1
+kind: KeycloakOrganization
+metadata:
+  name: test-keycloak-organization
+  namespace: default
+spec:
+  name: "Test Organization"
+  alias: "test-org"
+  domains:
+    - "example.com"
+    - "test.com"
+  redirectUrl: "https://example.com/redirect"
+  description: "Test organization"
+  attributes:
+    department:
+      - "engineering"
+      - "qa"
+    location:
+      - "us-east"
+  identityProviders:
+    - alias: "test-org-idp"
+  realmRef:
+    kind: KeycloakRealm
+    name: test-org-realm
+
+---
+
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakRealmIdentityProvider
+metadata:
+  name: test-org-idp
+  namespace: default
+spec:
+  alias: "test-org-idp"
+  enabled: true
+  providerId: "github"
+  realmRef:
+    kind: KeycloakRealm
+    name: test-org-realm
+  config:
+    clientId: "test-org-client-id"
+    clientSecret: "test-org-client-secret"
+    kc.org.domain: "example.com"
+    kc.org.broker.redirect.mode.email-matches: "true"

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealm.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealm.yaml
@@ -3,7 +3,6 @@ kind: KeycloakRealm
 metadata:
   name: keycloakrealm-sample
 spec:
-  id: bfebeff6-ac63-4b46-a1f3-37df5099a9c4
   realmName: realm-sample
   keycloakRef:
     name: keycloak-sample
@@ -16,6 +15,7 @@ spec:
   realmEventConfig:
     adminEventsDetailsEnabled: false
     adminEventsEnabled: true
+    adminEventsExpiration: 544
     enabledEventTypes:
       - UPDATE_CONSENT_ERROR
       - CLIENT_LOGIN
@@ -32,6 +32,15 @@ spec:
     refreshTokenMaxReuse: 300
     revokeRefreshToken: true
     defaultSignatureAlgorithm: RS256
+  login:
+    userRegistration: true
+    forgotPassword: true
+    rememberMe: true
+    emailAsUsername: true
+    loginWithEmail: true
+    duplicateEmails: false
+    verifyEmail: true
+    editUsername: true
   userProfileConfig:
     unmanagedAttributePolicy: "ENABLED"
     attributes:
@@ -94,3 +103,16 @@ spec:
             key: "password"
         username:
           value: "username"
+  sessions:
+    ssoLoginSettings:
+      accessCodeLifespanLogin: 1800      # 30 minutes
+      accessCodeLifespanUserAction: 300  # 5 minutes
+    ssoSessionSettings:
+      idleTimeout: 1800                  # 30 minutes
+      idleTimeoutRememberMe: 604800      # 7 days
+      maxLifespan: 36000                 # 10 hours
+      maxLifespanRememberMe: 2592000     # 30 days
+    ssoOfflineSessionSettings:
+      idleTimeout: 2592000               # 30 days
+      maxLifespan: 5184000               # 60 days
+      maxLifespanEnabled: true

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmgroup.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmgroup.yaml
@@ -7,3 +7,29 @@ spec:
     name: keycloakrealm-sample
     kind: KeycloakRealm
   name: ArgoCDAdmins
+---
+# Example of a child group using parentGroup
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakRealmGroup
+metadata:
+  name: keycloakrealmgroup-child-sample
+spec:
+  realmRef:
+    name: keycloakrealm-sample
+    kind: KeycloakRealm
+  name: ArgoCDDevelopers
+  parentGroup:
+    name: keycloakrealmgroup-sample
+
+---
+apiVersion: v1.edp.epam.com/v1
+kind: KeycloakRealmGroup
+metadata:
+  name: keycloakrealmgroup-child-sample2
+spec:
+  realmRef:
+    name: keycloakrealm-sample
+    kind: KeycloakRealm
+  name: ArgoCDGoDevs
+  parentGroup:
+    name: keycloakrealmgroup-child-sample

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmidentityprovider.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmidentityprovider.yaml
@@ -5,23 +5,33 @@ metadata:
 spec:
   realmRef:
     kind: KeycloakRealm
-    name: realm
-  alias: instagram
+    name: keycloakrealm-sample
+  alias: github
   authenticateByDefault: false
   enabled: true
   firstBrokerLoginFlowAlias: "first broker login"
-  providerId: "instagram"
+  postBrokerLoginFlowAlias: "browser"
+  providerId: "github"
   config:
     clientId: "foo"
-    clientSecret: "$secretName:secretKey"
-    hideOnLoginPage: "true"
+    clientSecret: "$test-idp-secret:secret"
     syncMode: "IMPORT"
     useJwksUrl: "true"
   mappers:
     - name: "test-33221"
       identityProviderMapper: "hardcoded-attribute-idp-mapper"
-      identityProviderAlias: "instagram"
+      identityProviderAlias: "github"
       config:
         attribute: "foo"
         "attribute.value": "bar"
         syncMode: "IMPORT"
+
+---
+  
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-idp-secret
+type: Opaque
+data:
+  secret: "c2VjcmV0"  # base64 encoded value of "secret"

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmuser.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmuser.yaml
@@ -13,8 +13,21 @@ spec:
   enabled: true
   emailVerified: true
   keepResource: true
+  passwordSecret:
+    key: password
+    name: keycloakrealmuser-sample-password
+    temporary: true
   requiredUserActions:
-    - UPDATE_PASSWORD
-  attributes:
-    foo: "bar"
-    baz: "jazz"
+    - UPDATE_PROFILE
+  attributesV2:
+    department: ["IT"]
+    location: ["Winterfell"]
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloakrealmuser-sample-password
+type: Opaque
+data:
+  password: "U29tZVBhc3N3b3JkMTIzIQ==" # SomePassword123!

--- a/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmuser_password.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/_crd_examples/keycloakrealmuser_password.yaml
@@ -19,3 +19,5 @@ spec:
   passwordSecret:
     name: existing-k8s-secret
     key: key-which-contains-password
+  identityProviders:
+    - provider-alias

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_clusterkeycloakrealms.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_clusterkeycloakrealms.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: clusterkeycloakrealms.v1.edp.epam.com
 spec:
   group: v1.edp.epam.com
@@ -97,6 +97,57 @@ spec:
                     nullable: true
                     type: boolean
                 type: object
+              login:
+                description: Login settings for the realm.
+                nullable: true
+                properties:
+                  duplicateEmails:
+                    default: false
+                    description: DuplicateEmails allows multiple users to have the
+                      same email address.
+                    type: boolean
+                  editUsername:
+                    default: false
+                    description: EditUsername allows to edit username.
+                    type: boolean
+                  emailAsUsername:
+                    default: false
+                    description: EmailAsUsername allows users to set email as username.
+                    type: boolean
+                  forgotPassword:
+                    default: false
+                    description: ForgotPassword shows a link on the login page for
+                      users who have forgotten their credentials.
+                    type: boolean
+                  loginWithEmail:
+                    default: true
+                    description: LoginWithEmail allows users to log in with their
+                      email address.
+                    type: boolean
+                  rememberMe:
+                    default: false
+                    description: RememberMe shows checkbox on the login page to allow
+                      the user to remain logged in between browser restarts until
+                      the session expires.
+                    type: boolean
+                  userRegistration:
+                    default: false
+                    description: UserRegistration enables/disables the registration
+                      page. A link for registration will show on the login page too.
+                    type: boolean
+                  verifyEmail:
+                    default: false
+                    description: VerifyEmail requires user to verify their email address
+                      after initial login or after address changes are submitted.
+                    type: boolean
+                type: object
+              organizationsEnabled:
+                default: false
+                description: |-
+                  OrganizationsEnabled enables Keycloak Organizations feature for this realm.
+                  When enabled, this realm can support Organization resources for multi-tenant scenarios,
+                  identity provider groupings, and domain-based user routing.
+                type: boolean
               passwordPolicy:
                 description: PasswordPolicies is a list of password policies to apply
                   to the realm.
@@ -153,6 +204,80 @@ spec:
               realmName:
                 description: RealmName specifies the name of the realm.
                 type: string
+              sessions:
+                description: Sessions defines the session settings for the realm.
+                properties:
+                  ssoLoginSettings:
+                    description: SSOLoginSettings defines the SSO login settings for
+                      the realm.
+                    properties:
+                      accessCodeLifespanLogin:
+                        default: 1800
+                        description: AccessCodeLifespanLogin represents the max time
+                          a user has to complete a login. This is recommended to be
+                          relatively long, such as 30 minutes or more.
+                        type: integer
+                      accessCodeLifespanUserAction:
+                        default: 300
+                        description: AccessCodeLifespanUserAction represents the max
+                          time a user has to complete login related actions like update
+                          password or configure totp. This is recommended to be relatively
+                          long, such as 5 minutes or more.
+                        type: integer
+                    type: object
+                  ssoOfflineSessionSettings:
+                    description: SSOOfflineSessionSettings defines the SSO offline
+                      session settings for the realm.
+                    properties:
+                      idleTimeout:
+                        default: 2592000
+                        description: |-
+                          IdleTimeout represents the time an offline session is allowed to be idle before it expires.
+                          You need to use offline token to refresh at least once within this period; otherwise offline session will expire.
+                        type: integer
+                      maxLifespan:
+                        default: 5184000
+                        description: MaxLifespan represents the max time before an
+                          offline session is expired regardless of activity.
+                        type: integer
+                      maxLifespanEnabled:
+                        default: false
+                        description: MaxLifespanEnabled enables the offline session
+                          maximum lifetime.
+                        type: boolean
+                    type: object
+                  ssoSessionSettings:
+                    description: SSOSessionSettings defines the SSO session settings
+                      for the realm.
+                    properties:
+                      idleTimeout:
+                        default: 1800
+                        description: |-
+                          IdleTimeout represents the time a session is allowed to be idle before it expires.
+                          Tokens and browser sessions are invalidated when a session is expired.
+                        type: integer
+                      idleTimeoutRememberMe:
+                        default: 0
+                        description: |-
+                          IdleTimeoutRememberMe represents the time a session is allowed to be idle before it expires.
+                          Tokens and browser sessions are invalidated when a session is expired.
+                          If not set it uses the standard ssoSessionIdle value.
+                        type: integer
+                      maxLifespan:
+                        default: 36000
+                        description: |-
+                          MaxLifespan represents the max time before a session is expired.
+                          Tokens and browser sessions are invalidated when a session is expired.
+                        type: integer
+                      maxLifespanRememberMe:
+                        default: 0
+                        description: |-
+                          MaxLifespanRememberMe represents the max time before a session is expired when a user has set the remember me option.
+                          Tokens and browser sessions are invalidated when a session is expired.
+                          If not set it uses the standard ssoSessionMax value.
+                        type: integer
+                    type: object
+                type: object
               smtp:
                 description: Smtp is the configuration for email in the realm.
                 nullable: true
@@ -174,10 +299,13 @@ spec:
                                     description: The key to select.
                                     type: string
                                   name:
+                                    default: ""
                                     description: |-
                                       Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                 required:
                                 - key
@@ -190,10 +318,13 @@ spec:
                                     description: The key of the secret to select from.
                                     type: string
                                   name:
+                                    default: ""
                                     description: |-
                                       Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                 required:
                                 - key
@@ -210,10 +341,13 @@ spec:
                                     description: The key to select.
                                     type: string
                                   name:
+                                    default: ""
                                     description: |-
                                       Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                 required:
                                 - key
@@ -226,10 +360,13 @@ spec:
                                     description: The key of the secret to select from.
                                     type: string
                                   name:
+                                    default: ""
                                     description: |-
                                       Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                 required:
                                 - key

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_clusterkeycloaks.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_clusterkeycloaks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: clusterkeycloaks.v1.edp.epam.com
 spec:
   group: v1.edp.epam.com
@@ -66,10 +66,13 @@ spec:
                         description: The key to select.
                         type: string
                       name:
+                        default: ""
                         description: |-
                           Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                     required:
                     - key
@@ -82,10 +85,13 @@ spec:
                         description: The key of the secret to select from.
                         type: string
                       name:
+                        default: ""
                         description: |-
                           Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                     required:
                     - key

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakauthflows.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakauthflows.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: keycloakauthflows.v1.edp.epam.com
 spec:
   group: v1.edp.epam.com
@@ -15,7 +15,7 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: Reconcilation status
+    - description: Reconciliation status
       jsonPath: .status.value
       name: Status
       type: string
@@ -109,15 +109,11 @@ spec:
                 description: ProviderID for root auth flow and provider for child
                   auth flows.
                 type: string
-              realm:
-                description: |-
-                  Deprecated: use RealmRef instead.
-                  Realm is name of KeycloakRealm custom resource.
-                type: string
               realmRef:
                 description: RealmRef is reference to Realm custom resource.
                 properties:
                   kind:
+                    default: KeycloakRealm
                     description: Kind specifies the kind of the Keycloak resource.
                     enum:
                     - KeycloakRealm
@@ -126,6 +122,8 @@ spec:
                   name:
                     description: Name specifies the name of the Keycloak resource.
                     type: string
+                required:
+                - name
                 type: object
               topLevel:
                 description: TopLevel is true if this is root auth flow.
@@ -134,6 +132,7 @@ spec:
             - alias
             - builtIn
             - providerId
+            - realmRef
             - topLevel
             type: object
           status:

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakclients.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakclients.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: keycloakclients.v1.edp.epam.com
 spec:
   group: v1.edp.epam.com
@@ -15,7 +15,7 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: Reconcilation status
+    - description: Reconciliation status
       jsonPath: .status.value
       name: Status
       type: string
@@ -45,8 +45,10 @@ spec:
             description: KeycloakClientSpec defines the desired state of KeycloakClient.
             properties:
               adminFineGrainedPermissionsEnabled:
-                description: AdminFineGrainedPermissionsEnabled enable/disable fine-grained
-                  admin permissions for a client.
+                description: |-
+                  AdminFineGrainedPermissionsEnabled enable/disable fine-grained admin permissions for a client.
+                  Feature flag admin-fine-grained-authz:v1 should be enabled in Keycloak server.
+                  Important: FGAP:V1 Keycloak feature remains in preview and may be deprecated and removed in a future releases.
                 type: boolean
               adminUrl:
                 description: |-
@@ -222,6 +224,8 @@ spec:
                                 within an access token or ID token representing the identity asking permissions.
                                 If not defined, user's groups are obtained from your realm configuration.
                               type: string
+                          required:
+                          - groups
                           type: object
                         logic:
                           default: POSITIVE
@@ -419,10 +423,34 @@ spec:
                   URI and tokens.
                 type: string
               clientRoles:
-                description: ClientRoles is a list of client roles names assigned
-                  to client.
+                description: |-
+                  ClientRoles is a list of client roles names assigned to client.
+                  Deprecated: Use ClientRolesV2 instead.
                 items:
                   type: string
+                nullable: true
+                type: array
+              clientRolesV2:
+                description: ClientRolesV2 is a list of client roles assigned to client.
+                items:
+                  properties:
+                    associatedClientRoles:
+                      description: |-
+                        AssociatedClientRoles is a list of client roles names associated with the current role.
+                        These roles won't be created automatically, user should specify them separately in clientRolesV2.
+                      items:
+                        type: string
+                      nullable: true
+                      type: array
+                    description:
+                      description: Description is a client role description.
+                      type: string
+                    name:
+                      description: Name is a client role name.
+                      type: string
+                  required:
+                  - name
+                  type: object
                 nullable: true
                 type: array
               consentRequired:
@@ -524,6 +552,7 @@ spec:
                 description: RealmRef is reference to Realm custom resource.
                 properties:
                   kind:
+                    default: KeycloakRealm
                     description: Kind specifies the kind of the Keycloak resource.
                     enum:
                     - KeycloakRealm
@@ -532,6 +561,8 @@ spec:
                   name:
                     description: Name specifies the name of the Keycloak resource.
                     type: string
+                required:
+                - name
                 type: object
               realmRoles:
                 description: RealmRoles is a list of realm roles assigned to client.
@@ -582,7 +613,19 @@ spec:
                   attributes:
                     additionalProperties:
                       type: string
-                    description: Attributes is a map of service account attributes.
+                    description: |-
+                      Attributes is a map of service account attributes.
+                      Deprecated: Use AttributesV2 instead.
+                    nullable: true
+                    type: object
+                  attributesV2:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: |-
+                      AttributesV2 is a map of service account attributes.
+                      Each attribute can have multiple values.
                     nullable: true
                     type: object
                   clientRoles:
@@ -595,7 +638,7 @@ spec:
                           type: string
                         roles:
                           description: Roles is a list of client roles names assigned
-                            to service account.
+                            to user.
                           items:
                             type: string
                           nullable: true
@@ -608,6 +651,12 @@ spec:
                   enabled:
                     description: Enabled is a flag to enable service account.
                     type: boolean
+                  groups:
+                    description: Groups is a list of groups assigned to service account
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
                   realmRoles:
                     description: RealmRoles is a list of realm roles assigned to service
                       account.
@@ -623,13 +672,6 @@ spec:
               surrogateAuthRequired:
                 description: SurrogateAuthRequired is a flag to enable surrogate auth.
                 type: boolean
-              targetRealm:
-                description: |-
-                  Deprecated: use RealmRef instead.
-                  TargetRealm is a realm name where client will be created.
-                  It has higher priority than RealmRef for backward compatibility.
-                  If both TargetRealm and RealmRef are specified, TargetRealm will be used for client creation.
-                type: string
               webOrigins:
                 description: |-
                   WebOrigins is a list of allowed CORS origins.
@@ -647,12 +689,72 @@ spec:
                 type: string
             required:
             - clientId
+            - realmRef
             type: object
           status:
             description: KeycloakClientStatus defines the observed state of KeycloakClient.
             properties:
               clientId:
                 type: string
+              conditions:
+                description: Conditions represent the latest available observations
+                  of an object's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                nullable: true
+                type: array
               failureCount:
                 format: int64
                 type: integer

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakclientscopes.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakclientscopes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: keycloakclientscopes.v1.edp.epam.com
 spec:
   group: v1.edp.epam.com
@@ -15,7 +15,7 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: Reconcilation status
+    - description: Reconciliation status
       jsonPath: .status.value
       name: Status
       type: string
@@ -52,7 +52,9 @@ spec:
                 nullable: true
                 type: object
               default:
-                description: Default is a flag to set client scope as default.
+                description: |-
+                  Default is a flag to set client scope as default.
+                  Deprecated: Use Type: default instead.
                 type: boolean
               description:
                 description: Description is a description of client scope.
@@ -87,15 +89,11 @@ spec:
                   type: object
                 nullable: true
                 type: array
-              realm:
-                description: |-
-                  Deprecated: use RealmRef instead.
-                  Realm is name of KeycloakRealm custom resource.
-                type: string
               realmRef:
                 description: RealmRef is reference to Realm custom resource.
                 properties:
                   kind:
+                    default: KeycloakRealm
                     description: Kind specifies the kind of the Keycloak resource.
                     enum:
                     - KeycloakRealm
@@ -104,10 +102,25 @@ spec:
                   name:
                     description: Name specifies the name of the Keycloak resource.
                     type: string
+                required:
+                - name
                 type: object
+              type:
+                default: none
+                description: |-
+                  Type of the client scope.
+                  If set to "default", the client scope is assigned to all clients by default.
+                  If set to "optional", the client scope can be assigned to clients on demand.
+                  If set to "none", the client scope is not assigned to any clients by default.
+                enum:
+                - default
+                - optional
+                - none
+                type: string
             required:
             - name
             - protocol
+            - realmRef
             type: object
           status:
             description: KeycloakClientScopeStatus defines the observed state of KeycloakClientScope.

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakorganizations.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakorganizations.yaml
@@ -1,0 +1,149 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: keycloakorganizations.v1.edp.epam.com
+spec:
+  group: v1.edp.epam.com
+  names:
+    kind: KeycloakOrganization
+    listKind: KeycloakOrganizationList
+    plural: keycloakorganizations
+    singular: keycloakorganization
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Reconciliation status
+      jsonPath: .status.value
+      name: Status
+      type: string
+    - description: Keycloak organization ID
+      jsonPath: .status.organizationId
+      name: Organization ID
+      type: string
+    - description: Keycloak realm name
+      jsonPath: .spec.realmName
+      name: Realm
+      type: string
+    - description: Keycloak instance name
+      jsonPath: .spec.keycloakRef.name
+      name: Keycloak
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakOrganization is the Schema for the organizations API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakOrganizationSpec defines the desired state of Organization.
+            properties:
+              alias:
+                description: |-
+                  Alias is the unique alias for the organization.
+                  The alias should be unique across Organizations.
+                type: string
+              attributes:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: Attributes is a map of custom attributes for the organization.
+                nullable: true
+                type: object
+              description:
+                description: Description is an optional description of the organization.
+                type: string
+              domains:
+                description: |-
+                  Domains is a list of email domains associated with the organization.
+                  Each domain should be unique across Organizations.
+                items:
+                  type: string
+                minItems: 1
+                type: array
+              identityProviders:
+                description: |-
+                  IdentityProviders is a list of identity providers associated with the organization.
+                  One identity provider can't be assigned to multiple organizations.
+                items:
+                  description: OrgIdentityProvider defines an identity provider for
+                    an organization.
+                  properties:
+                    alias:
+                      description: Alias is the unique identifier for the identity
+                        provider within the organization.
+                      type: string
+                  required:
+                  - alias
+                  type: object
+                nullable: true
+                type: array
+              name:
+                description: |-
+                  Name is the unique name of the organization.
+                  The name should be unique across Organizations.
+                type: string
+              realmRef:
+                description: RealmRef is reference to Realm custom resource.
+                properties:
+                  kind:
+                    default: KeycloakRealm
+                    description: Kind specifies the kind of the Keycloak resource.
+                    enum:
+                    - KeycloakRealm
+                    - ClusterKeycloakRealm
+                    type: string
+                  name:
+                    description: Name specifies the name of the Keycloak resource.
+                    type: string
+                required:
+                - name
+                type: object
+              redirectUrl:
+                description: RedirectURL is the optional redirect URL for the organization.
+                type: string
+            required:
+            - alias
+            - domains
+            - name
+            - realmRef
+            type: object
+          status:
+            description: KeycloakOrganizationStatus defines the observed state of
+              Organization.
+            properties:
+              error:
+                description: Error is the error message if the reconciliation failed.
+                type: string
+              organizationId:
+                description: OrganizationID is the unique identifier of the organization
+                  in Keycloak.
+                type: string
+              value:
+                description: Value contains the current reconciliation status.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmcomponents.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmcomponents.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: keycloakrealmcomponents.v1.edp.epam.com
 spec:
   group: v1.edp.epam.com
@@ -15,7 +15,7 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: Reconcilation status
+    - description: Reconciliation status
       jsonPath: .status.value
       name: Status
       type: string
@@ -90,15 +90,11 @@ spec:
               providerType:
                 description: ProviderType is a provider type of component.
                 type: string
-              realm:
-                description: |-
-                  Deprecated: use RealmRef instead.
-                  Realm is name of KeycloakRealm custom resource.
-                type: string
               realmRef:
                 description: RealmRef is reference to Realm custom resource.
                 properties:
                   kind:
+                    default: KeycloakRealm
                     description: Kind specifies the kind of the Keycloak resource.
                     enum:
                     - KeycloakRealm
@@ -107,11 +103,14 @@ spec:
                   name:
                     description: Name specifies the name of the Keycloak resource.
                     type: string
+                required:
+                - name
                 type: object
             required:
             - name
             - providerId
             - providerType
+            - realmRef
             type: object
           status:
             description: KeycloakComponentStatus defines the observed state of KeycloakRealmComponent.

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmgroups.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmgroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: keycloakrealmgroups.v1.edp.epam.com
 spec:
   group: v1.edp.epam.com
@@ -15,7 +15,7 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: Reconcilation status
+    - description: Reconciliation status
       jsonPath: .status.value
       name: Status
       type: string
@@ -67,7 +67,7 @@ spec:
                       type: string
                     roles:
                       description: Roles is a list of client roles names assigned
-                        to service account.
+                        to user.
                       items:
                         type: string
                       nullable: true
@@ -80,18 +80,28 @@ spec:
               name:
                 description: Name of keycloak group.
                 type: string
+              parentGroup:
+                description: |-
+                  ParentGroup is a reference to a parent KeycloakRealmGroup custom resource.
+                  If specified, this group will be created as a child group of the referenced parent.
+                  The parent KeycloakRealmGroup must exist in the same namespace.
+                nullable: true
+                properties:
+                  name:
+                    description: Name specifies the name of the KeycloakRealmGroup
+                      custom resource.
+                    type: string
+                required:
+                - name
+                type: object
               path:
                 description: Path is a group path.
-                type: string
-              realm:
-                description: |-
-                  Deprecated: use RealmRef instead.
-                  Realm is name of KeycloakRealm custom resource.
                 type: string
               realmRef:
                 description: RealmRef is reference to Realm custom resource.
                 properties:
                   kind:
+                    default: KeycloakRealm
                     description: Kind specifies the kind of the Keycloak resource.
                     enum:
                     - KeycloakRealm
@@ -100,6 +110,8 @@ spec:
                   name:
                     description: Name specifies the name of the Keycloak resource.
                     type: string
+                required:
+                - name
                 type: object
               realmRoles:
                 description: RealmRoles is a list of realm roles assigned to group.
@@ -108,13 +120,16 @@ spec:
                 nullable: true
                 type: array
               subGroups:
-                description: SubGroups is a list of subgroups assigned to group.
+                description: |-
+                  SubGroups is a list of subgroups assigned to group.
+                  Deprecated: This filed doesn't allow to fully support child groups. Use ParentGroup approach instead.
                 items:
                   type: string
                 nullable: true
                 type: array
             required:
             - name
+            - realmRef
             type: object
           status:
             description: KeycloakRealmGroupStatus defines the observed state of KeycloakRealmGroup.

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmidentityproviders.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmidentityproviders.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: keycloakrealmidentityproviders.v1.edp.epam.com
 spec:
   group: v1.edp.epam.com
@@ -15,7 +15,7 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: Reconcilation status
+    - description: Reconciliation status
       jsonPath: .status.value
       name: Status
       type: string
@@ -49,6 +49,12 @@ spec:
               addReadTokenRoleOnCreate:
                 description: AddReadTokenRoleOnCreate is a flag to add read token
                   role on create.
+                type: boolean
+              adminFineGrainedPermissionsEnabled:
+                description: |-
+                  AdminFineGrainedPermissionsEnabled enable/disable fine-grained admin permissions for an identity provider.
+                  Feature flag admin-fine-grained-authz:v1 should be enabled in Keycloak server.
+                  Important: FGAP:V1 Keycloak feature remains in preview and may be deprecated and removed in a future releases.
                 type: boolean
               alias:
                 description: Alias is a alias of identity provider.
@@ -102,18 +108,38 @@ spec:
                   type: object
                 nullable: true
                 type: array
+              permission:
+                description: Permission is a identity provider permissions configuration
+                nullable: true
+                properties:
+                  scopePermissions:
+                    description: ScopePermissions mapping of scope and the policies
+                      attached
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        policies:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              postBrokerLoginFlowAlias:
+                description: PostBrokerLoginFlowAlias is a post broker login flow
+                  alias.
+                type: string
               providerId:
                 description: ProviderID is a provider ID of identity provider.
-                type: string
-              realm:
-                description: |-
-                  Deprecated: use RealmRef instead.
-                  Realm is name of KeycloakRealm custom resource.
                 type: string
               realmRef:
                 description: RealmRef is reference to Realm custom resource.
                 properties:
                   kind:
+                    default: KeycloakRealm
                     description: Kind specifies the kind of the Keycloak resource.
                     enum:
                     - KeycloakRealm
@@ -122,6 +148,8 @@ spec:
                   name:
                     description: Name specifies the name of the Keycloak resource.
                     type: string
+                required:
+                - name
                 type: object
               storeToken:
                 description: StoreToken is a flag to store token.
@@ -134,6 +162,7 @@ spec:
             - config
             - enabled
             - providerId
+            - realmRef
             type: object
           status:
             description: KeycloakRealmIdentityProviderStatus defines the observed

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmrolebatches.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmrolebatches.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: keycloakrealmrolebatches.v1.edp.epam.com
 spec:
   group: v1.edp.epam.com
@@ -15,7 +15,7 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: Reconcilation status
+    - description: Reconciliation status
       jsonPath: .status.value
       name: Status
       type: string
@@ -44,15 +44,11 @@ spec:
           spec:
             description: KeycloakRealmRoleBatchSpec defines the desired state of KeycloakRealmRoleBatch.
             properties:
-              realm:
-                description: |-
-                  Deprecated: use RealmRef instead.
-                  Realm is name of KeycloakRealm custom resource.
-                type: string
               realmRef:
                 description: RealmRef is reference to Realm custom resource.
                 properties:
                   kind:
+                    default: KeycloakRealm
                     description: Kind specifies the kind of the Keycloak resource.
                     enum:
                     - KeycloakRealm
@@ -61,6 +57,8 @@ spec:
                   name:
                     description: Name specifies the name of the Keycloak resource.
                     type: string
+                required:
+                - name
                 type: object
               roles:
                 description: Roles is a list of roles to be created.
@@ -104,6 +102,7 @@ spec:
                   type: object
                 type: array
             required:
+            - realmRef
             - roles
             type: object
           status:

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmroles.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmroles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: keycloakrealmroles.v1.edp.epam.com
 spec:
   group: v1.edp.epam.com
@@ -15,7 +15,7 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: Reconcilation status
+    - description: Reconciliation status
       jsonPath: .status.value
       name: Status
       type: string
@@ -98,15 +98,11 @@ spec:
               name:
                 description: Name of keycloak role.
                 type: string
-              realm:
-                description: |-
-                  Deprecated: use RealmRef instead.
-                  Realm is name of KeycloakRealm custom resource.
-                type: string
               realmRef:
                 description: RealmRef is reference to Realm custom resource.
                 properties:
                   kind:
+                    default: KeycloakRealm
                     description: Kind specifies the kind of the Keycloak resource.
                     enum:
                     - KeycloakRealm
@@ -115,9 +111,12 @@ spec:
                   name:
                     description: Name specifies the name of the Keycloak resource.
                     type: string
+                required:
+                - name
                 type: object
             required:
             - name
+            - realmRef
             type: object
           status:
             description: KeycloakRealmRoleStatus defines the observed state of KeycloakRealmRole.

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealms.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealms.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: keycloakrealms.v1.edp.epam.com
 spec:
   group: v1.edp.epam.com
@@ -19,7 +19,7 @@ spec:
       jsonPath: .status.available
       name: Available
       type: boolean
-    - description: Reconcilation status
+    - description: Reconciliation status
       jsonPath: .status.value
       name: Status
       type: string
@@ -83,16 +83,11 @@ spec:
                 description: ID is the ID of the realm.
                 nullable: true
                 type: string
-              keycloakOwner:
-                description: |-
-                  Deprecated: use KeycloakRef instead.
-                  KeycloakOwner specifies the name of the Keycloak instance that owns the realm.
-                nullable: true
-                type: string
               keycloakRef:
                 description: KeycloakRef is reference to Keycloak custom resource.
                 properties:
                   kind:
+                    default: Keycloak
                     description: Kind specifies the kind of the Keycloak resource.
                     enum:
                     - Keycloak
@@ -101,7 +96,60 @@ spec:
                   name:
                     description: Name specifies the name of the Keycloak resource.
                     type: string
+                required:
+                - name
                 type: object
+              login:
+                description: Login settings for the realm.
+                nullable: true
+                properties:
+                  duplicateEmails:
+                    default: false
+                    description: DuplicateEmails allows multiple users to have the
+                      same email address.
+                    type: boolean
+                  editUsername:
+                    default: false
+                    description: EditUsername allows to edit username.
+                    type: boolean
+                  emailAsUsername:
+                    default: false
+                    description: EmailAsUsername allows users to set email as username.
+                    type: boolean
+                  forgotPassword:
+                    default: false
+                    description: ForgotPassword shows a link on the login page for
+                      users who have forgotten their credentials.
+                    type: boolean
+                  loginWithEmail:
+                    default: true
+                    description: LoginWithEmail allows users to log in with their
+                      email address.
+                    type: boolean
+                  rememberMe:
+                    default: false
+                    description: RememberMe shows checkbox on the login page to allow
+                      the user to remain logged in between browser restarts until
+                      the session expires.
+                    type: boolean
+                  userRegistration:
+                    default: false
+                    description: UserRegistration enables/disables the registration
+                      page. A link for registration will show on the login page too.
+                    type: boolean
+                  verifyEmail:
+                    default: false
+                    description: VerifyEmail requires user to verify their email address
+                      after initial login or after address changes are submitted.
+                    type: boolean
+                type: object
+              organizationsEnabled:
+                default: false
+                description: |-
+                  OrganizationsEnabled enables Keycloak Organizations feature for this realm.
+                  When enabled, this realm can support Organization resources for multi-tenant scenarios,
+                  identity provider groupings, and domain-based user routing.
+                type: boolean
               passwordPolicy:
                 description: PasswordPolicies is a list of password policies to apply
                   to the realm.
@@ -158,6 +206,83 @@ spec:
               realmName:
                 description: RealmName specifies the name of the realm.
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              sessions:
+                description: Sessions defines the session settings for the realm.
+                properties:
+                  ssoLoginSettings:
+                    description: SSOLoginSettings defines the SSO login settings for
+                      the realm.
+                    properties:
+                      accessCodeLifespanLogin:
+                        default: 1800
+                        description: AccessCodeLifespanLogin represents the max time
+                          a user has to complete a login. This is recommended to be
+                          relatively long, such as 30 minutes or more.
+                        type: integer
+                      accessCodeLifespanUserAction:
+                        default: 300
+                        description: AccessCodeLifespanUserAction represents the max
+                          time a user has to complete login related actions like update
+                          password or configure totp. This is recommended to be relatively
+                          long, such as 5 minutes or more.
+                        type: integer
+                    type: object
+                  ssoOfflineSessionSettings:
+                    description: SSOOfflineSessionSettings defines the SSO offline
+                      session settings for the realm.
+                    properties:
+                      idleTimeout:
+                        default: 2592000
+                        description: |-
+                          IdleTimeout represents the time an offline session is allowed to be idle before it expires.
+                          You need to use offline token to refresh at least once within this period; otherwise offline session will expire.
+                        type: integer
+                      maxLifespan:
+                        default: 5184000
+                        description: MaxLifespan represents the max time before an
+                          offline session is expired regardless of activity.
+                        type: integer
+                      maxLifespanEnabled:
+                        default: false
+                        description: MaxLifespanEnabled enables the offline session
+                          maximum lifetime.
+                        type: boolean
+                    type: object
+                  ssoSessionSettings:
+                    description: SSOSessionSettings defines the SSO session settings
+                      for the realm.
+                    properties:
+                      idleTimeout:
+                        default: 1800
+                        description: |-
+                          IdleTimeout represents the time a session is allowed to be idle before it expires.
+                          Tokens and browser sessions are invalidated when a session is expired.
+                        type: integer
+                      idleTimeoutRememberMe:
+                        default: 0
+                        description: |-
+                          IdleTimeoutRememberMe represents the time a session is allowed to be idle before it expires.
+                          Tokens and browser sessions are invalidated when a session is expired.
+                          If not set it uses the standard ssoSessionIdle value.
+                        type: integer
+                      maxLifespan:
+                        default: 36000
+                        description: |-
+                          MaxLifespan represents the max time before a session is expired.
+                          Tokens and browser sessions are invalidated when a session is expired.
+                        type: integer
+                      maxLifespanRememberMe:
+                        default: 0
+                        description: |-
+                          MaxLifespanRememberMe represents the max time before a session is expired when a user has set the remember me option.
+                          Tokens and browser sessions are invalidated when a session is expired.
+                          If not set it uses the standard ssoSessionMax value.
+                        type: integer
+                    type: object
+                type: object
               smtp:
                 description: Smtp is the configuration for email in the realm.
                 nullable: true
@@ -179,10 +304,13 @@ spec:
                                     description: The key to select.
                                     type: string
                                   name:
+                                    default: ""
                                     description: |-
                                       Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                 required:
                                 - key
@@ -195,10 +323,13 @@ spec:
                                     description: The key of the secret to select from.
                                     type: string
                                   name:
+                                    default: ""
                                     description: |-
                                       Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                 required:
                                 - key
@@ -215,10 +346,13 @@ spec:
                                     description: The key to select.
                                     type: string
                                   name:
+                                    default: ""
                                     description: |-
                                       Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                 required:
                                 - key
@@ -231,10 +365,13 @@ spec:
                                     description: The key of the secret to select from.
                                     type: string
                                   name:
+                                    default: ""
                                     description: |-
                                       Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                 required:
                                 - key
@@ -550,6 +687,7 @@ spec:
                 nullable: true
                 type: array
             required:
+            - keycloakRef
             - realmName
             type: object
           status:

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmusers.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloakrealmusers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: keycloakrealmusers.v1.edp.epam.com
 spec:
   group: v1.edp.epam.com
@@ -15,7 +15,7 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: Reconcilation status
+    - description: Reconciliation status
       jsonPath: .status.value
       name: Status
       type: string
@@ -47,9 +47,40 @@ spec:
               attributes:
                 additionalProperties:
                   type: string
-                description: Attributes is a map of user attributes.
+                description: |-
+                  Attributes is a map of user attributes.
+                  Deprecated: Use AttributesV2 instead.
                 nullable: true
                 type: object
+              attributesV2:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: |-
+                  AttributesV2 is a map of service account attributes.
+                  Each attribute can have multiple values.
+                nullable: true
+                type: object
+              clientRoles:
+                description: ClientRoles is a list of client roles assigned to user.
+                items:
+                  properties:
+                    clientId:
+                      description: ClientID is a client ID.
+                      type: string
+                    roles:
+                      description: Roles is a list of client roles names assigned
+                        to user.
+                      items:
+                        type: string
+                      nullable: true
+                      type: array
+                  required:
+                  - clientId
+                  type: object
+                nullable: true
+                type: array
               email:
                 description: Email is a user email.
                 type: string
@@ -68,6 +99,13 @@ spec:
                   type: string
                 nullable: true
                 type: array
+              identityProviders:
+                description: IdentityProviders is a list of identity providers aliases
+                  linked to the user.
+                items:
+                  type: string
+                nullable: true
+                type: array
               keepResource:
                 default: true
                 description: |-
@@ -79,9 +117,9 @@ spec:
                 description: LastName is a user last name.
                 type: string
               password:
-                description: Password is a user password. Allows to keep user password
-                  within Custom Resource. For security concerns, it is recommended
-                  to use PasswordSecret instead.
+                description: |-
+                  Password is a user password. Allows to keep user password within Custom Resource. For security concerns, it is recommended to use PasswordSecret instead.
+                  Deperecated: use PasswordSecret instead.
                 type: string
               passwordSecret:
                 description: PasswordSecret defines Kubernetes secret Name and Key,
@@ -94,19 +132,19 @@ spec:
                   name:
                     description: Name is the name of the secret.
                     type: string
+                  temporary:
+                    default: false
+                    description: Temporary indicates whether the password is temporary.
+                    type: boolean
                 required:
                 - key
                 - name
                 type: object
-              realm:
-                description: |-
-                  Deprecated: use RealmRef instead.
-                  Realm is name of KeycloakRealm custom resource.
-                type: string
               realmRef:
                 description: RealmRef is reference to Realm custom resource.
                 properties:
                   kind:
+                    default: KeycloakRealm
                     description: Kind specifies the kind of the Keycloak resource.
                     enum:
                     - KeycloakRealm
@@ -115,11 +153,13 @@ spec:
                   name:
                     description: Name specifies the name of the Keycloak resource.
                     type: string
+                required:
+                - name
                 type: object
               reconciliationStrategy:
                 description: |-
-                  ReconciliationStrategy is a strategy for reconciliation. Possible values: full, create-only.
-                  Default value: full. If set to create-only, user will be created only if it does not exist. If user exists, it will not be updated.
+                  ReconciliationStrategy is a strategy for reconciliation. Possible values: full, addOnly.
+                  Default value: full. If set to addOnly, user will be created only if it does not exist. If user exists, it will not be updated.
                   If set to full, user will be created if it does not exist, or updated if it exists.
                 type: string
               requiredUserActions:
@@ -139,14 +179,79 @@ spec:
                 description: Username is a username in keycloak.
                 type: string
             required:
+            - realmRef
             - username
             type: object
           status:
             description: KeycloakRealmUserStatus defines the observed state of KeycloakRealmUser.
             properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of an object's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                nullable: true
+                type: array
               failureCount:
                 format: int64
                 type: integer
+              lastSyncedPasswordSecretVersion:
+                description: |-
+                  LastSyncedPasswordSecretVersion stores the ResourceVersion of the password secret
+                  that was last successfully synced to Keycloak. Used to detect secret changes.
+                type: string
               value:
                 type: string
             type: object

--- a/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloaks.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/crds/v1.edp.epam.com_keycloaks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: keycloaks.v1.edp.epam.com
 spec:
   group: v1.edp.epam.com
@@ -64,10 +64,13 @@ spec:
                         description: The key to select.
                         type: string
                       name:
+                        default: ""
                         description: |-
                           Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                     required:
                     - key
@@ -80,10 +83,13 @@ spec:
                         description: The key of the secret to select from.
                         type: string
                       name:
+                        default: ""
                         description: |-
                           Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                     required:
                     - key

--- a/packages/system/keycloak-operator/charts/keycloak-operator/templates/clusterrole.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/templates/clusterrole.yaml
@@ -159,6 +159,32 @@ rules:
   - apiGroups:
       - v1.edp.epam.com
     resources:
+      - keycloakorganizations
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakorganizations/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
+      - keycloakorganizations/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - v1.edp.epam.com
+    resources:
       - keycloakrealmcomponents
     verbs:
       - create

--- a/packages/system/keycloak-operator/charts/keycloak-operator/templates/deployment.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/templates/deployment.yaml
@@ -16,11 +16,20 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "keycloak-operator.selectorLabels" . | nindent 8 }}
         name: {{ .Values.name }}
+        control-plane: controller-manager
+        {{- if hasKey .Values.podLabels "name" }}
+        {{ fail "The 'name' key is not allowed in podLabels" }}
+        {{- end }}
+        {{- range $key, $value := .Values.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       serviceAccountName: edp-{{ .Values.name }}
-      securityContext:
-        runAsNonRoot: true
+      {{- if .Values.securityContext }}
+      securityContext: {{ toYaml .Values.securityContext | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -28,12 +37,20 @@ spec:
       containers:
         - name: {{ .Values.name }}
           # Replace this with the built image name
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+          image: {{ if .Values.image.registry }}{{ .Values.image.registry }}/{{ end }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
           command:
             - /manager
-          securityContext:
-            allowPrivilegeEscalation: false
+          args:
+            - --metrics-bind-address=:8443
+            - --leader-elect
+            - --health-probe-bind-address=:8081
+            {{- if .Values.enableWebhooks }}
+            - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+            {{- end }}
+          {{- if .Values.containerSecurityContext }}
+          securityContext: {{ toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- end }}
           env:
             - name: WATCH_NAMESPACE
               {{- if .Values.clusterReconciliationEnabled }}
@@ -51,11 +68,26 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-        {{- if .Values.extraVolumeMounts }}
+            - name: ENABLE_OWNER_REF
+              value: {{ .Values.enableOwnerRef | quote }}
+            - name: ENABLE_WEBHOOKS
+              value: {{ .Values.enableWebhooks | quote }}
+        {{- if or .Values.extraVolumeMounts .Values.enableWebhooks }}
           volumeMounts:
+          {{- if .Values.enableWebhooks }}
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: webhook-certs
+              readOnly: true
+          {{- end }}
           {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
+        {{- end }}
+        {{- if .Values.enableWebhooks }}
+          ports:
+          - containerPort: 9443
+            name: webhook-server
+            protocol: TCP
         {{- end }}
           livenessProbe:
             httpGet:
@@ -71,8 +103,13 @@ spec:
             periodSeconds: 10
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-    {{- if .Values.extraVolumes }}
+    {{- if or .Values.extraVolumes .Values.enableWebhooks }}
       volumes:
+      {{- if .Values.enableWebhooks }}
+        - name: webhook-certs
+          secret:
+            secretName: webhook-server-cert
+      {{- end }}
       {{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/templates/operator_role.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/templates/operator_role.yaml
@@ -5,309 +5,82 @@ metadata:
   labels:
       {{- include "keycloak-operator.labels" . | nindent 4 }}
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakauthflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakauthflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakauthflows/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakclients
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakclients/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakclients/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakclientscopes
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakclientscopes/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakclientscopes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealmcomponents
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealmcomponents/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealmcomponents/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealmgroups
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealmgroups/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealmgroups/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealmidentityproviders
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealmidentityproviders/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealmidentityproviders/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealmrolebatches
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealmrolebatches/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealmrolebatches/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealmroles
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealmroles/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealmroles/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealms
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealms/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealms/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealmusers
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealmusers/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloakrealmusers/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloaks
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloaks/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - v1.edp.epam.com
-    resources:
-      - keycloaks/status
-    verbs:
-      - get
-      - patch
-      - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - v1
+  resources:
+  - configmap
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - v1.edp.epam.com
+  resources:
+  - keycloakauthflows
+  - keycloakclients
+  - keycloakclientscopes
+  - keycloakorganizations
+  - keycloakrealmcomponents
+  - keycloakrealmgroups
+  - keycloakrealmidentityproviders
+  - keycloakrealmrolebatches
+  - keycloakrealmroles
+  - keycloakrealms
+  - keycloakrealmusers
+  - keycloaks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - v1.edp.epam.com
+  resources:
+  - keycloakauthflows/finalizers
+  - keycloakclients/finalizers
+  - keycloakclientscopes/finalizers
+  - keycloakorganizations/finalizers
+  - keycloakrealmcomponents/finalizers
+  - keycloakrealmgroups/finalizers
+  - keycloakrealmidentityproviders/finalizers
+  - keycloakrealmrolebatches/finalizers
+  - keycloakrealmroles/finalizers
+  - keycloakrealms/finalizers
+  - keycloakrealmusers/finalizers
+  - keycloaks/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - v1.edp.epam.com
+  resources:
+  - keycloakauthflows/status
+  - keycloakclients/status
+  - keycloakclientscopes/status
+  - keycloakorganizations/status
+  - keycloakrealmcomponents/status
+  - keycloakrealmgroups/status
+  - keycloakrealmidentityproviders/status
+  - keycloakrealmrolebatches/status
+  - keycloakrealmroles/status
+  - keycloakrealms/status
+  - keycloakrealmusers/status
+  - keycloaks/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/packages/system/keycloak-operator/charts/keycloak-operator/templates/webhook/certmanager.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/templates/webhook/certmanager.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.enableWebhooks }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+      {{- include "keycloak-operator.labels" . | nindent 4 }}
+  name: {{ .Values.name }}-serving-cert
+spec:
+  dnsNames:
+  - {{ .Values.name }}-webhook-service.{{ .Release.Namespace }}.svc
+  - {{ .Values.name }}-webhook-service.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+  issuerRef:
+    kind: Issuer
+    name: {{ .Values.name }}-selfsigned-issuer
+  secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    {{- include "keycloak-operator.labels" . | nindent 4 }}
+  name: {{ .Values.name }}-selfsigned-issuer
+spec:
+  selfSigned: {}
+{{- end }}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/templates/webhook/manifest.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/templates/webhook/manifest.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.enableWebhooks }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ .Values.name }}-mutating-webhook-configuration-{{ .Release.Namespace }}
+  labels:
+      {{- include "keycloak-operator.labels" . | nindent 4 }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Values.name }}-serving-cert
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ .Values.name }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-v1-edp-epam-com-v1-keycloakclient
+  failurePolicy: Fail
+  name: mkeycloakclient-v1.kb.io
+  {{- /* Namespace-scoped webhook to prevent cross-namespace conflicts. */ -}}
+  {{- if not .Values.clusterReconciliationEnabled }}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - {{ .Release.Namespace }}
+  {{- end }}
+  rules:
+  - apiGroups:
+    - v1.edp.epam.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - keycloakclients
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+      {{- include "keycloak-operator.labels" . | nindent 4 }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Values.name }}-serving-cert
+  name: {{ .Values.name }}-validating-webhook-configuration-{{ .Release.Namespace }}
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ .Values.name }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-v1-edp-epam-com-v1-keycloakrealm
+  failurePolicy: Fail
+  name: vkeycloakrealm-v1.kb.io
+  {{- /* Namespace-scoped webhook validation to prevent cross-namespace conflicts. */ -}}
+  {{- if not .Values.clusterReconciliationEnabled }}
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - {{ .Release.Namespace }}
+  {{- end }}
+  rules:
+  - apiGroups:
+    - v1.edp.epam.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - keycloakrealms
+  sideEffects: None
+{{- end }}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/templates/webhook/rbac.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/templates/webhook/rbac.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.enableWebhooks }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "keycloak-operator.labels" . | nindent 4 }}
+  name: edp-{{ .Release.Namespace }}-webhook-clusterrole
+rules:
+- apiGroups:
+  - v1.edp.epam.com
+  resources:
+  - keycloakrealms
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "keycloak-operator.labels" . | nindent 4 }}
+  name: edp-{{ .Release.Namespace }}-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edp-{{ .Release.Namespace }}-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: edp-{{ .Values.name }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/templates/webhook/service.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/templates/webhook/service.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.enableWebhooks }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+      {{- include "keycloak-operator.labels" . | nindent 4 }}
+  name: {{ .Values.name }}-webhook-service
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    {{- include "keycloak-operator.selectorLabels" . | nindent 4 }}
+    control-plane: controller-manager
+{{- end }}

--- a/packages/system/keycloak-operator/charts/keycloak-operator/values.yaml
+++ b/packages/system/keycloak-operator/charts/keycloak-operator/values.yaml
@@ -2,6 +2,10 @@
 name: keycloak-operator
 # -- Annotations to be added to the Deployment
 annotations: {}
+# -- Cluster domain for constructing service DNS names
+clusterDomain: cluster.local
+# -- Labels to be added to the pod
+podLabels: {}
 # -- Node labels for pod assignment
 nodeSelector: {}
 # -- Node tolerations for server scheduling to nodes with taints
@@ -9,6 +13,8 @@ tolerations: []
 # -- Affinity for pod assignment
 affinity: {}
 image:
+  # -- KubeRocketCI keycloak-operator Docker image registry.
+  registry: ""
   # -- KubeRocketCI keycloak-operator Docker image name. The released image can be found on [Dockerhub](https://hub.docker.com/r/epamedp/keycloak-operator)
   repository: epamedp/keycloak-operator
   # if not defined then .Chart.AppVersion is used
@@ -27,6 +33,16 @@ resources:
     cpu: 50m
     memory: 64Mi
 
+# -- Deployment Security Context
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext:
+  runAsNonRoot: true
+
+# -- Container Security Context
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+
 # -- Additional volumes to be added to the pod
 extraVolumes: []
 #  - name: custom-ca
@@ -44,3 +60,11 @@ extraVolumeMounts: []
 # -- If clusterReconciliationEnabled is true, the operator reconciles all Keycloak instances in the cluster;
 #  otherwise, it only reconciles instances in the same namespace by default, and cluster-scoped resources are ignored.
 clusterReconciliationEnabled: false
+
+# -- If set to true, the operator will set the owner reference for all resources that have Keycloak or KeycloakRealm as reference.
+# This is legacy behavior and not recommended for use. In the future, this will be set to false by default.
+enableOwnerRef: true
+
+# -- If set to true, enables webhook resources (ValidatingWebhookConfiguration, Service, and Certificate).
+# Webhooks require cert-manager to be installed in the cluster.
+enableWebhooks: true

--- a/packages/system/keycloak-operator/images/keycloak-operator/Dockerfile
+++ b/packages/system/keycloak-operator/images/keycloak-operator/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1.2
+
+FROM alpine AS source
+ARG COMMIT_REF=facbc36
+RUN apk add --no-cache curl tar git
+WORKDIR /src
+
+RUN curl -sSL https://github.com/epam/edp-keycloak-operator/archive/${COMMIT_REF}.tar.gz \
+        | tar -xz --strip-components=1
+
+COPY patches /patches
+RUN git apply /patches/*.diff
+
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.24 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /go/src/keycloak-operator
+
+COPY --from=source /src/go.mod /src/go.sum ./
+RUN go mod download
+
+COPY --from=source /src .
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/manager ./cmd
+
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder /build/manager /manager
+USER 65532:65532
+ENTRYPOINT ["/manager"]

--- a/packages/system/keycloak-operator/images/keycloak-operator/patches/pr309.diff
+++ b/packages/system/keycloak-operator/images/keycloak-operator/patches/pr309.diff
@@ -1,0 +1,187 @@
+diff --git a/internal/controller/keycloakrealmgroup/chain/chain.go b/internal/controller/keycloakrealmgroup/chain/chain.go
+index 1ca497a0..dbc3844b 100644
+--- a/internal/controller/keycloakrealmgroup/chain/chain.go
++++ b/internal/controller/keycloakrealmgroup/chain/chain.go
+@@ -15,6 +15,10 @@ type GroupContext struct {
+ 	// GroupID is the Keycloak group ID, set by CreateOrUpdateGroup handler.
+ 	GroupID string
+ 
++	// ExistingGroupID is the Keycloak group ID from a previous reconciliation (status.ID).
++	// Used to detect renames: if set, the group is fetched by ID first.
++	ExistingGroupID string
++
+ 	// ParentGroupID is the parent group's Keycloak ID (empty if top-level).
+ 	ParentGroupID string
+ 
+diff --git a/internal/controller/keycloakrealmgroup/chain/create_or_update_group.go b/internal/controller/keycloakrealmgroup/chain/create_or_update_group.go
+index 0504d9dd..931fab27 100644
+--- a/internal/controller/keycloakrealmgroup/chain/create_or_update_group.go
++++ b/internal/controller/keycloakrealmgroup/chain/create_or_update_group.go
+@@ -33,17 +33,34 @@ func (h *CreateOrUpdateGroup) Serve(
+ 		err           error
+ 	)
+ 
+-	if groupCtx.ParentGroupID != "" {
+-		existingGroup, _, err = kClient.Groups.FindChildGroupByName(ctx, realm, groupCtx.ParentGroupID, spec.Name)
+-	} else {
+-		existingGroup, _, err = kClient.Groups.FindGroupByName(ctx, realm, spec.Name)
++	// If we already have an ID from a previous reconciliation, fetch by ID first.
++	// This handles renames: spec.Name may have changed but the ID stays the same.
++	if groupCtx.ExistingGroupID != "" {
++		existingGroup, _, err = kClient.Groups.GetGroup(ctx, realm, groupCtx.ExistingGroupID)
++		if err != nil && !keycloakv2.IsNotFound(err) {
++			return fmt.Errorf("unable to get group by ID %q: %w", groupCtx.ExistingGroupID, err)
++		}
++
++		if keycloakv2.IsNotFound(err) {
++			log.Info("Group not found by ID, will search by name", "groupID", groupCtx.ExistingGroupID)
++			existingGroup = nil
++		}
+ 	}
+ 
+-	if err != nil && !keycloakv2.IsNotFound(err) {
+-		return fmt.Errorf("unable to search for group %q: %w", spec.Name, err)
++	// If we didn't find the group by ID, search by name.
++	if existingGroup == nil {
++		if groupCtx.ParentGroupID != "" {
++			existingGroup, _, err = kClient.Groups.FindChildGroupByName(ctx, realm, groupCtx.ParentGroupID, spec.Name)
++		} else {
++			existingGroup, _, err = kClient.Groups.FindGroupByName(ctx, realm, spec.Name)
++		}
++
++		if err != nil && !keycloakv2.IsNotFound(err) {
++			return fmt.Errorf("unable to search for group %q: %w", spec.Name, err)
++		}
+ 	}
+ 
+-	if keycloakv2.IsNotFound(err) {
++	if existingGroup == nil {
+ 		groupRep := keycloakv2.GroupRepresentation{
+ 			Name:        &spec.Name,
+ 			Description: &spec.Description,
+@@ -67,6 +84,7 @@ func (h *CreateOrUpdateGroup) Serve(
+ 		log.Info("Group created", "groupID", groupCtx.GroupID)
+ 	} else {
+ 		groupCtx.GroupID = *existingGroup.Id
++		existingGroup.Name = &spec.Name
+ 		existingGroup.Description = &spec.Description
+ 		existingGroup.Path = &spec.Path
+ 		existingGroup.Attributes = &spec.Attributes
+diff --git a/internal/controller/keycloakrealmgroup/chain/create_or_update_group_test.go b/internal/controller/keycloakrealmgroup/chain/create_or_update_group_test.go
+index 26841a71..000c7538 100644
+--- a/internal/controller/keycloakrealmgroup/chain/create_or_update_group_test.go
++++ b/internal/controller/keycloakrealmgroup/chain/create_or_update_group_test.go
+@@ -265,3 +265,97 @@ func TestCreateOrUpdateGroup_Serve_FindChildGroupError(t *testing.T) {
+ 	err := h.Serve(context.Background(), group, kClient, groupCtx)
+ 	assert.ErrorContains(t, err, "unable to search for group")
+ }
++
++func TestCreateOrUpdateGroup_Serve_RenameByID(t *testing.T) {
++	mockGroups := mocks.NewMockGroupsClient(t)
++
++	kClient := &keycloakv2.KeycloakClient{Groups: mockGroups}
++	groupCtx := &GroupContext{RealmName: "test-realm", ExistingGroupID: "existing-id"}
++
++	group := &keycloakApi.KeycloakRealmGroup{}
++	group.Spec.Name = "new-name"
++	group.Spec.Description = "Updated desc"
++	group.Spec.Path = "/new-name"
++	group.Spec.Attributes = map[string][]string{"key": {"val"}}
++
++	mockGroups.EXPECT().GetGroup(
++		context.Background(), "test-realm", "existing-id",
++	).Return(&keycloakv2.GroupRepresentation{
++		Id:   ptr.To("existing-id"),
++		Name: ptr.To("old-name"),
++		Path: ptr.To("/old-name"),
++	}, nil, nil)
++
++	mockGroups.EXPECT().UpdateGroup(
++		context.Background(), "test-realm", "existing-id",
++		keycloakv2.GroupRepresentation{
++			Id:          ptr.To("existing-id"),
++			Name:        ptr.To("new-name"),
++			Description: ptr.To("Updated desc"),
++			Path:        ptr.To("/new-name"),
++			Attributes:  &map[string][]string{"key": {"val"}},
++		},
++	).Return(nil, nil)
++
++	h := NewCreateOrUpdateGroup()
++	err := h.Serve(context.Background(), group, kClient, groupCtx)
++	require.NoError(t, err)
++	assert.Equal(t, "existing-id", groupCtx.GroupID)
++}
++
++func TestCreateOrUpdateGroup_Serve_ExistingIDNotFound_FallsBackToName(t *testing.T) {
++	mockGroups := mocks.NewMockGroupsClient(t)
++
++	kClient := &keycloakv2.KeycloakClient{Groups: mockGroups}
++	groupCtx := &GroupContext{RealmName: "test-realm", ExistingGroupID: "deleted-id"}
++
++	group := &keycloakApi.KeycloakRealmGroup{}
++	group.Spec.Name = testGroupName
++	group.Spec.Path = "/test-group"
++	group.Spec.Attributes = map[string][]string{"key": {"val"}}
++
++	mockGroups.EXPECT().GetGroup(
++		context.Background(), "test-realm", "deleted-id",
++	).Return(nil, nil, keycloakv2.ErrNotFound)
++
++	mockGroups.EXPECT().FindGroupByName(
++		context.Background(), "test-realm", testGroupName,
++	).Return(nil, nil, keycloakv2.ErrNotFound)
++
++	mockGroups.EXPECT().CreateGroup(
++		context.Background(), "test-realm",
++		keycloakv2.GroupRepresentation{
++			Name:        ptr.To(testGroupName),
++			Description: ptr.To(""),
++			Path:        ptr.To("/test-group"),
++			Attributes:  &map[string][]string{"key": {"val"}},
++		},
++	).Return(&keycloakv2.Response{
++		HTTPResponse: &http.Response{
++			Header: http.Header{"Location": []string{"http://localhost/admin/realms/test-realm/groups/new-id"}},
++		},
++	}, nil)
++
++	h := NewCreateOrUpdateGroup()
++	err := h.Serve(context.Background(), group, kClient, groupCtx)
++	require.NoError(t, err)
++	assert.Equal(t, "new-id", groupCtx.GroupID)
++}
++
++func TestCreateOrUpdateGroup_Serve_GetGroupByIDError(t *testing.T) {
++	mockGroups := mocks.NewMockGroupsClient(t)
++
++	kClient := &keycloakv2.KeycloakClient{Groups: mockGroups}
++	groupCtx := &GroupContext{RealmName: "test-realm", ExistingGroupID: "existing-id"}
++
++	group := &keycloakApi.KeycloakRealmGroup{}
++	group.Spec.Name = testGroupName
++
++	mockGroups.EXPECT().GetGroup(
++		context.Background(), "test-realm", "existing-id",
++	).Return(nil, nil, errors.New("connection error"))
++
++	h := NewCreateOrUpdateGroup()
++	err := h.Serve(context.Background(), group, kClient, groupCtx)
++	assert.ErrorContains(t, err, "unable to get group by ID")
++}
+diff --git a/internal/controller/keycloakrealmgroup/keycloakrealmgroup_controller.go b/internal/controller/keycloakrealmgroup/keycloakrealmgroup_controller.go
+index 0f7e6ce3..52015e24 100644
+--- a/internal/controller/keycloakrealmgroup/keycloakrealmgroup_controller.go
++++ b/internal/controller/keycloakrealmgroup/keycloakrealmgroup_controller.go
+@@ -166,8 +166,9 @@ func (r *ReconcileKeycloakRealmGroup) tryReconcile(ctx context.Context, keycloak
+ 	}
+ 
+ 	groupCtx := &chain.GroupContext{
+-		RealmName:     realmName,
+-		ParentGroupID: parentGroupID,
++		RealmName:       realmName,
++		ParentGroupID:   parentGroupID,
++		ExistingGroupID: keycloakRealmGroup.Status.ID,
+ 	}
+ 
+ 	if err := chain.MakeChain().Serve(ctx, keycloakRealmGroup, kClientV2, groupCtx); err != nil {

--- a/packages/system/keycloak-operator/values.yaml
+++ b/packages/system/keycloak-operator/values.yaml
@@ -1,4 +1,8 @@
 keycloak-operator:
+  image:
+    registry: ghcr.io
+    repository: cozystack/cozystack/keycloak-operator
+    tag: "latest@sha256:27279247dfbd2d1e86fc4e827d34c891880ca65eefd75da1701bc0a1adf865a9"
   clusterReconciliationEnabled: true
   resources:
     limits:

--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -1,4 +1,4 @@
-image: quay.io/keycloak/keycloak:26.0.4
+image: quay.io/keycloak/keycloak:26.5.2
 
 ingress:
   # Custom hostname for the Keycloak Ingress.


### PR DESCRIPTION
## What this PR does

Updates the Keycloak Operator Helm chart to v1.32.0 and builds a custom
operator image from upstream master (https://github.com/epam/edp-keycloak-operator/commit/facbc36)
with the group rename detection patch from PR
https://github.com/epam/edp-keycloak-operator/pull/309 applied on top.

Bumps Keycloak server from 26.0.4 to 26.5.2, which is required by the
new operator client (sends `description` field rejected by older versions).

Adds SSO session settings (idleTimeout: 86400, maxLifespan: 604800) to
the ClusterKeycloakRealm to match the dashboard client's session attributes,
as Keycloak 26 enforces realm-level session limits strictly.

Removes `authorizationServicesEnabled` from the dashboard KeycloakClient,
which is incompatible with Keycloak 26's stricter validation.

### Release note

```release-note
[keycloak-operator] Update the operator to v1.32.0 with group rename fix
(https://github.com/epam/edp-keycloak-operator/pull/309). Bump Keycloak to 26.5.2.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional webhook support with cert-manager integration and webhook service; feature toggles for webhooks and owner refs
  * New realm login and session settings, organizations resource/CRD, and expanded client/user schemas (including ClientRolesV2)

* **Documentation**
  * Chart bumped to 1.32.0; README documents new values (clusterDomain, podLabels, image.registry, securityContext, containerSecurityContext)

* **Security / RBAC**
  * RBAC updated to cover organization resources and webhook bindings; consolidated operator permissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->