### PR TITLE
[kubernetes] Add conntrack to ubuntu-container-disk image

### DIFF
--- a/packages/apps/kubernetes/images/ubuntu-container-disk/Dockerfile
+++ b/packages/apps/kubernetes/images/ubuntu-container-disk/Dockerfile
@@ -45,7 +45,7 @@ RUN qemu-img resize image.img 5G \
  && guestfish --remote command "sed -i '/SystemdCgroup/ s/=.*/= true/' /etc/containerd/config.toml" \
  && guestfish --remote command "containerd config dump >/dev/null" \
 # install kubernetes
- && guestfish --remote command "apt-get install -yq kubelet kubeadm" \
+ && guestfish --remote command "apt-get install -yq kubelet kubeadm conntrack" \
 # clean apt cache
  && guestfish --remote sh 'apt-get clean && rm -rf /var/lib/apt/lists/*' \
 # write system configuration


### PR DESCRIPTION
## What this PR does

Adds the `conntrack` package to the `ubuntu-container-disk` Dockerfile. This fixes `kubeadm join` failures for Kubernetes versions v1.28 through v1.31.

### Root cause

Since Kubernetes v1.33, the `kubelet` deb package [no longer declares `conntrack` as a dependency](https://github.com/kubernetes/release/issues/4106). The container disk image installs kubelet/kubeadm from the v1.33 apt repo, so `conntrack` is no longer pulled in automatically.

For older Kubernetes versions (v1.28–v1.31), the `update-k8s.sh` script replaces the kubeadm/kubelet **binaries** at boot time but doesn't install missing apt dependencies. The older kubeadm binaries still perform a mandatory preflight check for `conntrack`, which fails:

```
[ERROR FileExisting-conntrack]: conntrack not found in system path
```

### Impact

| Version | Before | After |
|---------|--------|-------|
| v1.28–v1.31 | FAIL (conntrack missing) | PASS |
| v1.32 | PASS (check optional) | PASS |
| v1.33 | PASS (check removed) | PASS |

### Why Dockerfile vs preKubeadmCommands

Installing `conntrack` in the Dockerfile bakes it into the disk image, avoiding an extra `apt-get` call on every VM boot. This is the same approach used for containerd, kubelet, and kubeadm.

Fixes #2143

### Release note

```release-note
[kubernetes] Fix kubeadm join failure for Kubernetes versions <= v1.31 by adding conntrack to the container disk image.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Ubuntu container image for Kubernetes deployments with additional networking package support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->