### PR TITLE
fix(csi): hide disk.img and lost+found from RWX NFS mounts

### DIFF
--- a/packages/apps/kubernetes/images/kubevirt-csi-driver/node.go
+++ b/packages/apps/kubernetes/images/kubevirt-csi-driver/node.go
@@ -100,9 +100,10 @@ func (w *WrappedNodeService) NodePublishVolume(ctx context.Context, req *csi.Nod
 	}
 
 	// Auto-migrate: move user files from root into /data (skip internal artifacts).
+	// Fail the publish if migration cannot complete to avoid hiding user data.
 	entries, err := os.ReadDir(tmpMount)
 	if err != nil {
-		klog.Warningf("Failed to read NFS root for migration (volume %s): %v", req.GetVolumeId(), err)
+		return nil, status.Errorf(codes.Internal, "failed to read NFS root for migration (volume %s): %v", req.GetVolumeId(), err)
 	}
 	for _, entry := range entries {
 		name := entry.Name()
@@ -116,7 +117,10 @@ func (w *WrappedNodeService) NodePublishVolume(ctx context.Context, req *csi.Nod
 		}
 		klog.Infof("Migrating %s to /data/%s for volume %s", name, name, req.GetVolumeId())
 		if err := os.Rename(src, dst); err != nil {
-			klog.Warningf("Failed to migrate %s for volume %s: %v", name, req.GetVolumeId(), err)
+			if os.IsNotExist(err) {
+				continue // benign: concurrent publish already moved it
+			}
+			return nil, status.Errorf(codes.Internal, "failed to migrate %s for volume %s: %v", name, req.GetVolumeId(), err)
 		}
 	}
 


### PR DESCRIPTION
## Changes

Mount the `/data` subdirectory of the NFS export instead of the root filesystem in `NodePublishVolume`, so tenant pods no longer see internal LINSTOR/CDI artifacts (`disk.img`, `lost+found`) in their RWX PVC mount points.

### Backward compatibility

On first mount after upgrade, any existing user files at the NFS root are automatically migrated into `/data`. Internal artifacts (`disk.img`, `lost+found`, `data`) are skipped. This is transparent to the user.

### How it works

1. Temp-mount the NFS root to a scratch directory
2. Create `/data` subdirectory if it doesn't exist
3. Move any user files from root into `/data` (migration for pre-fix volumes)
4. Unmount the temp mount
5. Mount `<nfs-export>/data` at the pod's target path

## Test plan

- [ ] Create a new RWX PVC on a tenant cluster → `ls` shows no `disk.img` or `lost+found`
- [ ] Write a file from one pod, read it from another pod on a different node
- [ ] Mount a pre-existing RWX PVC (created before fix) → user data is migrated into `/data` automatically
- [ ] `go build ./...` passes in `packages/apps/kubernetes/images/kubevirt-csi-driver/`
- [ ] `make generate` passes at repo root

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * NFS mounts now expose only the data subdirectory, hiding internal artifacts and avoiding clutter at mount targets.
  * Existing read-only and already-mounted behaviors preserved.
  * User files on existing mounts are migrated into the data subdirectory during transition to avoid data loss; migration failures now cause the publish to fail to protect data.
  * Improved error handling, cleanup, and detailed logging during mount, migration, and unmount steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->