### PR TITLE
fix(linstor): set verify-alg to crc32c to avoid crct10dif unavailability

### DIFF
--- a/packages/system/linstor/templates/cluster.yaml
+++ b/packages/system/linstor/templates/cluster.yaml
@@ -20,6 +20,8 @@ spec:
   - name: DrbdOptions/auto-diskful-allow-cleanup
     value: {{ .Values.linstor.autoDiskful.allowCleanup | quote }}
   {{- end }}
+  - name: DrbdOptions/Net/verify-alg
+    value: "crc32c"
   - name: DrbdOptions/Net/connect-int
     value: "15"
   - name: DrbdOptions/Net/ping-int


### PR DESCRIPTION
## Summary
- Set `DrbdOptions/Net/verify-alg` to `crc32c` at the controller level to prevent DRBD connection failures on kernels where `crct10dif` is unavailable
- Fixes an issue where all DRBD resources become Diskless after upgrading to Talos v1.12.6 (kernel 6.18.18)

## Why
LINSTOR's auto-verify algorithm selection picks `crct10dif` by default, but this kernel crypto module is no longer available in newer kernels. This causes DRBD peer connections to fail with `VERIFYAlgNotAvail: failed to allocate crct10dif for verify`, resulting in lost quorum on all nodes.

## Test plan
- [ ] Deploy to a cluster running Talos v1.12.6 (kernel 6.18.18)
- [ ] Verify DRBD resources connect and replicate normally
- [ ] Confirm `drbdsetup` uses `crc32c` as verify-alg

Closes #2302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration**
  * Added network verification algorithm configuration option for DRBD cluster setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->