### PR TITLE
fix(kubernetes): set explicit ephemeral-storage on virt-launcher pods

### DIFF
--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -70,6 +70,8 @@ spec:
             memory:
               guest: {{ .group.resources.memory }}
             {{- end }}
+            resources:
+              {{- include "cozy-lib.resources.sanitize" (list (dict "ephemeral-storage" .group.ephemeralStorage) $) | nindent 14 }}
           evictionStrategy: External
           volumes:
           - name: system


### PR DESCRIPTION
## Summary
- Set explicit `domain.resources` with ephemeral-storage on VirtualMachine spec in KubevirtMachineTemplate
- Limits and requests are calculated via `cozy-lib.resources.sanitize` using the configured `ephemeralStorage` value and allocation ratio

## Problem
Without explicit ephemeral-storage resources on the VirtualMachine spec, virt-launcher pods inherit default limits from the namespace LimitRange. These defaults can be significantly lower than the actual emptyDisk capacity (e.g. 2Gi limit vs 20Gi disk). When the VM's containerd unpacks container images, it writes to emptyDir volumes on the host, quickly exceeding the pod's total ephemeral-storage limit. This causes kubelet to evict the pod, crashing the VM and creating a restart loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved virtual machine resource configuration with explicit ephemeral storage management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->