### PR TITLE
fix(multus): pin master CNI to 05-cilium.conflist

### DIFF
--- a/packages/system/multus/templates/multus-daemonset-thick.yml
+++ b/packages/system/multus/templates/multus-daemonset-thick.yml
@@ -119,6 +119,7 @@ data:
         "cniConfigDir": "/host/etc/cni/net.d",
         "multusAutoconfigDir": "/host/etc/cni/net.d",
         "multusConfigFile": "auto",
+        "multusMasterCNI": "05-cilium.conflist",
         "socketDir": "/host/run/multus/"
     }
 ---


### PR DESCRIPTION
## Summary
- Pin multusMasterCNI to `05-cilium.conflist` to prevent race condition at boot
- Fixes issue where multus auto-detects wrong conflist, bypassing Cilium CNI chain

## Problem
During node boot (e.g. Talos upgrade), multus auto-detects the master CNI conflist by scanning
the CNI config directory. If kube-ovn writes `10-kube-ovn.conflist` before Cilium writes
`05-cilium.conflist`, multus selects the wrong file. Pods on the affected node then bypass
the Cilium chain entirely, have no Cilium endpoint, and their traffic gets blocked by
cluster-wide network policies.

## Fix
Set `multusMasterCNI: "05-cilium.conflist"` in the multus daemon config to explicitly
pin the master CNI file, eliminating the race condition.

## Upstream
- Issue: https://github.com/k8snetworkplumbingwg/multus-cni/issues/1499
- Tracking: https://github.com/cozystack/cozystack/issues/2310

## Test plan
- [x] Verified `multusMasterCNI` JSON key matches upstream struct tag
- [ ] Deploy and verify `00-multus.conf` points to `05-cilium.conflist` after node reboot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Multus network daemon configuration to designate Cilium as the master Container Network Interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->