### PR TITLE
[monitoring] Add slack dashboard url and vmagent env label and dynamictext-panel to Grafna

### DIFF
--- a/packages/system/monitoring/images/grafana/Dockerfile
+++ b/packages/system/monitoring/images/grafana/Dockerfile
@@ -13,3 +13,4 @@ RUN curl -L https://github.com/VictoriaMetrics/victorialogs-datasource/releases/
 
 RUN grafana-cli --pluginsDir /var/lib/grafana-plugins plugins install natel-discrete-panel
 RUN grafana-cli --pluginsDir /var/lib/grafana-plugins plugins install grafana-worldmap-panel
+RUN grafana-cli --pluginsDir /var/lib/grafana-plugins plugins install marcusolsson-dynamictext-panel

--- a/packages/system/monitoring/templates/alerta/alerta.yaml
+++ b/packages/system/monitoring/templates/alerta/alerta.yaml
@@ -140,6 +140,14 @@ spec:
             - name: SLACK_SEVERITY_FILTER
               value: {{ .Values.alerta.alerts.slack.disabledSeverity | toJson | quote }}
             {{- end }}
+            {{- if .Values.alerta.alerts.slack.dashboardUrl }}
+            - name: DASHBOARD_URL
+              value: {{ .Values.alerta.alerts.slack.dashboardUrl | quote }}
+            {{- end }}
+            {{- if .Values.alerta.alerts.slack.summaryFmt }}
+            - name: SLACK_SUMMARY_FMT
+              value: {{ .Values.alerta.alerts.slack.summaryFmt | quote }}
+            {{- end }}
             {{- end }}
 
           ports:

--- a/packages/system/monitoring/templates/vm/vmagent.yaml
+++ b/packages/system/monitoring/templates/vm/vmagent.yaml
@@ -11,6 +11,9 @@ spec:
   externalLabels:
     cluster: {{ .Values.vmagent.externalLabels.cluster }}
     tenant: {{ .Release.Namespace }}
+    {{- if .Values.vmagent.externalLabels.environment }}
+    environment: {{ .Values.vmagent.externalLabels.environment | quote }}
+    {{- end }}
   extraArgs:
     promscrape.maxScrapeSize: "32MB"
     promscrape.streamParse: "true"

--- a/packages/system/monitoring/values.yaml
+++ b/packages/system/monitoring/values.yaml
@@ -63,6 +63,8 @@ alerta:
     slack:
       url: ""
       disabledSeverity: []
+      dashboardUrl: ""
+      summaryFmt: ""
 grafana:
   db:
     size: 10Gi
@@ -76,6 +78,7 @@ grafana:
 vmagent:
   externalLabels:
     cluster: cozystack
+    environment: ""
   remoteWrite:
     urls:
       - http://vminsert-shortterm:8480/insert/0/prometheus


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Extends the `monitoring` system chart with additional optional configuration for the Alerta Slack plugin, a VMAgent environment label, and adds a Grafana plugin to the custom image build.

### Alerta — Slack plugin (`alerta.alerts.slack`)

| Value | Env var | Description |
|---|---|---|
| `dashboardUrl` | `DASHBOARD_URL` | Links Slack alert messages back to the Alerta console |
| `summaryFmt` | `SLACK_SUMMARY_FMT` | Jinja2 template string for customizing Slack message format |

All new fields are optional and default to empty, preserving existing behavior when unset.

### VMAgent — external labels (`vmagent.externalLabels`)

- Added optional `environment` label that gets attached to all scraped metrics (e.g. `Staging`, `Production`)
- When left empty, no label is added and Alerta falls back to its built-in default of `"Production"`

### Grafana — custom image

- Added [`marcusolsson-dynamictext-panel`](https://grafana.com/grafana/plugins/marcusolsson-dynamictext-panel/) plugin to the Grafana image build


Added marcusolsson-dynamictext-panel plugin to the Grafana image build

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[monitoring] Add optional Slack DASHBOARD_URL and SLACK_SUMMARY_FMT configuration for Alerta, optional vmagent environment external label, and marcusolsson-dynamictext-panel Grafana plugin
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an additional Grafana visualization panel to expand dashboard options.
  * Extended Slack alerting with optional dashboard URL and customizable summary format.
  * Added an optional environment label for external metric ingestion to improve context and filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->