### PR TITLE
[kube-ovn] Fix MASTER_NODES for multi-master generic Kubernetes clusters

### DIFF
--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -70,15 +70,12 @@
   "SVC_CIDR" $svcCIDR
   "JOIN_CIDR" $joinCIDR -}}
 {{- $kubeovnDict := dict "ipv4" $kubeovnIpv4 -}}
-{{- /* Set MASTER_NODES: explicit value > parsed from apiServerEndpoint > empty (use helm lookup) */ -}}
+{{- /* Set MASTER_NODES: explicit value or empty (let kube-ovn discover nodes by label) */ -}}
 {{- $masterNodes := .Values.networking.kubeovn.MASTER_NODES -}}
-{{- if and (not $masterNodes) $apiServerEndpoint -}}
-{{- $masterNodes = $apiHost -}}
-{{- end -}}
 {{- if $masterNodes -}}
 {{- $_ := set $kubeovnDict "MASTER_NODES" $masterNodes -}}
 {{- end -}}
-{{- /* For generic k8s (k3s, kubeadm), control-plane label has value "true" */ -}}
+{{- /* For generic k8s (k3s), control-plane label has value "true" */ -}}
 {{- $_ := set $kubeovnDict "MASTER_NODES_LABEL" "node-role.kubernetes.io/control-plane=true" -}}
 {{- $kubeovnValues := dict "kube-ovn" $kubeovnDict -}}
 {{- $_ := set $networkingComponents "kubeovn" (dict "values" $kubeovnValues) -}}


### PR DESCRIPTION
## What this PR does

Removes the `apiServerEndpoint` fallback for `MASTER_NODES` in the `isp-full-generic` variant.

When `MASTER_NODES` is not explicitly set (the default), the template used to parse a single IP from `apiServerEndpoint` and pass it to kube-ovn. This prevented kube-ovn from discovering all control-plane nodes, breaking OVN RAFT consensus on multi-master clusters (`ovn-central` crashed with `host ip X not in env NODE_IPS`).

Now kube-ovn uses its built-in Helm `lookup` to find all control-plane nodes by the `MASTER_NODES_LABEL` (`node-role.kubernetes.io/control-plane=true`), correctly discovering all masters.

Explicit `MASTER_NODES` override via platform values is preserved.

The `isp-full` (Talos) variant is not affected — it uses a separate code path.

Fixes #2242

### Release note

```release-note
[kube-ovn] Fix multi-master support for generic Kubernetes clusters by letting kube-ovn auto-discover control-plane nodes by label instead of falling back to a single API server IP
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for automatic control plane node discovery using Kubernetes node labels, providing greater flexibility and scalability options for cluster configurations.

* **Bug Fixes**
  * Removed unreliable automatic node configuration fallback logic to improve overall deployment consistency and predictability. Master nodes now require explicit configuration or automatic discovery through Kubernetes node labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->