### PR TITLE
[monitoring] Fix infra dashboards missing in default variant

### DIFF
--- a/packages/system/monitoring/templates/dashboards.yaml
+++ b/packages/system/monitoring/templates/dashboards.yaml
@@ -14,7 +14,7 @@ spec:
   url: http://grafana-dashboards.cozy-grafana-operator.svc/{{ . }}.json
 {{- end }}
 {{- end }}
-{{- if eq .Release.Namespace "tenant-root" }}
+{{- if or (eq .Release.Namespace "tenant-root") (eq .Release.Namespace "cozy-monitoring") }}
 {{- range (split "\n" (.Files.Get "dashboards-infra.list")) }}
 {{- $parts := split "/" . }}
 {{- if eq (len $parts) 2 }}


### PR DESCRIPTION
## What this PR does

- Adds `cozy-monitoring` namespace to the infra dashboards rendering condition in `dashboards.yaml`
- The default variant deploys the monitoring chart to `cozy-monitoring`, but the condition from #2197 only checked for `tenant-root`, causing all infrastructure dashboards to be missing
- This is consistent with the existing pattern in `vmagent.yaml` which already handles both namespaces

## Release note

```release-note
[monitoring] Fix infrastructure dashboards not rendering in default variant where monitoring is deployed to cozy-monitoring namespace
```

Fixes #2349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure & Monitoring**
  * Expanded Grafana dashboard availability across additional deployment environments for infrastructure monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->