### PR TITLE
[platform] Add missing apps to tenant admin RBAC

### DIFF
--- a/packages/system/cozystack-basics/templates/clusterroles.yaml
+++ b/packages/system/cozystack-basics/templates/clusterroles.yaml
@@ -194,12 +194,18 @@ rules:
   - buckets
   - clickhouses
   - foos
+  - foundationdbs
+  - harbors
   - httpcaches
   - kafkas
   - kuberneteses
   - mariadbs
+  - mongodbs
   - natses
+  - openbaos
+  - opensearches
   - postgreses
+  - qdrants
   - rabbitmqs
   - redises
   - seaweedfses
@@ -207,6 +213,7 @@ rules:
   - virtualmachines
   - vmdisks
   - vminstances
+  - vpns
   - infos
   - virtualprivateclouds
   verbs:


### PR DESCRIPTION
## What this PR does

Adds 7 missing application resources to the `cozy:tenant:admin:base` ClusterRole for `apps.cozystack.io`:
foundationdbs, harbors, mongodbs, openbaos, opensearches, qdrants, vpns.

Without these permissions, tenant admins could not create these applications — the "Add" button was inactive in the dashboard.

### Release note

```release-note
[platform] Fix tenant admins unable to create FoundationDB, Harbor, MongoDB, OpenBAO, OpenSearch, Qdrant, and VPN applications by adding missing RBAC permissions
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded tenant administrator permissions to manage additional platform resources, including databases, search services, and network infrastructure components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->