### PR TITLE
[scheduler] Make cozystack-scheduler storage-aware via LINSTOR extender

### DIFF
--- a/packages/core/platform/sources/cozystack-scheduler.yaml
+++ b/packages/core/platform/sources/cozystack-scheduler.yaml
@@ -17,3 +17,14 @@ spec:
       install:
         namespace: kube-system
         releaseName: cozystack-scheduler
+  - name: linstor
+    dependsOn:
+    - cozystack.linstor-scheduler
+    components:
+    - name: cozystack-scheduler
+      path: system/cozystack-scheduler
+      valuesFiles:
+      - values-linstor.yaml
+      install:
+        namespace: kube-system
+        releaseName: cozystack-scheduler

--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -25,10 +25,12 @@
 {{include "cozystack.platform.package" (list "cozystack.networking" "kubeovn-cilium" $ $networkingComponents) }}
 {{include "cozystack.platform.system.common-packages" $ }}
 {{include "cozystack.platform.package.default" (list "cozystack.linstor" $) }}
+{{include "cozystack.platform.package" (list "cozystack.cozystack-scheduler" "linstor" $) }}
 {{- end }}
 
 {{- if eq .Values.bundles.system.variant "isp-hosted" }}
 {{include "cozystack.platform.package" (list "cozystack.networking" "noop" $) }}
+{{include "cozystack.platform.package.default" (list "cozystack.cozystack-scheduler" $) }}
 {{- end }}
 
 {{- if eq .Values.bundles.system.variant "isp-full-generic" }}
@@ -92,6 +94,7 @@
 {{- /* Pass talos.enabled: false to linstor for generic Linux */ -}}
 {{- $linstorComponents := dict "linstor" (dict "values" (dict "talos" (dict "enabled" false))) -}}
 {{include "cozystack.platform.package" (list "cozystack.linstor" "default" $ $linstorComponents) }}
+{{include "cozystack.platform.package" (list "cozystack.cozystack-scheduler" "linstor" $) }}
 {{- end }}
 
 # Cozystack Engine
@@ -130,7 +133,6 @@
 {{include "cozystack.platform.package.default" (list "cozystack.cozystack-basics" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.backupstrategy-controller" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.backup-controller" $) }}
-{{include "cozystack.platform.package.default" (list "cozystack.cozystack-scheduler" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.vertical-pod-autoscaler" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.metrics-server" $) }}
 {{- $monitoringAgentsComponents := dict "monitoring-agents" (dict "values" (dict "global" (dict "target" "tenant-root"))) -}}

--- a/packages/system/cozystack-scheduler/Chart.yaml
+++ b/packages/system/cozystack-scheduler/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: cozy-cozystack-scheduler
-version: 0.2.0
+version: 0.3.0

--- a/packages/system/cozystack-scheduler/Makefile
+++ b/packages/system/cozystack-scheduler/Makefile
@@ -3,6 +3,9 @@ export NAMESPACE=kube-system
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 update:
 	rm -rf charts
 	tag=$$(git ls-remote --tags --sort="v:refname" https://github.com/cozystack/cozystack-scheduler | awk -F'[/^]' 'END{print $$3}') && \

--- a/packages/system/cozystack-scheduler/charts/cozystack-scheduler/Chart.yaml
+++ b/packages/system/cozystack-scheduler/charts/cozystack-scheduler/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: cozy-cozystack-scheduler
-version: 0.2.0
+version: 0.3.0

--- a/packages/system/cozystack-scheduler/charts/cozystack-scheduler/templates/configmap.yaml
+++ b/packages/system/cozystack-scheduler/charts/cozystack-scheduler/templates/configmap.yaml
@@ -52,3 +52,7 @@ data:
               - name: CozystackInterPodAffinity
               - name: CozystackNodeAffinity
               - name: CozystackPodTopologySpread
+    {{- with .Values.extenders }}
+    extenders:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}

--- a/packages/system/cozystack-scheduler/charts/cozystack-scheduler/values.yaml
+++ b/packages/system/cozystack-scheduler/charts/cozystack-scheduler/values.yaml
@@ -1,4 +1,4 @@
-image: ghcr.io/cozystack/cozystack/cozystack-scheduler:v0.2.0@sha256:89c285c5c5fe3ed8d7d597acf32fc9f045394e0f8efafd1878d6080cf112f6c2
+image: ghcr.io/cozystack/cozystack/cozystack-scheduler:v0.3.0@sha256:89c285c5c5fe3ed8d7d597acf32fc9f045394e0f8efafd1878d6080cf112f6c2
 replicas: 1
 # defaultLabelSelectorKeys overrides the pod label keys used to auto-populate
 # nil LabelSelectors in SchedulingClass affinity and topology spread terms.
@@ -7,3 +7,17 @@ replicas: 1
 #   - apps.cozystack.io/application.kind
 #   - apps.cozystack.io/application.name
 # defaultLabelSelectorKeys: []
+
+# extenders is a list of scheduler extenders to call during the scheduling cycle.
+# Each entry is passed directly into KubeSchedulerConfiguration.extenders[].
+# Example:
+#   extenders:
+#     - urlPrefix: http://linstor-scheduler-extender.cozy-linstor.svc:8099
+#       filterVerb: filter
+#       prioritizeVerb: prioritize
+#       weight: 5
+#       enableHTTPS: false
+#       httpTimeout: 10s
+#       nodeCacheCapable: false
+#       ignorable: true
+extenders: []

--- a/packages/system/cozystack-scheduler/tests/configmap_test.yaml
+++ b/packages/system/cozystack-scheduler/tests/configmap_test.yaml
@@ -1,0 +1,26 @@
+suite: scheduler configmap tests
+
+templates:
+  - charts/cozy-cozystack-scheduler/templates/configmap.yaml
+
+tests:
+  - it: renders extenders when configured
+    values:
+      - ../values-linstor.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["scheduler-config.yaml"]
+          pattern: "urlPrefix: http://linstor-scheduler-extender"
+      - matchRegex:
+          path: data["scheduler-config.yaml"]
+          pattern: "ignorable: true"
+
+  - it: omits extenders by default
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - notMatchRegex:
+          path: data["scheduler-config.yaml"]
+          pattern: "extenders:"

--- a/packages/system/cozystack-scheduler/values-linstor.yaml
+++ b/packages/system/cozystack-scheduler/values-linstor.yaml
@@ -1,0 +1,10 @@
+cozy-cozystack-scheduler:
+  extenders:
+    - urlPrefix: http://linstor-scheduler-extender.cozy-linstor.svc:8099
+      filterVerb: filter
+      prioritizeVerb: prioritize
+      weight: 5
+      enableHTTPS: false
+      httpTimeout: 10s
+      nodeCacheCapable: false
+      ignorable: true

--- a/packages/system/linstor-scheduler/Makefile
+++ b/packages/system/linstor-scheduler/Makefile
@@ -3,9 +3,13 @@ export NAMESPACE=cozy-linstor
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 update:
 	rm -rf charts
 	helm repo add piraeus-charts https://piraeus.io/helm-charts/
 	helm repo update piraeus-charts
 	helm pull piraeus-charts/linstor-scheduler --untar --untardir charts
 	patch --no-backup-if-mismatch -p4 < patches/disable-ca-key-rotation.patch
+	patch --no-backup-if-mismatch -p4 < patches/add-scheduler-component-label.patch

--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/deployment.yaml
+++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       {{- end }}
       labels:
         {{- include "linstor-scheduler.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: scheduler
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/packages/system/linstor-scheduler/patches/add-scheduler-component-label.patch
+++ b/packages/system/linstor-scheduler/patches/add-scheduler-component-label.patch
@@ -1,0 +1,9 @@
+diff --git a/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/deployment.yaml b/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/deployment.yaml
+--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/deployment.yaml
++++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/templates/deployment.yaml
+@@ -21,4 +21,5 @@
+       labels:
+         {{- include "linstor-scheduler.selectorLabels" . | nindent 8 }}
++        app.kubernetes.io/component: scheduler
+     spec:
+       {{- with .Values.imagePullSecrets }}

--- a/packages/system/linstor-scheduler/templates/extender-service.yaml
+++ b/packages/system/linstor-scheduler/templates/extender-service.yaml
@@ -1,0 +1,26 @@
+{{/*
+  Exposes the linstor-scheduler-extender sidecar (port 8099) as a
+  cluster-internal Service so that other schedulers (e.g. cozystack-scheduler)
+  can use it as a scheduler extender.
+
+  The selector labels match the subchart's deployment pods. They are
+  hardcoded here because the subchart helpers expect a subchart rendering
+  context that is unavailable in the wrapper chart.
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: linstor-scheduler-extender
+  labels:
+    app.kubernetes.io/component: extender
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8099
+      targetPort: 8099
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: linstor-scheduler
+    app.kubernetes.io/instance: linstor-scheduler
+    app.kubernetes.io/component: scheduler

--- a/packages/system/linstor-scheduler/tests/extender-service_test.yaml
+++ b/packages/system/linstor-scheduler/tests/extender-service_test.yaml
@@ -1,0 +1,35 @@
+suite: extender service targets deployment pods
+
+templates:
+  - templates/extender-service.yaml
+  - charts/linstor-scheduler/templates/deployment.yaml
+
+release:
+  name: linstor-scheduler
+
+tests:
+  - it: service selector matches deployment pod labels
+    template: charts/linstor-scheduler/templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: linstor-scheduler
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
+          value: linstor-scheduler
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: scheduler
+
+  - it: service selector uses the same values
+    template: templates/extender-service.yaml
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: linstor-scheduler
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: linstor-scheduler
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: scheduler


### PR DESCRIPTION
## What this PR does

Makes `cozystack-scheduler` LINSTOR storage-aware by configuring it to call the existing `linstor-scheduler-extender` as a scheduler extender. This fixes #2328 (phase 1): pods with both a `SchedulingClass` and LINSTOR PVCs now get storage-locality-aware placement instead of bypassing LINSTOR's filter/prioritize logic.

Changes:
- **linstor-scheduler package**: expose the extender sidecar (port 8099) via a new ClusterIP Service; patch the vendored deployment to add a `app.kubernetes.io/component: scheduler` label for clean Service targeting
- **cozystack-scheduler package**: bump to v0.3.0 which adds configurable `extenders` support; set the LINSTOR extender URL in wrapper values
- **tests**: helm-unittest for extender rendering in the ConfigMap

### Release note

```release-note
[scheduler] cozystack-scheduler now calls the LINSTOR scheduler extender for storage-aware pod placement. Pods assigned to a SchedulingClass that also use LINSTOR-backed PVCs will prefer nodes with local volume replicas.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scheduler extenders support for custom scheduling behavior.
  * Optional linstor scheduler integration variant with extender configuration and a dedicated service for extender traffic.
  * Deployment labels updated to allow service-selector alignment with scheduler pods.

* **Chores**
  * Scheduler chart and image bumped to v0.3.0.
  * Added Helm unittest suites and new test targets to validate templates and extender behavior.
* **Bundles**
  * Scheduler now included per-variant (linstor) instead of always-on.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->