### PR TITLE
[postgres] Fix database deletion lifecycle management

### DIFF
--- a/packages/apps/postgres/templates/init-script.yaml
+++ b/packages/apps/postgres/templates/init-script.yaml
@@ -73,8 +73,7 @@ stringData:
 
     echo "databases to delete: $DELETE_DBS"
     for db in $DELETE_DBS; do
-    psql -v ON_ERROR_STOP=1 --echo-all -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '$db' AND pid <> pg_backend_pid();"
-    psql -v ON_ERROR_STOP=1 --echo-all -c "DROP DATABASE IF EXISTS \"$db\";"
+    psql -v ON_ERROR_STOP=1 --echo-all -c "DROP DATABASE IF EXISTS \"$db\" WITH (FORCE);"
     done
 
     echo "== delete orphaned managed roles"


### PR DESCRIPTION
## What this PR does

Previously, removing a database from `values.databases` had no effect — the database and its associated roles (`<db>_admin`, `<db>_readonly`) persisted in PostgreSQL indefinitely. This made it impossible to declaratively manage database lifecycle via Helm values.

Added two cleanup stages to the init script, mirroring the existing user deletion logic:
- **Delete databases** that have the `database managed by helm` comment but are no longer listed in `values.databases` — active connections are terminated before dropping
- **Delete orphaned roles** (`<db>_admin`, `<db>_readonly`) with proper membership revocation (`REVOKE ... FROM`) before `REASSIGN OWNED` / `DROP OWNED` / `DROP ROLE`

This also fixes the reported issue where creating a database, removing it, and creating it again would silently retain stale data from the first instance.

### Release note

```release-note
[postgres] Databases removed from `values.databases` are now properly dropped along with their associated roles. Previously removed databases and roles would persist indefinitely.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database initialization to automatically remove databases and roles that were removed from your Helm configuration, avoiding orphaned resources.
  * Now force-terminates active sessions, reassigns owned objects, and cleans up role memberships to ensure reliable removals.
  * Improves consistency of database state during upgrades and configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->