### PR TITLE
Fix system postgresql images to 17.7-standard-trixie

### DIFF
--- a/packages/core/platform/images/migrations/migrations/37
+++ b/packages/core/platform/images/migrations/migrations/37
@@ -1,42 +1,77 @@
-#!/bin/sh
+#!/bin/bash
 # Migration 37 --> 38
-# Backfill spec.version on postgreses.apps.cozystack.io resources.
+# Pin PostgreSQL image to 17.7-standard-trixie for system databases.
 #
-# Before this migration PostgreSQL had a default version field set to v18.
-# This migration sets spec.version to "v17" for any postgres app resource that
-# does not already have it set, to ensure compatibility with monitoring
-# configurations that are hardcoded to PostgreSQL 17.
+# This migration updates the imageName for all CNPG clusters belonging to
+# system components (keycloak-db, grafana-db, alerta-db, seaweedfs-db, and
+# harbor's dynamically-named DB):
+# - If imageName is not set: pins to 17.7-standard-trixie
+# - If imageName has any PG 17 tag: forces 17.7-standard-trixie
+# - If imageName has a bare version tag (e.g. :18.1): appends -standard-trixie
+#
+# NOTE: This migration ONLY updates system CNPG Cluster resources (clusters.postgresql.cnpg.io),
+# NOT user-created Postgres applications.
 
 set -euo pipefail
 
-DEFAULT_VERSION="v17"
+TARGET_IMAGE="ghcr.io/cloudnative-pg/postgresql:17.7-standard-trixie"
 
-# Skip if the CRD does not exist (postgres was never installed)
-if ! kubectl api-resources --api-group=apps.cozystack.io -o name 2>/dev/null | grep -q '^postgreses\.'; then
-  echo "CRD postgreses.apps.cozystack.io not found, skipping migration"
-  kubectl create configmap -n cozy-system cozystack-version \
-    --from-literal=version=38 --dry-run=client -o yaml | kubectl apply -f-
-  exit 0
-fi
+# Static system database names
+STATIC_DB_NAMES="keycloak-db grafana-db alerta-db seaweedfs-db"
 
-POSTGRESES=$(kubectl get postgreses.apps.cozystack.io -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}')
-for resource in $POSTGRESES; do
-  NS="${resource%%/*}"
-  APP_NAME="${resource##*/}"
+echo "=== Updating PostgreSQL images for system databases ==="
+echo "Target image: $TARGET_IMAGE"
 
-  # Skip if spec.version is already set
-  CURRENT_VER=$(kubectl get postgreses.apps.cozystack.io -n "$NS" "$APP_NAME" \
-    -o jsonpath='{.spec.version}')
-  if [ -n "$CURRENT_VER" ]; then
-    echo "SKIP $NS/$APP_NAME: spec.version already set to '$CURRENT_VER'"
+# Fetch all CNPG clusters with their name, namespace, imageName, and Helm release annotation in one call
+ALL_CLUSTERS=$(kubectl get clusters.postgresql.cnpg.io -A \
+  -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\t"}{.spec.imageName}{"\t"}{.metadata.annotations.meta\.helm\.sh/release-name}{"\n"}{end}' 2>/dev/null || true)
+
+while IFS=$'\t' read -r NAMESPACE CLUSTER_NAME CURRENT_IMAGE HELM_RELEASE; do
+  [ -z "$NAMESPACE" ] && continue
+
+  # Check if cluster name matches one of the static system databases
+  MATCH=false
+  for db_name in $STATIC_DB_NAMES; do
+    if [ "$CLUSTER_NAME" = "$db_name" ]; then
+      MATCH=true
+      break
+    fi
+  done
+
+  # For harbor: match clusters ending with -db whose Helm release ends with -system
+  if [ "$MATCH" = false ] && [[ "$CLUSTER_NAME" == *-db ]] && [[ "$HELM_RELEASE" == *-system ]]; then
+    MATCH=true
+  fi
+
+  if [ "$MATCH" = false ]; then
     continue
   fi
 
-  echo "Patching postgres/$APP_NAME in $NS: setting version=$DEFAULT_VERSION"
+  PATCH_IMAGE=""
 
-  kubectl patch postgreses.apps.cozystack.io -n "$NS" "$APP_NAME" --type=merge \
-    --patch "{\"spec\":{\"version\":\"${DEFAULT_VERSION}\"}}"
-done
+  if [ -z "$CURRENT_IMAGE" ]; then
+    # imageName not set — pin to target
+    PATCH_IMAGE="$TARGET_IMAGE"
+    echo "PATCH $NAMESPACE/$CLUSTER_NAME: imageName not set, setting to $PATCH_IMAGE"
+  elif [[ "$CURRENT_IMAGE" =~ :17\. ]]; then
+    # Any PG 17 image — force to the pinned 17.7-standard-trixie
+    PATCH_IMAGE="$TARGET_IMAGE"
+    echo "PATCH $NAMESPACE/$CLUSTER_NAME: PG 17 detected, $CURRENT_IMAGE -> $PATCH_IMAGE"
+  elif [[ "$CURRENT_IMAGE" =~ :[0-9]+\.[0-9]+$ ]]; then
+    # Bare version tag for other majors (e.g. :18.1) — append -standard-trixie suffix
+    PATCH_IMAGE="${CURRENT_IMAGE}-standard-trixie"
+    echo "PATCH $NAMESPACE/$CLUSTER_NAME: bare tag detected, $CURRENT_IMAGE -> $PATCH_IMAGE"
+  else
+    echo "SKIP $NAMESPACE/$CLUSTER_NAME: imageName already set to $CURRENT_IMAGE"
+    continue
+  fi
+
+  kubectl patch clusters.postgresql.cnpg.io -n "$NAMESPACE" "$CLUSTER_NAME" \
+    --type=merge \
+    --patch "{\"spec\":{\"imageName\":\"${PATCH_IMAGE}\"}}"
+done <<< "$ALL_CLUSTERS"
+
+echo "=== PostgreSQL image update completed ==="
 
 # Stamp version
 kubectl create configmap -n cozy-system cozystack-version \

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -6,7 +6,7 @@ sourceRef:
 migrations:
   enabled: false
   image: ghcr.io/cozystack/cozystack/platform-migrations:v1.2.1@sha256:e8fcf006a4451fc0e961455e9b27a61b7103ee49b1a81fe5e4662ffed093fad6
-  targetVersion: 37
+  targetVersion: 38
 # Bundle deployment configuration
 bundles:
   system:

--- a/packages/system/harbor/templates/database.yaml
+++ b/packages/system/harbor/templates/database.yaml
@@ -5,7 +5,9 @@ metadata:
   name: {{ .Values.harbor.fullnameOverride }}-db
 spec:
   instances: {{ .Values.db.replicas }}
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.7
+  {{- $existingCluster := lookup "postgresql.cnpg.io/v1" "Cluster" .Release.Namespace (printf "%s-db" .Values.harbor.fullnameOverride) }}
+  {{- $image := dig "spec" "imageName" "ghcr.io/cloudnative-pg/postgresql:17.7-standard-trixie" $existingCluster }}
+  imageName: {{ if regexMatch ":17\\." $image }}ghcr.io/cloudnative-pg/postgresql:17.7-standard-trixie{{ else if regexMatch ":[0-9]+\\.[0-9]+$" $image }}{{ printf "%s-standard-trixie" $image }}{{ else }}{{ $image }}{{ end }}
   storage:
     size: {{ .Values.db.size }}
     {{- with .Values.db.storageClass }}

--- a/packages/system/keycloak/templates/db.yaml
+++ b/packages/system/keycloak/templates/db.yaml
@@ -4,7 +4,9 @@ metadata:
   name: keycloak-db
 spec:
   instances: 2
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.7
+  {{- $existingCluster := lookup "postgresql.cnpg.io/v1" "Cluster" .Release.Namespace "keycloak-db" }}
+  {{- $image := dig "spec" "imageName" "ghcr.io/cloudnative-pg/postgresql:17.7-standard-trixie" $existingCluster }}
+  imageName: {{ if regexMatch ":17\\." $image }}ghcr.io/cloudnative-pg/postgresql:17.7-standard-trixie{{ else if regexMatch ":[0-9]+\\.[0-9]+$" $image }}{{ printf "%s-standard-trixie" $image }}{{ else }}{{ $image }}{{ end }}
   storage:
     size: 20Gi
   {{- if .Values._cluster.scheduling }}

--- a/packages/system/monitoring/templates/alerta/alerta-db.yaml
+++ b/packages/system/monitoring/templates/alerta/alerta-db.yaml
@@ -5,7 +5,9 @@ metadata:
   name: alerta-db
 spec:
   instances: 2
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.7
+  {{- $existingCluster := lookup "postgresql.cnpg.io/v1" "Cluster" .Release.Namespace "alerta-db" }}
+  {{- $image := dig "spec" "imageName" "ghcr.io/cloudnative-pg/postgresql:17.7-standard-trixie" $existingCluster }}
+  imageName: {{ if regexMatch ":17\\." $image }}ghcr.io/cloudnative-pg/postgresql:17.7-standard-trixie{{ else if regexMatch ":[0-9]+\\.[0-9]+$" $image }}{{ printf "%s-standard-trixie" $image }}{{ else }}{{ $image }}{{ end }}
   {{- if .Values._cluster.scheduling }}
   {{- $rawConstraints := get .Values._cluster.scheduling "globalAppTopologySpreadConstraints" }}
   {{- if $rawConstraints }}

--- a/packages/system/monitoring/templates/grafana/db.yaml
+++ b/packages/system/monitoring/templates/grafana/db.yaml
@@ -4,7 +4,9 @@ metadata:
   name: grafana-db
 spec:
   instances: 2
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.7
+  {{- $existingCluster := lookup "postgresql.cnpg.io/v1" "Cluster" .Release.Namespace "grafana-db" }}
+  {{- $image := dig "spec" "imageName" "ghcr.io/cloudnative-pg/postgresql:17.7-standard-trixie" $existingCluster }}
+  imageName: {{ if regexMatch ":17\\." $image }}ghcr.io/cloudnative-pg/postgresql:17.7-standard-trixie{{ else if regexMatch ":[0-9]+\\.[0-9]+$" $image }}{{ printf "%s-standard-trixie" $image }}{{ else }}{{ $image }}{{ end }}
   storage:
     size: {{ .Values.grafana.db.size }}
   {{- if .Values._cluster.scheduling }}

--- a/packages/system/seaweedfs/templates/database.yaml
+++ b/packages/system/seaweedfs/templates/database.yaml
@@ -5,7 +5,9 @@ metadata:
   name: seaweedfs-db
 spec:
   instances: {{ .Values.db.replicas }}
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.7
+  {{- $existingCluster := lookup "postgresql.cnpg.io/v1" "Cluster" .Release.Namespace "seaweedfs-db" }}
+  {{- $image := dig "spec" "imageName" "ghcr.io/cloudnative-pg/postgresql:17.7-standard-trixie" $existingCluster }}
+  imageName: {{ if regexMatch ":17\\." $image }}ghcr.io/cloudnative-pg/postgresql:17.7-standard-trixie{{ else if regexMatch ":[0-9]+\\.[0-9]+$" $image }}{{ printf "%s-standard-trixie" $image }}{{ else }}{{ $image }}{{ end }}
   storage:
     size: {{ .Values.db.size }}
     {{- with .Values.db.storageClass }}


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
Fix system postgresql images to 17.7-standard-trixie
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Database Helm charts now preserve and reuse existing PostgreSQL image settings, normalizing tags to the standard-trixie variant when appropriate.
  * Migration configuration bumped to target version 38.

* **Bug Fixes**
  * Migration logic updated to correctly locate and adjust CNPG Cluster resources and to log per-cluster patch/skip decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->