### PR TITLE
Add Matthieu Robin (@matthieu-robin) as Maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,3 +10,4 @@
 | Timur Tukaev | [@tym83](https://github.com/tym83) | Ænix | Cozystack Website, Marketing, Community Management |
 | Kirill Klinchenkov | [@klinch0](https://github.com/klinch0) | Ænix | Core Maintainer |
 | Nikita Bykov | [@nbykov0](https://github.com/nbykov0) | Ænix | Maintainer of ARM and stuff |
+| Matthieu Robin | [@matthieu-robin](https://github.com/matthieu-robin) | Hidora | Managed Applications, Platform Quality & Benchmarking |


### PR DESCRIPTION
## Maintainer Nomination: Matthieu Robin

Per the process in [CONTRIBUTOR_LADDER.md](./CONTRIBUTOR_LADDER.md#maintainer), this PR nominates **Matthieu Robin** (@matthieu-robin, Hidora) as a Maintainer.

### Summary

Matthieu has contributed consistently across managed applications, platform quality, and community engagement. Key areas include:

- Full managed OpenSearch service (operator, packaging, validation)
- Workload monitoring with instance profile labels
- Operational hardening (etcd-defrag resource limits)
- Kubernetes benchmarking and platform validation
- CozySummit speaker and Program Committee member

Full discussion and vote: #2344

### Process checklist

- [x] @matthieu-robin please comment confirming you agree to all [Maintainer responsibilities](./CONTRIBUTOR_LADDER.md#maintainer)
- [x] Majority of current Maintainers (5 of 8) approve this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project maintainers documentation to reflect the current team composition and responsibility assignments. The update documents team members responsible for overseeing managed applications, platform quality initiatives, and benchmarking efforts to ensure comprehensive coverage of critical project areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->