### PR TITLE
[platform] Validate computed tenant namespace length in cozystack-api

### DIFF
--- a/pkg/registry/apps/application/rest.go
+++ b/pkg/registry/apps/application/rest.go
@@ -164,6 +164,17 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 		return nil, apierrors.NewInvalid(r.gvk.GroupKind(), app.Name, nameLenErrs)
 	}
 
+	// For Tenant applications, also validate that the computed workload
+	// namespace fits within the DNS-1123 label limit. A deeply-nested tenant
+	// can exceed the limit even when its own name passes the per-name Helm
+	// release length check, because the namespace is formed from the full
+	// ancestor chain.
+	if r.kindName == "Tenant" {
+		if nsErrs := r.validateTenantNamespaceLength(app.Namespace, app.Name); len(nsErrs) > 0 {
+			return nil, apierrors.NewInvalid(r.gvk.GroupKind(), app.Name, nsErrs)
+		}
+	}
+
 	// Validate that values don't contain reserved keys (starting with "_")
 	if err := validateNoInternalKeys(app.Spec); err != nil {
 		return nil, apierrors.NewBadRequest(err.Error())
@@ -1049,6 +1060,12 @@ func validateNoInternalKeys(values *apiextv1.JSON) error {
 // chart-generated resource suffixes within the 63-char DNS-1035 label limit.
 const maxHelmReleaseName = 53
 
+// maxNamespaceName is the DNS-1123 label limit for Kubernetes namespace names.
+// The tenant Helm chart creates a Namespace whose name is the computed
+// workload namespace (parent namespace + "-" + tenant name), so the total
+// must fit inside a single 63-char DNS-1123 label.
+const maxNamespaceName = 63
+
 // validateNameLength checks that the application name won't exceed Kubernetes limits.
 // prefix + name must fit within the Helm release name limit (53 chars).
 func (r *REST) validateNameLength(name string) field.ErrorList {
@@ -1066,6 +1083,24 @@ func (r *REST) validateNameLength(name string) field.ErrorList {
 	if len(name) > maxLen {
 		allErrs = append(allErrs, field.Invalid(fldPath, name,
 			fmt.Sprintf("must be no more than %d characters (release prefix %q)", maxLen, r.releaseConfig.Prefix)))
+	}
+	return allErrs
+}
+
+// validateTenantNamespaceLength checks that the computed workload namespace
+// for a Tenant application fits within the DNS-1123 label limit. The namespace
+// is formed by dash-joining the parent namespace with the tenant name, so
+// deep nesting can exceed the limit even when each individual name passes the
+// per-name Helm release length check.
+func (r *REST) validateTenantNamespaceLength(currentNamespace, tenantName string) field.ErrorList {
+	fldPath := field.NewPath("metadata").Child("name")
+	allErrs := field.ErrorList{}
+
+	computed := r.computeTenantNamespace(currentNamespace, tenantName)
+	if len(computed) > maxNamespaceName {
+		allErrs = append(allErrs, field.Invalid(fldPath, tenantName,
+			fmt.Sprintf("computed tenant namespace %q would be %d characters, which exceeds the %d-character Kubernetes namespace limit; shorten the tenant name or reduce ancestor nesting depth",
+				computed, len(computed), maxNamespaceName)))
 	}
 	return allErrs
 }

--- a/pkg/registry/apps/application/rest_validation_test.go
+++ b/pkg/registry/apps/application/rest_validation_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package application
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -98,6 +99,104 @@ func TestValidateNameLength(t *testing.T) {
 			}
 			if !tt.wantError && len(errs) > 0 {
 				t.Errorf("unexpected error for name %q (len=%d): %v", tt.appName, len(tt.appName), errs)
+			}
+		})
+	}
+}
+
+// TestValidateTenantNamespaceLength covers the check that the computed
+// workload namespace for a Tenant application fits inside the 63-char
+// DNS-1123 label limit. The namespace is formed by dash-joining the
+// parent namespace with the tenant name, so deep nesting can exceed the
+// limit even when each individual name passes the per-name Helm release
+// length check.
+//
+// The "tenant-root" branches of computeTenantNamespace do not get a
+// dedicated overflow case: that branch produces "tenant-<name>" (7 +
+// len(name)), so for the computed result to exceed 63 chars the name
+// would need to exceed 56 chars, which is already blocked by
+// validateNameLength (max 46 for the "tenant-" prefix). The invariant
+// holds by arithmetic.
+func TestValidateTenantNamespaceLength(t *testing.T) {
+	tests := []struct {
+		name             string
+		currentNamespace string
+		tenantName       string
+		wantError        bool
+	}{
+		{
+			name:             "tenant-root with short name passes",
+			currentNamespace: "tenant-root",
+			tenantName:       "alpha",
+			wantError:        false,
+		},
+		{
+			name:             "root tenant inside root namespace passes",
+			currentNamespace: "tenant-root",
+			tenantName:       "root",
+			wantError:        false,
+		},
+		{
+			name:             "short parent and short name passes",
+			currentNamespace: "tenant-foo",
+			tenantName:       "bar",
+			wantError:        false,
+		},
+		{
+			name:             "exactly at 63-char limit passes",
+			currentNamespace: "tenant-" + strings.Repeat("a", 45), // 52 chars
+			tenantName:       strings.Repeat("b", 10),             // 10 chars -> 52+1+10 = 63
+			wantError:        false,
+		},
+		{
+			name:             "one char over the limit fails",
+			currentNamespace: "tenant-" + strings.Repeat("a", 45), // 52 chars
+			tenantName:       strings.Repeat("b", 11),             // 11 chars -> 52+1+11 = 64
+			wantError:        true,
+		},
+		{
+			name:             "deeply nested failure with issue-style names",
+			currentNamespace: "tenant-" + strings.Repeat("a", 35), // 42 chars
+			tenantName:       strings.Repeat("b", 25),             // 25 chars -> 42+1+25 = 68
+			wantError:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &REST{
+				kindName: "Tenant",
+				releaseConfig: config.ReleaseConfig{
+					Prefix: "tenant-",
+				},
+			}
+
+			errs := r.validateTenantNamespaceLength(tt.currentNamespace, tt.tenantName)
+
+			if tt.wantError && len(errs) == 0 {
+				computed := r.computeTenantNamespace(tt.currentNamespace, tt.tenantName)
+				t.Errorf("expected error for parent=%q name=%q (computed=%q, len=%d), got none",
+					tt.currentNamespace, tt.tenantName, computed, len(computed))
+				return
+			}
+			if !tt.wantError && len(errs) > 0 {
+				t.Errorf("unexpected error for parent=%q name=%q: %v",
+					tt.currentNamespace, tt.tenantName, errs)
+				return
+			}
+
+			// For failing cases, verify the error message surfaces the
+			// computed namespace string and its actual length so a
+			// regression in the message format is caught.
+			if tt.wantError {
+				computed := r.computeTenantNamespace(tt.currentNamespace, tt.tenantName)
+				msg := errs.ToAggregate().Error()
+				if !strings.Contains(msg, computed) {
+					t.Errorf("error message must contain computed namespace %q, got: %s", computed, msg)
+				}
+				if !strings.Contains(msg, fmt.Sprintf("%d characters", len(computed))) {
+					t.Errorf("error message must contain the computed length %d, got: %s", len(computed), msg)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## What this PR does

The aggregated `cozystack-api` validates each individual Tenant name length against the Helm release limit (46 chars for the `tenant-` prefix), but it never validates the **computed workload namespace** that is built by dash-joining the parent namespace with the tenant name. A user can therefore `kubectl apply` a nested `Tenant` whose own name passes the per-name check, only to have Kubernetes later reject the generated `Namespace` for exceeding the 63-character DNS-1123 label limit. The failure surfaces as an opaque HelmRelease reconcile error, and the Tenant CR is left stranded in the cluster with a `status.namespace` that can never exist.

This PR closes that gap at the aggregation layer by rejecting such requests synchronously in `Create()` with a clear `field.Invalid` error that names the computed namespace and its length, so the failure is reported at `kubectl apply` time before any HelmRelease is created.

The change is scoped to the `Tenant` kind only. `Update()` is not touched because Kubernetes names and namespaces are immutable and the existing code already intentionally skips name validation there. No Helm chart, CRD, or codegen changes are required.

The PR is split into two commits that document the bug and its fix via TDD:

1. **Pin the gap** — adds a test that demonstrates the pre-fix behavior: the pre-fix Create() path has no function that rejects a realistic nested-tenant combination whose computed namespace exceeds 63 chars. Reviewers can check out this commit and observe the gap.
2. **The fix** — adds `validateTenantNamespaceLength`, the `kindName == "Tenant"` gate in `Create()`, and `TestValidateTenantNamespaceLength` covering boundary cases (pass at 63, fail at 64, fail at 68). The pinning test from commit 1 is removed in the same commit now that the gap is closed.

### Release note

```release-note
[platform] cozystack-api now rejects Tenant creation at admission time when the ancestor-chain namespace would exceed the 63-character Kubernetes namespace limit, instead of allowing the resource through and failing later at HelmRelease reconcile.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tenant application creation now validates computed tenant namespace length against the Kubernetes DNS-1123 63-character limit; creations that would produce too-long namespace names now fail with a clear validation error.

* **Tests**
  * Added tests covering tenant namespace length validation, including multiple parent/tenant-name scenarios, boundary conditions, and verification that error messages include the offending namespace and its length.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->