### PR TITLE
[etcd] Add protective limits to defrag CronJob

### DIFF
--- a/packages/extra/etcd/templates/etcd-defrag.yaml
+++ b/packages/extra/etcd/templates/etcd-defrag.yaml
@@ -4,9 +4,14 @@ metadata:
   name: {{ .Release.Name }}-defrag
 spec:
   schedule: "0 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
   successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 1800
+      backoffLimit: 2
       template:
         spec:
           containers:


### PR DESCRIPTION
## What this PR does

Adds missing protective limits to the etcd defrag CronJob to prevent job accumulation during cluster upgrades.

After upgrading CozyStack to v1.1.2, defrag CronJobs accumulated hundreds of running/failed pods across tenants because etcd was temporarily unavailable during the upgrade. Without `concurrencyPolicy: Forbid`, new jobs kept being created hourly while previous ones were still failing.

Changes:
- `concurrencyPolicy: Forbid` — prevent parallel defrag jobs
- `startingDeadlineSeconds: 300` — don't catch up on missed schedules older than 5 minutes
- `failedJobsHistoryLimit: 1` — limit failed job retention
- `activeDeadlineSeconds: 1800` — 30 minute timeout per job
- `backoffLimit: 2` — limit retries to 2 instead of default 6

### Release note

```release-note
[etcd] Fix defrag CronJob accumulating hundreds of pods during cluster upgrades by adding concurrencyPolicy, job timeout, and retry limits
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated etcd defragmentation job configuration to enhance reliability and operational stability in production environments. New controls prevent concurrent job executions to avoid resource contention, enforce startup and execution deadlines, limit retry attempts for failed operations, and maintain failure history for improved monitoring and troubleshooting. These improvements ensure more predictable and stable defragmentation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->