### PR TITLE
[dashboard] Add secret-hash annotation to KeycloakClient for secret sync

### DIFF
--- a/packages/system/dashboard/templates/keycloakclient.yaml
+++ b/packages/system/dashboard/templates/keycloakclient.yaml
@@ -49,6 +49,8 @@ apiVersion: v1.edp.epam.com/v1
 kind: KeycloakClient
 metadata:
   name: dashboard-client
+  annotations:
+    secret-hash: {{ $dashboardClient | sha256sum }}
 spec:
   serviceAccount:
     enabled: true


### PR DESCRIPTION
## What this PR does

Adds a `secret-hash` annotation to the dashboard `KeycloakClient` CRD resource containing the SHA256 hash of the client secret value.

Without this annotation, if the `dashboard-client` Kubernetes Secret is recreated with a new value (e.g. after upgrade or reinstall), the `KeycloakClient` spec remains unchanged, the EDP Keycloak operator skips reconciliation, and Keycloak retains the stale secret — causing authentication failures for the dashboard.

With the annotation, any change to the secret value updates the hash in metadata, triggering operator reconciliation and syncing the new secret to Keycloak.

This aligns the implementation with cozyportal, where the same pattern is already used.

### Release note

```release-note
[dashboard] Fix dashboard-client secret desynchronization with Keycloak after upgrades by adding secret-hash annotation to KeycloakClient resource
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced authentication service configuration metadata tracking to improve system management and operational reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->