### PR TITLE
[piraeus-operator] Fix LINSTOR satellite alert labels and scrape flapping false positives

### DIFF
--- a/packages/system/piraeus-operator/alerts/piraeus-datastore.yaml
+++ b/packages/system/piraeus-operator/alerts/piraeus-datastore.yaml
@@ -7,14 +7,22 @@ spec:
   groups:
     - name: linstor.rules
       rules:
-        - alert: linstorControllerOffline
+        - alert: linstorControllerUnavailable
           annotations:
             description: |
-              LINSTOR Controller is not reachable.
-          expr: up{job="linstor-controller"} == 0
+              LINSTOR Controller deployment has no available replicas.
+          expr: kube_deployment_status_replicas_available{namespace="cozy-linstor",deployment="linstor-controller"} < 1
           for: 3m
           labels:
             severity: critical
+        - alert: linstorControllerMetricsScrapeFailing
+          annotations:
+            description: |
+              LINSTOR Controller metrics endpoint is not being scraped successfully.
+          expr: up{job="linstor-controller"} == 0
+          for: 10m
+          labels:
+            severity: warning
         - alert: linstorSatelliteErrorRate
           annotations:
             description: |


### PR DESCRIPTION
## Summary

This fixes two issues in the LINSTOR alerts shipped by `cozy-piraeus-operator`:

- `linstorSatelliteErrorRate` uses a non-existent `name` label in annotations, which results in `Satellite ""` in notifications.
- `linstorSatelliteErrorRate` can produce false positives when the `linstor-controller` scrape flaps and historical `linstor_error_reports_count` counters reappear inside the alert window.

## Test plan

- Verified the rendered rule updates `{{ $labels.name }}` to `{{ $labels.hostname }}` for LINSTOR satellite alerts.
- Verified the `linstorSatelliteErrorRate` expression now requires stable `up{job="linstor-controller"}` for the full 15 minute window.
- Applied the same logic in a live cluster and confirmed the false-positive `linstorSatelliteErrorRate` alerts stopped firing once controller scrape recovered.

## Release note

```release-note
Fix LINSTOR satellite alert annotations and reduce false positives when controller scraping flaps.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Controller alert now evaluates deployment availability and waits 3 minutes before firing to reduce transient noise.
  * Satellite error alerts include an additional check requiring the controller to have been continuously up recently to avoid spurious triggers.
  * Notifications and dashboards now include hostnames for clearer identification.

* **New Features**
  * Added a dedicated warning for controller metrics scrape failures with a 10-minute delay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->