### PR TITLE
[bucket] Fix s3manager endpoint mismatch with COSI credentials

### DIFF
--- a/packages/system/bucket/templates/deployment.yaml
+++ b/packages/system/bucket/templates/deployment.yaml
@@ -1,3 +1,12 @@
+{{- $endpoint := printf "s3.%s" .Values._namespace.host }}
+{{- range $name, $user := .Values.users }}
+  {{- $secretName := printf "%s-%s" $.Values.bucketName $name }}
+  {{- $existingSecret := lookup "v1" "Secret" $.Release.Namespace $secretName }}
+  {{- if $existingSecret }}
+    {{- $bucketInfo := fromJson (b64dec (index $existingSecret.data "BucketInfo")) }}
+    {{- $endpoint = trimPrefix "https://" (index $bucketInfo.spec.secretS3 "endpoint") }}
+  {{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -17,6 +26,6 @@ spec:
         image: "{{ $.Files.Get "images/s3manager.tag" | trim }}"
         env:
         - name: ENDPOINT
-          value: "s3.{{ .Values._namespace.host }}"
+          value: {{ $endpoint | quote }}
         - name: SKIP_SSL_VERIFICATION
           value: "true"


### PR DESCRIPTION
## What this PR does

Fixes s3manager UI deployment to use the actual S3 endpoint from BucketInfo (COSI) instead of constructing it from the tenant namespace host.

The deployment was using `s3.<tenant>.<cluster-domain>` while credentials issued by COSI point to the root-level S3 endpoint. This mismatch caused "invalid credentials" errors on login even with correct credentials from the bucket secret.

Falls back to the constructed namespace host on first deploy before BucketAccess secrets exist.

### Release note

```release-note
[bucket] Fix s3manager endpoint mismatch causing "invalid credentials" errors in login mode
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Deployment configuration now supports per-user endpoint customization. Endpoints are dynamically retrieved from account-specific settings, enabling flexible configurations while maintaining backward compatibility for standard deployments without custom settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->