### PR TITLE
[kubernetes] Fixed k8s<1.32 creation

### DIFF
--- a/packages/apps/kubernetes/Makefile
+++ b/packages/apps/kubernetes/Makefile
@@ -1,4 +1,4 @@
-KUBERNETES_VERSION = v1.35
+KUBERNETES_VERSIONS = $(shell awk -F'"' '{print $$2}' files/versions.yaml)
 KUBERNETES_PKG_TAG = $(shell awk '$$1 == "version:" {print $$2}' Chart.yaml)
 
 include ../../../hack/common-envs.mk
@@ -15,17 +15,19 @@ update:
 image: image-ubuntu-container-disk image-kubevirt-cloud-provider image-kubevirt-csi-driver image-cluster-autoscaler
 
 image-ubuntu-container-disk:
-	docker buildx build images/ubuntu-container-disk \
-		--build-arg KUBERNETES_VERSION=${KUBERNETES_VERSION} \
-		--tag $(REGISTRY)/ubuntu-container-disk:$(call settag,$(KUBERNETES_VERSION)) \
-		--tag $(REGISTRY)/ubuntu-container-disk:$(call settag,$(KUBERNETES_VERSION)-$(TAG)) \
-		--cache-from type=registry,ref=$(REGISTRY)/ubuntu-container-disk:latest \
-		--cache-to type=inline \
-		--metadata-file images/ubuntu-container-disk.json \
-		$(BUILDX_ARGS)
-	echo "$(REGISTRY)/ubuntu-container-disk:$(call settag,$(KUBERNETES_VERSION))@$$(yq e '."containerimage.digest"' images/ubuntu-container-disk.json -o json -r)" \
-		> images/ubuntu-container-disk.tag
-	rm -f images/ubuntu-container-disk.json
+	$(foreach ver,$(KUBERNETES_VERSIONS), \
+		docker buildx build images/ubuntu-container-disk \
+			--build-arg KUBERNETES_VERSION=$(ver) \
+			--tag $(REGISTRY)/ubuntu-container-disk:$(call settag,$(ver)) \
+			--tag $(REGISTRY)/ubuntu-container-disk:$(call settag,$(ver)-$(TAG)) \
+			--cache-from type=registry,ref=$(REGISTRY)/ubuntu-container-disk:$(call settag,$(ver)) \
+			--cache-to type=inline \
+			--metadata-file images/ubuntu-container-disk-$(ver).json \
+			$(BUILDX_ARGS) && \
+		echo "$(REGISTRY)/ubuntu-container-disk:$(call settag,$(ver))@$$(yq e '."containerimage.digest"' images/ubuntu-container-disk-$(ver).json -o json -r)" \
+			> images/ubuntu-container-disk-$(ver).tag && \
+		rm -f images/ubuntu-container-disk-$(ver).json; \
+	)
 
 image-kubevirt-cloud-provider:
 	docker buildx build images/kubevirt-cloud-provider \

--- a/packages/apps/kubernetes/images/ubuntu-container-disk-v1.30.tag
+++ b/packages/apps/kubernetes/images/ubuntu-container-disk-v1.30.tag
@@ -1,0 +1,1 @@
+ttl.sh/rjfkdsjflsk/ubuntu-container-disk:v1.30@sha256:8c2276f68beb67edf5bf76d6c97b271dd9303b336e1d5850ae2b91a590c9bb57

--- a/packages/apps/kubernetes/images/ubuntu-container-disk-v1.31.tag
+++ b/packages/apps/kubernetes/images/ubuntu-container-disk-v1.31.tag
@@ -1,0 +1,1 @@
+ttl.sh/rjfkdsjflsk/ubuntu-container-disk:v1.31@sha256:2b631cd227bc9b1bae16de033830e756cd6590b512dc0d2b13367ee626f3e4ca

--- a/packages/apps/kubernetes/images/ubuntu-container-disk-v1.32.tag
+++ b/packages/apps/kubernetes/images/ubuntu-container-disk-v1.32.tag
@@ -1,0 +1,1 @@
+ttl.sh/rjfkdsjflsk/ubuntu-container-disk:v1.32@sha256:600d6ce7df4eaa8cc79c7d6d1b01ecac43e7696beb84eafce752d9210a16455f

--- a/packages/apps/kubernetes/images/ubuntu-container-disk-v1.33.tag
+++ b/packages/apps/kubernetes/images/ubuntu-container-disk-v1.33.tag
@@ -1,0 +1,1 @@
+ttl.sh/rjfkdsjflsk/ubuntu-container-disk:v1.33@sha256:243e55d6f2887a4f6ce8526de52fd083b7b88194d5c7f3eaa51b87efb557ac88

--- a/packages/apps/kubernetes/images/ubuntu-container-disk-v1.34.tag
+++ b/packages/apps/kubernetes/images/ubuntu-container-disk-v1.34.tag
@@ -1,0 +1,1 @@
+ttl.sh/rjfkdsjflsk/ubuntu-container-disk:v1.34@sha256:ad8377d5644ba51729dc69dff4c9f6b4a48957075d054a58c61a45d0bb41f6af

--- a/packages/apps/kubernetes/images/ubuntu-container-disk-v1.35.tag
+++ b/packages/apps/kubernetes/images/ubuntu-container-disk-v1.35.tag
@@ -1,0 +1,1 @@
+ttl.sh/rjfkdsjflsk/ubuntu-container-disk:v1.35@sha256:1c2f2430383a9b9882358c60c194465c1b6092b4aa77536a0343cf74155c0067

--- a/packages/apps/kubernetes/images/ubuntu-container-disk.tag
+++ b/packages/apps/kubernetes/images/ubuntu-container-disk.tag
@@ -1,1 +1,0 @@
-ghcr.io/cozystack/cozystack/ubuntu-container-disk:v1.35@sha256:39f626c802dd84f95720ffb54fcd80dfb8a58ac280498870d0a1aa30d4252f94

--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -74,7 +74,7 @@ spec:
           volumes:
           - name: system
             containerDisk:
-              image: "{{ $.Files.Get "images/ubuntu-container-disk.tag" | trim }}"
+              image: "{{ $.Files.Get (printf "images/ubuntu-container-disk-%s.tag" $.Values.version) | trim }}"
           - name: ephemeral
             emptyDisk:
               capacity: {{ .group.ephemeralStorage | default "20Gi" }}
@@ -249,6 +249,9 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs: {}
+          # Ignore this for 1.31
+          ignorePreflightErrors:
+          - FileExisting-conntrack
         discovery:
           bootstrapToken:
             apiServerEndpoint: {{ $.Release.Name }}.{{ $.Release.Namespace }}.svc:6443


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

This PR adds version specific ubuntu base images to fix errors when base image has new deb packages of kubeadm and kubelet installed, but at runtime it was downgraded by replacing just binaries. Now update by replacing binaries works as intended - latest patch version of minor version used.

Core issue was in kubeadm<1.32 expecting conntrack binary in its preflight checks but it was not found. It happened because kubelet deb package dropped conntrack dependency since 1.32 (actually it absent in 1.31.14 too).
So now status of supported tenant k8s versions is:
- 1.30 - works because kubelet package provided conntrack, also conntrack preflight check ignored (see 1.31).
- 1.31 - works because conntrack preflight check ignored (for some reason kubelet 1.31.14 did't provide conntrack dependency, unlike 1.31.13 did).
- \>=1.32 - works because conntrack preflight check removed from `kubeadm init` entirely.

Conntrack preflight check ignoring is legit for tenant kubernetes clusters because until 1.32 it was used in kube-proxy but cozystack k8s approach doesn't use kube-proxy (replaced with cilium).

Issue with conntrack may be mitigated with only `ignorePreflightErrors`, but I think proper base image build will help to avoid similar bugs in future.

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[kubernetes] Fixed tenant k8s older than 1.32 creation by adding version specific ubuntu base images
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-version Kubernetes support with version-specific container images.
  * Enhanced compatibility with newer Kubernetes releases, including version 1.31.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->