### PR TITLE
[platform] Enable cozystack-scheduler by default

### DIFF
--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -130,7 +130,7 @@
 {{include "cozystack.platform.package.default" (list "cozystack.cozystack-basics" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.backupstrategy-controller" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.backup-controller" $) }}
-{{include "cozystack.platform.package.optional.default" (list "cozystack.velero" $) }}
+{{include "cozystack.platform.package.default" (list "cozystack.cozystack-scheduler" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.vertical-pod-autoscaler" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.metrics-server" $) }}
 {{- $monitoringAgentsComponents := dict "monitoring-agents" (dict "values" (dict "global" (dict "target" "tenant-root"))) -}}
@@ -148,11 +148,11 @@
 {{include "cozystack.platform.package.optional.default" (list "cozystack.external-dns" $) }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.external-dns-application" $) }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.external-secrets-operator" $) }}
+{{include "cozystack.platform.package.optional.default" (list "cozystack.velero" $) }}
 {{- if has "cozystack.bootbox" (default (list) .Values.bundles.enabledPackages) }}
 {{include "cozystack.platform.package.default" (list "cozystack.bootbox-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.bootbox" $) }}
 {{- end }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.hetzner-robotlb" $) }}
-{{include "cozystack.platform.package.optional.default" (list "cozystack.cozystack-scheduler" $) }}
 
 {{- end }}


### PR DESCRIPTION
## What this PR does

Install the cozystack-scheduler package and the SchedulingClass CRD by default.

### Release-note

```release-note
[cozystack-scheduler] Enable the cozystack-scheduler and SchedulingClass
CRD by default.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default system package configuration: Scheduler component is now included by default; backup tool moved to optional packages for custom installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->