### PR TITLE
fix(kubernetes): use full FQDN for kubeadm join apiServerEndpoint

### DIFF
--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -1,6 +1,7 @@
 {{- $etcd := .Values._namespace.etcd }}
 {{- $ingress := .Values._namespace.ingress }}
 {{- $host := .Values._namespace.host }}
+{{- $clusterDomain := (index .Values._cluster "cluster-domain") | default "cluster.local" }}
 {{- $kubevirtmachinetemplateNames := list }}
 {{- define "kubevirtmachinetemplate" -}}
 spec:
@@ -256,7 +257,7 @@ spec:
           - FileExisting-conntrack
         discovery:
           bootstrapToken:
-            apiServerEndpoint: {{ $.Release.Name }}.{{ $.Release.Namespace }}.svc:6443
+            apiServerEndpoint: {{ $.Release.Name }}.{{ $.Release.Namespace }}.svc.{{ $clusterDomain }}:6443
       initConfiguration:
         skipPhases:
         - addon/kube-proxy


### PR DESCRIPTION
## Summary

- Use full FQDN (`<name>.<namespace>.svc.<cluster-domain>:6443`) instead of partial (`<name>.<namespace>.svc:6443`) for the kubeadm join `apiServerEndpoint`
- Read cluster domain from `_cluster.cluster-domain` (same pattern as mongodb, nats, clickhouse charts)

## Problem

KubeVirt worker VMs fail to join managed Kubernetes clusters with `NodeStartupTimeout`. The kubeadm join config uses a partial FQDN:

```yaml
apiServerEndpoint: kubernetes-botz-infra.tenant-simbotix.svc:6443
```

This requires DNS search domain expansion (appending `.cluster.local`) to resolve. However, KubeVirt worker VMs get their DNS via DHCP and do **not** have the cluster's search domains in `/etc/resolv.conf`.

Even from a pod with correct search domains, the partial FQDN fails to resolve:

```
$ nslookup kubernetes-botz-infra.tenant-simbotix.svc
** server can't find kubernetes-botz-infra.tenant-simbotix.svc: NXDOMAIN

$ nslookup kubernetes-botz-infra.tenant-simbotix.svc.cluster.local
Address: 10.96.80.135   ✅
```

## Fix

Append the cluster domain to produce a full FQDN:

```yaml
apiServerEndpoint: kubernetes-botz-infra.tenant-simbotix.svc.cluster.local:6443
```

## Test plan

- [x] Verified partial FQDN returns NXDOMAIN from within cluster
- [x] Verified full FQDN resolves correctly
- [ ] Deploy managed K8s cluster with fix and verify workers join

Fixes #2372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made Kubernetes cluster domain configurable in cluster setup, with a default value maintained for standard deployments. Updated API server endpoint discovery to incorporate the configurable cluster domain during node bootstrap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->