### PR TITLE
[dashboard] Fix StorageClass "Error" in forms by granting RBAC read access

### DIFF
--- a/packages/system/dashboard/templates/rbac.yaml
+++ b/packages/system/dashboard/templates/rbac.yaml
@@ -20,6 +20,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## What this PR does

Adds `get`/`list`/`watch` permissions for `storage.k8s.io/storageclasses` to the `cozystack-dashboard-readonly` ClusterRole.

The dashboard UI fetches StorageClasses to populate dropdowns (e.g. in the Postgres form), but authenticated users lacked permissions on this resource, causing "Error" to be displayed instead of the StorageClass name.

### Release note

```release-note
[dashboard] Fix StorageClass dropdown showing "Error" by adding storageclasses read access to the dashboard readonly ClusterRole
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced dashboard read-only permissions to include access to storage classes, improving visibility into cluster storage resources and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->