### PR TITLE
[dashboard] Fix broken backup menu links missing cluster context

### DIFF
--- a/internal/controller/dashboard/static_refactored.go
+++ b/internal/controller/dashboard/static_refactored.go
@@ -1985,6 +1985,10 @@ func CreateAllNavigations() []*dashboardv1alpha1.Navigation {
 		// Namespaced API resources
 		"base-factory-namespaced-api-networking.k8s.io-v1-ingresses":         "kube-ingress-details",
 		"base-factory-namespaced-api-cozystack.io-v1alpha1-workloadmonitors": "workloadmonitor-details",
+		// Backup resources (not ApplicationDefinitions, so ensureNavigation doesn't cover them)
+		"base-factory-namespaced-api-backups.cozystack.io-v1alpha1-plans":      "plan-details",
+		"base-factory-namespaced-api-backups.cozystack.io-v1alpha1-backupjobs": "backupjob-details",
+		"base-factory-namespaced-api-backups.cozystack.io-v1alpha1-backups":    "backup-details",
 	}
 
 	return []*dashboardv1alpha1.Navigation{


### PR DESCRIPTION
## What this PR does

Adds missing `baseFactoriesMapping` entries for backup resources (plans, backupjobs, backups) to the static Navigation resource.

Backup resources are not ApplicationDefinitions, so `ensureNavigation()` never creates their navigation mappings. Without these mappings, the OpenUI frontend cannot resolve the `{cluster}` context for backup pages, producing broken sidebar links with an empty cluster segment (e.g. `/openapi-ui//tenant-root/api-table/backups.cozystack.io/v1alpha1/plans` instead of `/openapi-ui/default/tenant-root/...`).

### Release note

```release-note
[dashboard] Fix broken backup menu links by adding missing baseFactoriesMapping entries for backup resources
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backup resources are now integrated into dashboard navigation, providing quick access to backup plans, backup job monitoring, and detailed backup information for streamlined operations management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->