### PR TITLE
[system] Fix tenant RBAC for endpointslices read access

### DIFF
--- a/packages/system/cozystack-basics/templates/clusterroles.yaml
+++ b/packages/system/cozystack-basics/templates/clusterroles.yaml
@@ -21,6 +21,9 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "services", "persistentvolumes", "endpoints", "events", "resourcequotas"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
   verbs: ["get", "list", "watch"]
@@ -90,6 +93,14 @@ rules:
   - endpoints
   - events
   - resourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
   verbs:
   - get
   - list


### PR DESCRIPTION
## What this PR does

Adds `discovery.k8s.io/endpointslices` read permissions (get, list, watch) to `cozy:tenant:base` and `cozy:tenant:view:base` ClusterRoles.

Dashboard requests EndpointSlices to display the "Pod serving" section on the Service details page. Without this permission, tenant users see a 403 error.

### Release note

```release-note
[system] Fix 403 error on Service details page by granting tenants read access to EndpointSlices
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced system permission configurations to improve platform reliability and ensure proper access controls for core services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->