### PR TITLE
[kilo] Switch from fork to upstream squat/kilo

### DIFF
--- a/packages/system/kilo/Makefile
+++ b/packages/system/kilo/Makefile
@@ -5,9 +5,9 @@ include ../../../hack/common-envs.mk
 include ../../../hack/package.mk
 
 update:
-	tag=$$(git ls-remote --tags --sort="v:refname" https://github.com/cozystack/kilo | awk -F'[/^]' 'END{print $$3}') && \
-	digest=$$(skopeo inspect --override-os linux --override-arch amd64 --format '{{.Digest}}' docker://ghcr.io/cozystack/cozystack/kilo:amd64-$${tag}) && \
-	REPOSITORY="ghcr.io/cozystack/cozystack/kilo" \
+	tag=$$(git ls-remote --tags --sort="v:refname" https://github.com/squat/kilo | awk -F'[/^]' 'END{print $$3}') && \
+	digest=$$(skopeo inspect --override-os linux --override-arch amd64 --format '{{.Digest}}' docker://ghcr.io/squat/kilo:$${tag}) && \
+	REPOSITORY="ghcr.io/squat/kilo" \
 		yq -i '.kilo.image.repository = strenv(REPOSITORY)' values.yaml && \
 	TAG="$${tag}@$${digest}" \
 		yq -i '.kilo.image.tag = strenv(TAG)' values.yaml

--- a/packages/system/kilo/values.yaml
+++ b/packages/system/kilo/values.yaml
@@ -1,8 +1,8 @@
 kilo:
   image:
     pullPolicy: IfNotPresent
-    tag: v0.8.2@sha256:9f27000ffd0bbf9adf3aefd017b7835dfae57b6ea38bf7488fb636536c2467da
-    repository: ghcr.io/cozystack/cozystack/kilo
+    tag: 0.7.0@sha256:c7468aee96425f47369fd1d33b9736147aebc2e9c6e4355d0593461c30af308e
+    repository: ghcr.io/squat/kilo
   transitCIDR: 100.66.0.0/16
   meshGranularity: location
   cleanUpInterface: false


### PR DESCRIPTION
## What this PR does

Switch kilo from the cozystack/kilo fork to the upstream squat/kilo
repository (v0.7.0).

All functional patches from the fork have been upstreamed:
- `--internal-cidr` flag for IP auto-detection filtering (#403)
- Allowed-location-ips overlap with node IPs fix (#404)
- Auto-detect WireGuard MTU from underlay interface (#406)
- Preferred source for WireGuard routes (#408)
- Cilium IPIP overlay support (#409)

The fork only retained rebranding and CI-specific commits beyond
upstream, which are no longer needed.

Changes:
- Makefile: point to `squat/kilo` repo and `ghcr.io/squat/kilo` image
- values.yaml: updated via `make update` to `0.7.0` with digest pin

### Release note

```release-note
[kilo] Switch from cozystack/kilo fork to upstream squat/kilo v0.7.0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the kilo component to use a different source repository and new version configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->