### PR TITLE
[dashboard] Fix EndpointSlice column definitions for Pod serving table

### DIFF
--- a/internal/controller/dashboard/static_refactored.go
+++ b/internal/controller/dashboard/static_refactored.go
@@ -154,6 +154,14 @@ func CreateAllCustomColumnsOverrides() []*dashboardv1alpha1.CustomColumnsOverrid
 			createStringColumn("Version", ".status.version"),
 		}),
 
+		// Factory service details endpointslice (Pod serving table)
+		createCustomColumnsOverride("factory-kube-service-details-endpointslice", []any{
+			createStringColumn("Pod", ".targetRef.name"),
+			createArrayColumn("Addresses", ".addresses"),
+			createBoolColumn("Ready", ".conditions.ready"),
+			createStringColumn("Node", ".nodeName"),
+		}),
+
 		// Factory service details port mapping
 		createCustomColumnsOverride("factory-kube-service-details-port-mapping", []any{
 			createStringColumn("Name", ".name"),


### PR DESCRIPTION
## What this PR does

Fixes the "Pod serving" (EndpointSlice) table on the service details page which displayed "Raw:" prefixes and "Invalid Date" values. The root cause was a missing `CustomColumnsOverride` for the `factory-kube-service-details-endpointslice` customization ID referenced by the `EnrichedTable` component.

Adds column definitions: Pod (`.targetRef.name`), Addresses (`.addresses`), Ready (`.conditions.ready`), Node (`.nodeName`).

<img width="1113" height="260" alt="Pod serving table" src="https://github.com/user-attachments/assets/5bf92080-feee-44b3-942f-a019ba388427" />



### Release note

```release-note
[dashboard] Fix EndpointSlice rendering in service details — Pod serving table now correctly displays pod name, addresses, readiness, and node.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new columns to the service endpoints view in the dashboard, displaying Pod name, IP addresses, Ready status, and assigned Node information for better visibility into pod serving details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->