### PR TITLE
fix(platform): propagate resource allocation ratios to packages

### DIFF
--- a/packages/core/platform/templates/apps.yaml
+++ b/packages/core/platform/templates/apps.yaml
@@ -36,6 +36,9 @@ stringData:
       branding:
         {{- . | toYaml | nindent 8 }}
       {{- end }}
+      cpu-allocation-ratio: {{ .Values.resources.cpuAllocationRatio | quote }}
+      memory-allocation-ratio: {{ .Values.resources.memoryAllocationRatio | quote }}
+      ephemeral-storage-allocation-ratio: {{ .Values.resources.ephemeralStorageAllocationRatio | quote }}
       {{- with .Values.scheduling }}
       scheduling:
         {{- . | toYaml | nindent 8 }}

--- a/packages/core/platform/templates/bundles/iaas.yaml
+++ b/packages/core/platform/templates/bundles/iaas.yaml
@@ -2,7 +2,11 @@
 {{- fail "bundles.iaas.enabled can only be true when bundles.system.variant is 'isp-full' or 'isp-full-generic'" }}
 {{- end }}
 {{- if and .Values.bundles.iaas.enabled (or (eq .Values.bundles.system.variant "isp-full") (eq .Values.bundles.system.variant "isp-full-generic")) }}
-{{include "cozystack.platform.package.default" (list "cozystack.kubevirt" $) }}
+{{- $kubevirtComponents := dict -}}
+{{- if .Values.resources.cpuAllocationRatio -}}
+{{- $_ := set $kubevirtComponents "kubevirt" (dict "values" (dict "cpuAllocationRatio" (.Values.resources.cpuAllocationRatio | int))) -}}
+{{- end -}}
+{{include "cozystack.platform.package" (list "cozystack.kubevirt" "default" $ $kubevirtComponents) }}
 {{include "cozystack.platform.package.default" (list "cozystack.kubevirt-cdi" $) }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.gpu-operator" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.kamaji" $) }}


### PR DESCRIPTION
## What this PR does

Fixes a regression introduced in the bundle restructure (2d022e38) where `cpuAllocationRatio`, `memoryAllocationRatio`, and `ephemeralStorageAllocationRatio` from `platform/values.yaml` became no-ops — never propagated to child packages.

The old monolithic bundles read these values from the cozystack ConfigMap via `lookup` and passed them explicitly. After migration to the Package CRD model, the bridge was lost: cozy-lib expects the ratios in `_cluster` config (via `cozystack-values` Secret), but platform never wrote them there, so the hardcoded defaults (10, 1, 40) were always used regardless of what the user configured.

This commit restores the propagation by:
- Adding `cpu-allocation-ratio`, `memory-allocation-ratio`, and `ephemeral-storage-allocation-ratio` to the `_cluster` section in the `cozystack-values` Secret, so cozy-lib in all managed applications picks them up
- Passing `cpuAllocationRatio` to the kubevirt Package component values, so the KubeVirt CR gets the configured value

### Release note

```release-note
[platform] Fix propagation of resource allocation ratios (cpu, memory, ephemeral-storage) to managed applications and KubeVirt, which were silently ignored since the bundle restructure.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new resource allocation configuration fields to platform templates for flexible resource management.
  * Enhanced conditional handling of resource settings within container infrastructure components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->