### PR TITLE
[dashboard] Add keycloakInternalUrl for backend-to-backend OIDC requests

### DIFF
--- a/packages/core/platform/templates/apps.yaml
+++ b/packages/core/platform/templates/apps.yaml
@@ -26,6 +26,7 @@ stringData:
       oidc-enabled: {{ .Values.authentication.oidc.enabled | quote }}
       oidc-insecure-skip-verify: {{ .Values.authentication.oidc.insecureSkipVerify | quote }}
       extra-keycloak-redirect-uri-for-dashboard: {{ index .Values.authentication.oidc.keycloakExtraRedirectUri | quote }}
+      keycloak-internal-url: {{ .Values.authentication.oidc.keycloakInternalUrl | quote }}
       expose-services: {{ .Values.publishing.exposedServices | join "," | quote }}
       expose-ingress: {{ .Values.publishing.ingressName | quote }}
       expose-external-ips: {{ .Values.publishing.externalIPs | join "," | quote }}

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -54,6 +54,11 @@ authentication:
     enabled: false
     insecureSkipVerify: false
     keycloakExtraRedirectUri: ""
+    # Internal URL to access KeyCloak realm for backend-to-backend requests (bypasses external DNS).
+    # When set, oauth2-proxy uses --skip-oidc-discovery and routes all backend calls (token, jwks,
+    # userinfo, logout) through this URL while keeping browser redirects on the external URL.
+    # Example: http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy
+    keycloakInternalUrl: ""
 # Pod scheduling configuration
 scheduling:
   globalAppTopologySpreadConstraints: ""

--- a/packages/system/dashboard/templates/gatekeeper.yaml
+++ b/packages/system/dashboard/templates/gatekeeper.yaml
@@ -1,6 +1,7 @@
 {{- $host := index .Values._cluster "root-host" }}
 {{- $oidcEnabled := index .Values._cluster "oidc-enabled" }}
 {{- $oidcInsecureSkipVerify := index .Values._cluster "oidc-insecure-skip-verify" }}
+{{- $keycloakInternalUrl := index .Values._cluster "keycloak-internal-url" | default "" }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -55,7 +56,16 @@ spec:
             - --http-address=0.0.0.0:8000
             - --redirect-url=https://dashboard.{{ $host }}/oauth2/callback
             - --oidc-issuer-url=https://keycloak.{{ $host }}/realms/cozy
+            {{- if $keycloakInternalUrl }}
+            - --skip-oidc-discovery
+            - --login-url=https://keycloak.{{ $host }}/realms/cozy/protocol/openid-connect/auth
+            - --redeem-url={{ $keycloakInternalUrl }}/protocol/openid-connect/token
+            - --oidc-jwks-url={{ $keycloakInternalUrl }}/protocol/openid-connect/certs
+            - --validate-url={{ $keycloakInternalUrl }}/protocol/openid-connect/userinfo
+            - --backend-logout-url={{ $keycloakInternalUrl }}/protocol/openid-connect/logout?id_token_hint={id_token}
+            {{- else }}
             - --backend-logout-url=https://keycloak.{{ $host }}/realms/cozy/protocol/openid-connect/logout?id_token_hint={id_token}
+            {{- end }}
             - --whitelist-domain=keycloak.{{ $host }}
             - --email-domain=*
             - --pass-access-token=true


### PR DESCRIPTION
## What this PR does

Adds `authentication.oidc.keycloakInternalUrl` platform value that allows oauth2-proxy
in the dashboard to route backend calls (token exchange, JWKS, userinfo, logout) through
an internal cluster URL while keeping browser redirects on the external Keycloak URL.

When set, oauth2-proxy uses `--skip-oidc-discovery` and explicit endpoint URLs pointing
to the internal Keycloak service. This avoids external DNS lookups and TLS overhead for
pod-to-pod communication.

Fully backward-compatible: when the value is empty (default), behavior is unchanged.

### Release note

```release-note
[dashboard] Added `authentication.oidc.keycloakInternalUrl` platform value to route oauth2-proxy backend requests through internal Keycloak service URL, bypassing external DNS and TLS.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration support for an internal KeyCloak URL, enabling backend authentication requests to be routed through an alternative endpoint while maintaining existing external URLs for browser interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->