### PR TITLE
[dashboard] Fix JSONPath crash on Tenant details with resourceQuotas

### DIFF
--- a/packages/system/dashboard/images/openapi-ui/openapi-k8s-toolkit/patches/flatmap-unresolved-placeholder.diff
+++ b/packages/system/dashboard/images/openapi-ui/openapi-k8s-toolkit/patches/flatmap-unresolved-placeholder.diff
@@ -1,7 +1,7 @@
 diff --git a/src/components/molecules/EnrichedTable/organisms/EnrichedTableProvider/utils.ts b/src/components/molecules/EnrichedTable/organisms/EnrichedTableProvider/utils.ts
 --- a/src/components/molecules/EnrichedTable/organisms/EnrichedTableProvider/utils.ts
 +++ b/src/components/molecules/EnrichedTable/organisms/EnrichedTableProvider/utils.ts
-@@ -185,8 +185,13 @@
+@@ -185,6 +185,11 @@
                  return `['${escaped}']`
                })
              }


### PR DESCRIPTION
## What this PR does

Fixes a crash on the Tenant details page when `resourceQuotas` are configured. The dashboard renders a ResourceQuota table with a "Used" column that references `$.status.used[_flatMapData_Key]`. When the flatMap placeholder is not resolved during initial render, the raw placeholder is passed to the JSONPath parser, causing:

```text
Parse error on line 1: $.status.used[_flatMapData_Key]
Expecting 'STAR', 'SCRIPT_EXPRESSION', 'INTEGER', ... got 'IDENTIFIER'
```

The original `flatmap-dynamic-key.diff` patch that handled this was removed during the 1.4.0 dashboard upgrade, assuming upstream included the fix. Upstream adopted the code reordering (flatMap expansion before customFields resolution) but not the fallback protection for unresolved placeholders.

Adds a patch to `openapi-k8s-toolkit` that checks for unresolved `_flatMap*_Key` placeholders after regex substitution and returns `null` instead of calling `jp.query()` with an invalid expression.

### Release note

```release-note
[dashboard] Fix crash on Tenant details page when resourceQuotas are configured
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tables now gracefully handle unresolved placeholder fields by treating them as empty/null instead of attempting lookup, preventing display errors and preserving previously correct rendering of resolved fields.
  * Reduces unexpected array-wrapping in single-value cells so values display consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->