### PR TITLE
Add Mattia Eleuteri (@mattia-eleuteri) as Maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,3 +11,4 @@
 | Kirill Klinchenkov | [@klinch0](https://github.com/klinch0) | Ænix | Core Maintainer |
 | Nikita Bykov | [@nbykov0](https://github.com/nbykov0) | Ænix | Maintainer of ARM and stuff |
 | Matthieu Robin | [@matthieu-robin](https://github.com/matthieu-robin) | Hidora | Managed Applications, Platform Quality & Benchmarking |
+| Mattia Eleuteri | [@mattia-eleuteri](https://github.com/mattia-eleuteri) | Hidora | CSI, Storage, Networking & Security |


### PR DESCRIPTION
## Maintainer Nomination: Mattia Eleuteri

Per the process in [CONTRIBUTOR_LADDER.md](./CONTRIBUTOR_LADDER.md#maintainer), this PR nominates **Mattia Eleuteri** (@mattia-eleuteri, Hidora) as a Maintainer.

### Summary

Mattia has demonstrated sustained, high-quality contributions across CSI/storage, networking, monitoring, and security. Key areas include:

- CSI fixes for migration, RWX NFS mounts, and multi-node volumes
- CiliumNetworkPolicy and VPC peering for multi-tenant environments
- Monitoring improvements (vmagent, infrastructure dashboards)
- Security scanning and hardening
- New platform packages (external-dns)

Full discussion and vote: #2343

### Process checklist

- [x] @mattia-eleuteri please comment confirming you agree to all [Maintainer responsibilities](./CONTRIBUTOR_LADDER.md#maintainer)
- [x] Majority of current Maintainers (5 of 8) approve this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Mattia Eleuteri (Hidora) to the project maintainers list, assigned to CSI, Storage, Networking & Security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->