### PR TITLE
[linstor] Fix swapped VMPodScrape job labels

### DIFF
--- a/packages/system/linstor/templates/podscrape.yaml
+++ b/packages/system/linstor/templates/podscrape.yaml
@@ -11,7 +11,7 @@ spec:
     relabelConfigs:
     - action: labeldrop
       regex: (endpoint|namespace|pod|container)
-    - replacement: linstor-controller
+    - replacement: linstor-satellite
       targetLabel: job
     - sourceLabels: [__meta_kubernetes_pod_node_name]
       targetLabel: node
@@ -34,7 +34,7 @@ spec:
     relabelConfigs:
     - action: labeldrop
       regex: (endpoint|namespace|pod|container)
-    - replacement: linstor-satellite
+    - replacement: linstor-controller
       targetLabel: job
     - sourceLabels: [__meta_kubernetes_pod_node_name]
       targetLabel: controller_node


### PR DESCRIPTION
## What this PR does

Fixes swapped `job` labels in the `cozy-linstor` VictoriaMetrics `VMPodScrape` templates.

Before this change:
- `linstor-satellite` metrics were relabeled as `job=linstor-controller`
- `linstor-controller` metrics were relabeled as `job=linstor-satellite`

This caused `linstorControllerOffline` alerts to fire for satellite endpoints such as `:9942` while reporting that the controller was unreachable.

After this change:
- `linstor-satellite` metrics keep `job=linstor-satellite`
- `linstor-controller` metrics keep `job=linstor-controller`

This restores consistent alerting and dashboard semantics for LINSTOR monitoring.

### Release note

```release-note
[linstor] Fix swapped VictoriaMetrics `VMPodScrape` job labels in `cozy-linstor` so `linstorControllerOffline` alerts target the controller instead of satellite endpoints.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Prometheus relabeling so Linstor controller and satellite scrapes now receive the correct job labels.
  * Ensures metrics are attributed to the proper components, improving accuracy of monitoring and alerting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->