### PR TITLE
[api] Reject tenant names with dashes at Create time

### DIFF
--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -222,8 +222,12 @@ EOF
   # server-side name check runs and the error we grep for is the tenant
   # contract error, not a kubectl schema rejection. (--validate=false is the
   # deprecated alias.)
-  local output
-  output=$(kubectl apply --validate=ignore -f - <<EOF 2>&1 || true
+  local output rc
+  # Run the apply in its own subshell so we can capture BOTH stdout+stderr
+  # AND the exit code explicitly, without `|| true` swallowing a real failure
+  # mode (e.g. network error, auth failure) that should also fail the test.
+  output=$(
+    kubectl apply --validate=ignore -f - 2>&1 <<EOF
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Tenant
 metadata:
@@ -231,12 +235,15 @@ metadata:
   namespace: tenant-root
 spec: {}
 EOF
-)
+  ) && rc=0 || rc=$?
+  echo "kubectl apply exit=$rc, output=$output"
+  # kubectl MUST have failed: success would mean validation regressed.
+  [ "$rc" -ne 0 ]
   # Assert the tenant-specific message is present (distinguishes from
   # generic DNS-1035 errors and from network/auth failures).
   echo "$output" | grep -q "tenant names must"
-  # And assert kubectl did NOT report creation — if validation regressed,
-  # the server would accept the object and kubectl would print "... created".
+  # And assert kubectl did NOT report creation — if validation regressed
+  # into a "warn" variant, the server could still accept the object.
   ! echo "$output" | grep -qi "created"
 
   # Post-condition cleanup: even though we expect validation to reject the

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -200,8 +200,28 @@ EOF
   kubectl wait hr/keycloak hr/keycloak-configure hr/keycloak-operator -n cozy-keycloak --timeout=10m --for=condition=ready
 }
 
+@test "Aggregated API rejects Tenant name with dashes" {
+  # Regression guard: the tenant Helm chart's tenant.name helper splits the
+  # Release.Name on "-" and fails unless the result is exactly
+  # ["tenant", "<name>"]. The aggregated API must catch tenant names
+  # containing dashes up-front with a tenant-specific error, instead of
+  # silently accepting the Application and letting Flux fail later.
+  local output
+  output=$(kubectl apply -f - <<EOF 2>&1 || true
+apiVersion: apps.cozystack.io/v1alpha1
+kind: Tenant
+metadata:
+  name: foo-bar
+  namespace: tenant-root
+spec: {}
+EOF
+)
+  echo "$output" | grep -q "tenant names must"
+  ! echo "$output" | grep -qi "created"
+}
+
 @test "Create tenant with isolated mode enabled" {
-  kubectl -n tenant-root get tenants.apps.cozystack.io test || 
+  kubectl -n tenant-root get tenants.apps.cozystack.io test ||
   kubectl apply -f - <<EOF
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Tenant

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -207,17 +207,23 @@ EOF
   # containing dashes up-front with a tenant-specific error, instead of
   # silently accepting the Application and letting Flux fail later.
 
+  # Defensive cleanup: if a prior regression left foo-bar in the cluster,
+  # remove it before exercising the validation so we are not observing
+  # stale state. Safe even in the happy path because of --ignore-not-found.
+  kubectl delete tenants.apps.cozystack.io foo-bar -n tenant-root --ignore-not-found
+
   # Preflight: tenant-root is created by earlier tests in this suite. Fail
   # loudly if it is missing so this test does not silently trigger an
   # unrelated "namespace not found" error and misreport as a pass.
   kubectl get namespace tenant-root
 
-  # --validate=false forces kubectl to skip client-side OpenAPI validation
+  # --validate=ignore forces kubectl to skip client-side OpenAPI validation
   # and send the payload straight to the aggregated API. This guarantees the
   # server-side name check runs and the error we grep for is the tenant
-  # contract error, not a kubectl schema rejection.
+  # contract error, not a kubectl schema rejection. (--validate=false is the
+  # deprecated alias.)
   local output
-  output=$(kubectl apply --validate=false -f - <<EOF 2>&1 || true
+  output=$(kubectl apply --validate=ignore -f - <<EOF 2>&1 || true
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Tenant
 metadata:
@@ -232,6 +238,11 @@ EOF
   # And assert kubectl did NOT report creation — if validation regressed,
   # the server would accept the object and kubectl would print "... created".
   ! echo "$output" | grep -qi "created"
+
+  # Post-condition cleanup: even though we expect validation to reject the
+  # create, removing foo-bar unconditionally keeps the cluster clean for
+  # subsequent tests in case validation regresses and the object is created.
+  kubectl delete tenants.apps.cozystack.io foo-bar -n tenant-root --ignore-not-found
 }
 
 @test "Create tenant with isolated mode enabled" {

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -206,8 +206,18 @@ EOF
   # ["tenant", "<name>"]. The aggregated API must catch tenant names
   # containing dashes up-front with a tenant-specific error, instead of
   # silently accepting the Application and letting Flux fail later.
+
+  # Preflight: tenant-root is created by earlier tests in this suite. Fail
+  # loudly if it is missing so this test does not silently trigger an
+  # unrelated "namespace not found" error and misreport as a pass.
+  kubectl get namespace tenant-root
+
+  # --validate=false forces kubectl to skip client-side OpenAPI validation
+  # and send the payload straight to the aggregated API. This guarantees the
+  # server-side name check runs and the error we grep for is the tenant
+  # contract error, not a kubectl schema rejection.
   local output
-  output=$(kubectl apply -f - <<EOF 2>&1 || true
+  output=$(kubectl apply --validate=false -f - <<EOF 2>&1 || true
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Tenant
 metadata:
@@ -216,7 +226,11 @@ metadata:
 spec: {}
 EOF
 )
+  # Assert the tenant-specific message is present (distinguishes from
+  # generic DNS-1035 errors and from network/auth failures).
   echo "$output" | grep -q "tenant names must"
+  # And assert kubectl did NOT report creation — if validation regressed,
+  # the server would accept the object and kubectl would print "... created".
   ! echo "$output" | grep -qi "created"
 }
 

--- a/packages/apps/tenant/README.md
+++ b/packages/apps/tenant/README.md
@@ -6,15 +6,15 @@ Tenants can be created recursively and are subject to the following rules:
 
 ### Tenant naming
 
-Tenant names must follow DNS-1035 naming rules:
--   Must start with a lowercase letter (`a-z`)
--   Can only contain lowercase letters, numbers, and hyphens (`a-z`, `0-9`, `-`)
--   Must end with a letter or number (not a hyphen)
+Tenant names must be alphanumeric:
+
+-   Lowercase letters (`a-z`) and digits (`0-9`) only
+-   Must start with a lowercase letter
+-   Dashes (`-`) are **not allowed**, unlike with other services
 -   Maximum length depends on the cluster configuration (Helm release prefix and root domain)
 
-**Note:** Using dashes (`-`) in tenant names is **allowed but discouraged**, unlike with other services.
-This is to keep consistent naming in tenants, nested tenants, and services deployed in them.
-Names with dashes (e.g., `foo-bar`) may lead to ambiguous parsing of internal resource names like `tenant-foo-bar`.
+This restriction exists to keep consistent naming in tenants, nested tenants, and services deployed in them.
+A tenant cannot be named `foo-bar` because parsing internal resource names like `tenant-foo-bar` would be ambiguous.
 
 For example:
 

--- a/pkg/apis/apps/validation/validation.go
+++ b/pkg/apis/apps/validation/validation.go
@@ -17,20 +17,42 @@ limitations under the License.
 package validation
 
 import (
+	"regexp"
+
 	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-// ValidateApplicationName validates that an Application name conforms to DNS-1035.
-// This is required because Application names are used to create Kubernetes resources
-// (Services, Namespaces, etc.) that must have DNS-1035 compliant names.
-// Note: length validation is handled separately by validateNameLength in the REST
-// handler, which computes dynamic limits based on Helm release prefix.
-func ValidateApplicationName(name string, fldPath *field.Path) field.ErrorList {
+// tenantNameRegex enforces alphanumeric-only tenant names. This is stricter
+// than DNS-1035 because the tenant Helm chart's tenant.name helper
+// (packages/apps/tenant/templates/_helpers.tpl) splits Release.Name on "-"
+// and fails unless the result is exactly ["tenant", "<name>"]. Any dash
+// inside <name> would break that invariant at Helm template time, so the
+// aggregated API must reject such names up-front with a specific error.
+var tenantNameRegex = regexp.MustCompile(`^[a-z0-9]+$`)
+
+// ValidateApplicationName validates that an Application name is acceptable for
+// the given kind. All applications must conform to DNS-1035 because their
+// names are used to create Kubernetes resources (Services, Namespaces, etc.)
+// that require DNS-1035 compliance. Tenant applications additionally must be
+// alphanumeric (no dashes) because of the Helm chart constraint described on
+// tenantNameRegex.
+// Note: length validation is handled separately by validateNameLength in the
+// REST handler, which computes dynamic limits based on Helm release prefix.
+func ValidateApplicationName(name, kindName string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(name) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath, "name is required"))
+		return allErrs
+	}
+
+	// Tenant names must be alphanumeric — see tenantNameRegex comment for the
+	// reason. Check before DNS-1035 so the error message is specific to the
+	// tenant contract, not the generic DNS label rules.
+	if kindName == "Tenant" && !tenantNameRegex.MatchString(name) {
+		allErrs = append(allErrs, field.Invalid(fldPath, name,
+			"tenant names must be alphanumeric (lowercase letters and digits only); dashes are not allowed"))
 		return allErrs
 	}
 

--- a/pkg/apis/apps/validation/validation.go
+++ b/pkg/apis/apps/validation/validation.go
@@ -23,20 +23,23 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-// tenantNameRegex enforces alphanumeric-only tenant names. This is stricter
-// than DNS-1035 because the tenant Helm chart's tenant.name helper
-// (packages/apps/tenant/templates/_helpers.tpl) splits Release.Name on "-"
-// and fails unless the result is exactly ["tenant", "<name>"]. Any dash
-// inside <name> would break that invariant at Helm template time, so the
-// aggregated API must reject such names up-front with a specific error.
-var tenantNameRegex = regexp.MustCompile(`^[a-z0-9]+$`)
+// tenantNameRegex enforces alphanumeric-only tenant names that begin with a
+// lowercase letter. This is stricter than DNS-1035 because the tenant Helm
+// chart's tenant.name helper (packages/apps/tenant/templates/_helpers.tpl)
+// splits Release.Name on "-" and fails unless the result is exactly
+// ["tenant", "<name>"]. Any dash inside <name> would break that invariant at
+// Helm template time, so the aggregated API must reject such names up-front
+// with a specific error. Requiring a leading letter (rather than letting
+// leading-digit names fall through to DNS-1035) keeps the error message
+// tenant-specific for all invalid inputs.
+var tenantNameRegex = regexp.MustCompile(`^[a-z][a-z0-9]*$`)
 
 // ValidateApplicationName validates that an Application name is acceptable for
 // the given kind. All applications must conform to DNS-1035 because their
 // names are used to create Kubernetes resources (Services, Namespaces, etc.)
 // that require DNS-1035 compliance. Tenant applications additionally must be
-// alphanumeric (no dashes) because of the Helm chart constraint described on
-// tenantNameRegex.
+// alphanumeric and begin with a lowercase letter because of the Helm chart
+// constraint described on tenantNameRegex.
 // Note: length validation is handled separately by validateNameLength in the
 // REST handler, which computes dynamic limits based on Helm release prefix.
 func ValidateApplicationName(name, kindName string, fldPath *field.Path) field.ErrorList {
@@ -47,12 +50,13 @@ func ValidateApplicationName(name, kindName string, fldPath *field.Path) field.E
 		return allErrs
 	}
 
-	// Tenant names must be alphanumeric — see tenantNameRegex comment for the
-	// reason. Check before DNS-1035 so the error message is specific to the
-	// tenant contract, not the generic DNS label rules.
+	// Tenant names must be alphanumeric starting with a letter — see
+	// tenantNameRegex comment for the reason. Check before DNS-1035 so the
+	// error message is specific to the tenant contract, not the generic DNS
+	// label rules.
 	if kindName == "Tenant" && !tenantNameRegex.MatchString(name) {
 		allErrs = append(allErrs, field.Invalid(fldPath, name,
-			"tenant names must be alphanumeric (lowercase letters and digits only); dashes are not allowed"))
+			"tenant names must start with a lowercase letter and contain only lowercase letters and digits; dashes are not allowed"))
 		return allErrs
 	}
 

--- a/pkg/apis/apps/validation/validation.go
+++ b/pkg/apis/apps/validation/validation.go
@@ -23,6 +23,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
+// TenantKind is the Application.Kind string that gates the tenant-specific
+// name rules below. It must stay in sync with the `kind` field of the tenant
+// ApplicationDefinition (packages/system/tenant-rd/cozyrds/tenant.yaml) which
+// is the upstream source the aggregated API reads at startup via
+// config.Application.Kind.
+const TenantKind = "Tenant"
+
 // tenantNameRegex enforces alphanumeric-only tenant names that begin with a
 // lowercase letter. This is stricter than DNS-1035 because the tenant Helm
 // chart's tenant.name helper (packages/apps/tenant/templates/_helpers.tpl)
@@ -54,7 +61,7 @@ func ValidateApplicationName(name, kindName string, fldPath *field.Path) field.E
 	// tenantNameRegex comment for the reason. Check before DNS-1035 so the
 	// error message is specific to the tenant contract, not the generic DNS
 	// label rules.
-	if kindName == "Tenant" && !tenantNameRegex.MatchString(name) {
+	if kindName == TenantKind && !tenantNameRegex.MatchString(name) {
 		allErrs = append(allErrs, field.Invalid(fldPath, name,
 			"tenant names must start with a lowercase letter and contain only lowercase letters and digits; dashes are not allowed"))
 		return allErrs

--- a/pkg/apis/apps/validation/validation_test.go
+++ b/pkg/apis/apps/validation/validation_test.go
@@ -27,54 +27,76 @@ func TestValidateApplicationName(t *testing.T) {
 	tests := []struct {
 		name      string
 		appName   string
+		kindName  string
 		wantError bool
 	}{
-		// Valid names
-		{"valid simple name", "tenant-one", false},
-		{"valid single letter", "a", false},
-		{"valid with numbers", "abc-123", false},
-		{"valid lowercase", "my-tenant", false},
-		{"valid long name", "my-very-long-tenant-name", false},
-		{"valid double hyphen", "my--tenant", false},
-		{"valid at DNS-1035 max (63 chars)", strings.Repeat("a", 63), false},
+		// Valid names (non-tenant kinds permit DNS-1035 including hyphens)
+		{"valid simple name", "tenant-one", "MySQL", false},
+		{"valid single letter", "a", "MySQL", false},
+		{"valid with numbers", "abc-123", "MySQL", false},
+		{"valid lowercase", "my-tenant", "MySQL", false},
+		{"valid long name", "my-very-long-tenant-name", "MySQL", false},
+		{"valid double hyphen", "my--tenant", "MySQL", false},
+		{"valid at DNS-1035 max (63 chars)", strings.Repeat("a", 63), "MySQL", false},
+		{"valid with empty kind", "my-db", "", false},
 
 		// Invalid: starts with wrong character
-		{"starts with digit", "1john", true},
-		{"only digits", "123", true},
-		{"starts with hyphen", "-tenant", true},
+		{"starts with digit", "1john", "MySQL", true},
+		{"only digits", "123", "MySQL", true},
+		{"starts with hyphen", "-tenant", "MySQL", true},
 
 		// Invalid: ends with wrong character
-		{"ends with hyphen", "tenant-", true},
+		{"ends with hyphen", "tenant-", "MySQL", true},
 
 		// Invalid: wrong characters
-		{"uppercase letters", "Tenant", true},
-		{"mixed case", "myTenant", true},
-		{"underscore", "my_tenant", true},
-		{"dot", "my.tenant", true},
-		{"space", "my tenant", true},
-		{"unicode cyrillic", "тенант", true},
-		{"unicode emoji", "tenant🚀", true},
-		{"special chars", "tenant@home", true},
-		{"colon", "tenant:one", true},
-		{"slash", "tenant/one", true},
+		{"uppercase letters", "Tenant", "MySQL", true},
+		{"mixed case", "myTenant", "MySQL", true},
+		{"underscore", "my_tenant", "MySQL", true},
+		{"dot", "my.tenant", "MySQL", true},
+		{"space", "my tenant", "MySQL", true},
+		{"unicode cyrillic", "тенант", "MySQL", true},
+		{"unicode emoji", "tenant🚀", "MySQL", true},
+		{"special chars", "tenant@home", "MySQL", true},
+		{"colon", "tenant:one", "MySQL", true},
+		{"slash", "tenant/one", "MySQL", true},
 
 		// Invalid: empty or whitespace
-		{"empty string", "", true},
-		{"only spaces", "   ", true},
-		{"leading space", " tenant", true},
-		{"trailing space", "tenant ", true},
+		{"empty string", "", "MySQL", true},
+		{"only spaces", "   ", "MySQL", true},
+		{"leading space", " tenant", "MySQL", true},
+		{"trailing space", "tenant ", "MySQL", true},
 
 		// Invalid: exceeds DNS-1035 max length (63)
-		{"too long (64 chars)", strings.Repeat("a", 64), true},
-		{"way too long (100 chars)", strings.Repeat("a", 100), true},
+		{"too long (64 chars)", strings.Repeat("a", 64), "MySQL", true},
+		{"way too long (100 chars)", strings.Repeat("a", 100), "MySQL", true},
+
+		// Tenant kind: stricter alphanumeric-only rule.
+		// The tenant Helm chart's tenant.name helper (packages/apps/tenant/templates/_helpers.tpl)
+		// splits Release.Name on "-" and fails unless the result is exactly
+		// ["tenant", "<name>"]. Any dash inside <name> breaks that invariant, so
+		// the aggregated API must reject tenant names containing dashes up-front
+		// with a specific error — instead of letting Flux reconciliation fail later.
+		{"tenant alphanumeric simple", "foo", "Tenant", false},
+		{"tenant alphanumeric with digits", "foo123", "Tenant", false},
+		{"tenant single char", "a", "Tenant", false},
+		{"tenant single hyphen", "foo-bar", "Tenant", true},
+		{"tenant leading hyphen", "-foo", "Tenant", true},
+		{"tenant trailing hyphen", "foo-", "Tenant", true},
+		{"tenant double hyphen", "foo--bar", "Tenant", true},
+		{"tenant uppercase", "Foo", "Tenant", true},
+		{"tenant underscore", "foo_bar", "Tenant", true},
+		{"tenant empty", "", "Tenant", true},
+		// Leading digit is alphanumeric (tenant regex passes) but falls through
+		// to DNS-1035, which requires a leading alphabetic character.
+		{"tenant leading digit", "123foo", "Tenant", true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errs := ValidateApplicationName(tt.appName, field.NewPath("metadata").Child("name"))
+			errs := ValidateApplicationName(tt.appName, tt.kindName, field.NewPath("metadata").Child("name"))
 			if (len(errs) > 0) != tt.wantError {
-				t.Errorf("ValidateApplicationName(%q) returned %d errors, wantError = %v, errors = %v",
-					tt.appName, len(errs), tt.wantError, errs)
+				t.Errorf("ValidateApplicationName(%q, kind=%q) returned %d errors, wantError = %v, errors = %v",
+					tt.appName, tt.kindName, len(errs), tt.wantError, errs)
 			}
 		})
 	}

--- a/pkg/apis/apps/validation/validation_test.go
+++ b/pkg/apis/apps/validation/validation_test.go
@@ -159,11 +159,10 @@ func TestValidateApplicationName_TenantLengthFallthrough(t *testing.T) {
 		t.Fatalf("expected DNS-1035 length error for 64-char tenant name, got none")
 	}
 	// This error is the generic DNS-1035 one, NOT the tenant-specific message.
+	// We deliberately do not assert against the exact upstream DNS-1035 text
+	// (that would tie this test to a k8s.io/apimachinery internal string and
+	// break on unrelated upstream wording changes).
 	if strings.Contains(errs[0].Detail, "tenant names must") {
 		t.Errorf("64-char tenant name should surface the generic DNS-1035 error, got tenant-specific: %q", errs[0].Detail)
-	}
-	// Sanity check: the DNS-1035 error we do expect mentions length bounds.
-	if !strings.Contains(errs[0].Detail, "63") {
-		t.Errorf("expected DNS-1035 length hint in error detail, got: %q", errs[0].Detail)
 	}
 }

--- a/pkg/apis/apps/validation/validation_test.go
+++ b/pkg/apis/apps/validation/validation_test.go
@@ -86,8 +86,9 @@ func TestValidateApplicationName(t *testing.T) {
 		{"tenant uppercase", "Foo", "Tenant", true},
 		{"tenant underscore", "foo_bar", "Tenant", true},
 		{"tenant empty", "", "Tenant", true},
-		// Leading digit is alphanumeric (tenant regex passes) but falls through
-		// to DNS-1035, which requires a leading alphabetic character.
+		// Leading digit must be caught by the tenant-specific regex (not by
+		// falling through to DNS-1035) so the error message reflects the
+		// tenant contract — see TestValidateApplicationName_TenantErrorMessage.
 		{"tenant leading digit", "123foo", "Tenant", true},
 	}
 
@@ -97,6 +98,44 @@ func TestValidateApplicationName(t *testing.T) {
 			if (len(errs) > 0) != tt.wantError {
 				t.Errorf("ValidateApplicationName(%q, kind=%q) returned %d errors, wantError = %v, errors = %v",
 					tt.appName, tt.kindName, len(errs), tt.wantError, errs)
+			}
+		})
+	}
+}
+
+// TestValidateApplicationName_TenantErrorMessage pins the contract that when
+// a tenant name is invalid, the returned error message is specific to the
+// tenant naming rule — not the generic DNS-1035 message. Otherwise users get
+// back "must start with an alphabetic character" or similar and have no way
+// to know the constraint is tied to the tenant Helm chart.
+func TestValidateApplicationName_TenantErrorMessage(t *testing.T) {
+	// Every tenant-invalid name below must surface a tenant-specific error
+	// message. In particular, "123foo" starts with a digit — the original
+	// implementation let that fall through to DNS-1035 with a generic error;
+	// the regex is tightened specifically so this case fails up-front.
+	invalidTenantNames := []string{
+		"foo-bar",  // dash
+		"-foo",     // leading dash
+		"foo-",     // trailing dash
+		"foo--bar", // double dash
+		"Foo",      // uppercase
+		"foo_bar",  // underscore
+		"foo.bar",  // dot
+		"foo bar",  // space
+		"123foo",   // leading digit — must not fall through to DNS-1035
+	}
+
+	const wantSubstring = "tenant names must"
+
+	for _, name := range invalidTenantNames {
+		t.Run(name, func(t *testing.T) {
+			errs := ValidateApplicationName(name, "Tenant", field.NewPath("metadata").Child("name"))
+			if len(errs) == 0 {
+				t.Fatalf("expected error for tenant name %q, got none", name)
+			}
+			if !strings.Contains(errs[0].Detail, wantSubstring) {
+				t.Errorf("tenant name %q: error detail = %q, want substring %q (generic DNS-1035 message is not tenant-specific)",
+					name, errs[0].Detail, wantSubstring)
 			}
 		})
 	}

--- a/pkg/apis/apps/validation/validation_test.go
+++ b/pkg/apis/apps/validation/validation_test.go
@@ -140,3 +140,30 @@ func TestValidateApplicationName_TenantErrorMessage(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateApplicationName_TenantLengthFallthrough documents the one
+// invalid-tenant case where the error message is intentionally NOT tenant-
+// specific: when a name contains only valid tenant characters but exceeds
+// the DNS-1035 63-char label limit, the length error comes from DNS-1035
+// because length is not a tenant-specific constraint (every application
+// kind is subject to the same Kubernetes label limit). REST.validateNameLength
+// further tightens the limit using the Helm release prefix, so tenants cannot
+// actually reach 64 characters end-to-end — this test only pins the package-
+// level fallthrough so a future refactor does not accidentally promote the
+// length error into tenant-specific wording.
+func TestValidateApplicationName_TenantLengthFallthrough(t *testing.T) {
+	name := strings.Repeat("a", 64) // valid tenant pattern, too long for DNS-1035
+
+	errs := ValidateApplicationName(name, "Tenant", field.NewPath("metadata").Child("name"))
+	if len(errs) == 0 {
+		t.Fatalf("expected DNS-1035 length error for 64-char tenant name, got none")
+	}
+	// This error is the generic DNS-1035 one, NOT the tenant-specific message.
+	if strings.Contains(errs[0].Detail, "tenant names must") {
+		t.Errorf("64-char tenant name should surface the generic DNS-1035 error, got tenant-specific: %q", errs[0].Detail)
+	}
+	// Sanity check: the DNS-1035 error we do expect mentions length bounds.
+	if !strings.Contains(errs[0].Detail, "63") {
+		t.Errorf("expected DNS-1035 length hint in error detail, got: %q", errs[0].Detail)
+	}
+}

--- a/pkg/apis/apps/validation/validation_test.go
+++ b/pkg/apis/apps/validation/validation_test.go
@@ -151,6 +151,12 @@ func TestValidateApplicationName_TenantErrorMessage(t *testing.T) {
 // actually reach 64 characters end-to-end — this test only pins the package-
 // level fallthrough so a future refactor does not accidentally promote the
 // length error into tenant-specific wording.
+//
+// NOTE: this is an architectural decision, not a user-facing requirement.
+// If tenant length is ever promoted into a tenant-specific rule (e.g. to
+// include the Helm release prefix budget in this package's error message),
+// this test should be updated or deleted — it is not a backwards-compat
+// guarantee, just a checkpoint on the current layering.
 func TestValidateApplicationName_TenantLengthFallthrough(t *testing.T) {
 	name := strings.Repeat("a", 64) // valid tenant pattern, too long for DNS-1035
 

--- a/pkg/registry/apps/application/rest.go
+++ b/pkg/registry/apps/application/rest.go
@@ -154,8 +154,8 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 		return nil, fmt.Errorf("expected *appsv1alpha1.Application object, got %T", obj)
 	}
 
-	// Validate Application name conforms to DNS-1035
-	if errs := validation.ValidateApplicationName(app.Name, field.NewPath("metadata").Child("name")); len(errs) > 0 {
+	// Validate Application name format (DNS-1035 plus any kind-specific rules)
+	if errs := r.validateNameFormat(app.Name); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(r.gvk.GroupKind(), app.Name, errs)
 	}
 
@@ -1065,6 +1065,13 @@ const maxHelmReleaseName = 53
 // workload namespace (parent namespace + "-" + tenant name), so the total
 // must fit inside a single 63-char DNS-1123 label.
 const maxNamespaceName = 63
+
+// validateNameFormat checks an Application name against DNS-1035 and any
+// kind-specific format rules (e.g. Tenant names must be alphanumeric — see
+// validation.ValidateApplicationName for the reasoning).
+func (r *REST) validateNameFormat(name string) field.ErrorList {
+	return validation.ValidateApplicationName(name, r.kindName, field.NewPath("metadata").Child("name"))
+}
 
 // validateNameLength checks that the application name won't exceed Kubernetes limits.
 // prefix + name must fit within the Helm release name limit (53 chars).

--- a/pkg/registry/apps/application/rest.go
+++ b/pkg/registry/apps/application/rest.go
@@ -1153,7 +1153,7 @@ func (r *REST) convertHelmReleaseToApplication(ctx context.Context, hr *helmv2.H
 	app.SetConditions(conditions)
 
 	// Add namespace field for Tenant applications
-	if r.kindName == "Tenant" {
+	if r.kindName == validation.TenantKind {
 		app.Status.Namespace = r.computeTenantNamespace(hr.Namespace, app.Name)
 		externalIPsCount, err := r.countTenantExternalIPs(ctx, app.Status.Namespace)
 		if err != nil {

--- a/pkg/registry/apps/application/rest_validation_test.go
+++ b/pkg/registry/apps/application/rest_validation_test.go
@@ -24,6 +24,46 @@ import (
 	"github.com/cozystack/cozystack/pkg/config"
 )
 
+func TestValidateNameFormat(t *testing.T) {
+	tests := []struct {
+		name      string
+		kindName  string
+		appName   string
+		wantError bool
+	}{
+		// Non-tenant kinds follow DNS-1035 only — hyphens are allowed.
+		{"non-tenant accepts hyphen", "MySQL", "my-db", false},
+		{"non-tenant accepts double hyphen", "MySQL", "my--db", false},
+		{"non-tenant rejects uppercase", "MySQL", "MyDB", true},
+
+		// Tenant kind enforces alphanumeric-only — see
+		// packages/apps/tenant/templates/_helpers.tpl for the reason.
+		{"tenant accepts alphanumeric", "Tenant", "foo", false},
+		{"tenant accepts digits", "Tenant", "foo123", false},
+		{"tenant rejects single hyphen", "Tenant", "foo-bar", true},
+		{"tenant rejects leading hyphen", "Tenant", "-foo", true},
+		{"tenant rejects trailing hyphen", "Tenant", "foo-", true},
+		{"tenant rejects uppercase", "Tenant", "Foo", true},
+		{"tenant rejects underscore", "Tenant", "foo_bar", true},
+		{"tenant rejects empty", "Tenant", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &REST{kindName: tt.kindName}
+
+			errs := r.validateNameFormat(tt.appName)
+
+			if tt.wantError && len(errs) == 0 {
+				t.Errorf("expected error for name %q (kind=%q), got none", tt.appName, tt.kindName)
+			}
+			if !tt.wantError && len(errs) > 0 {
+				t.Errorf("unexpected error for name %q (kind=%q): %v", tt.appName, tt.kindName, errs)
+			}
+		})
+	}
+}
+
 func TestValidateNameLength(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/registry/apps/application/rest_validation_test.go
+++ b/pkg/registry/apps/application/rest_validation_test.go
@@ -51,14 +51,14 @@ func TestValidateNameFormat(t *testing.T) {
 
 		// Tenant kind enforces alphanumeric-only — see
 		// packages/apps/tenant/templates/_helpers.tpl for the reason.
-		{"tenant accepts alphanumeric", "Tenant", "foo", false},
-		{"tenant accepts digits", "Tenant", "foo123", false},
-		{"tenant rejects single hyphen", "Tenant", "foo-bar", true},
-		{"tenant rejects leading hyphen", "Tenant", "-foo", true},
-		{"tenant rejects trailing hyphen", "Tenant", "foo-", true},
-		{"tenant rejects uppercase", "Tenant", "Foo", true},
-		{"tenant rejects underscore", "Tenant", "foo_bar", true},
-		{"tenant rejects empty", "Tenant", "", true},
+		{"tenant accepts alphanumeric", validation.TenantKind, "foo", false},
+		{"tenant accepts digits", validation.TenantKind, "foo123", false},
+		{"tenant rejects single hyphen", validation.TenantKind, "foo-bar", true},
+		{"tenant rejects leading hyphen", validation.TenantKind, "-foo", true},
+		{"tenant rejects trailing hyphen", validation.TenantKind, "foo-", true},
+		{"tenant rejects uppercase", validation.TenantKind, "Foo", true},
+		{"tenant rejects underscore", validation.TenantKind, "foo_bar", true},
+		{"tenant rejects empty", validation.TenantKind, "", true},
 	}
 
 	for _, tt := range tests {
@@ -96,7 +96,7 @@ func TestUpdate_ForceAllowCreate_RejectsTenantDashName(t *testing.T) {
 	resourceCfg := &config.ResourceConfig{
 		Resources: []config.Resource{
 			{
-				Application: config.ApplicationConfig{Kind: "Tenant"},
+				Application: config.ApplicationConfig{Kind: validation.TenantKind},
 			},
 		},
 	}
@@ -116,9 +116,9 @@ func TestUpdate_ForceAllowCreate_RejectsTenantDashName(t *testing.T) {
 		gvk: schema.GroupVersionKind{
 			Group:   appsv1alpha1.GroupName,
 			Version: "v1alpha1",
-			Kind:    "Tenant",
+			Kind:    validation.TenantKind,
 		},
-		kindName: "Tenant",
+		kindName: validation.TenantKind,
 		releaseConfig: config.ReleaseConfig{
 			Prefix: "tenant-",
 		},
@@ -127,7 +127,7 @@ func TestUpdate_ForceAllowCreate_RejectsTenantDashName(t *testing.T) {
 	newApp := &appsv1alpha1.Application{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps.cozystack.io/v1alpha1",
-			Kind:       "Tenant",
+			Kind:       validation.TenantKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo-bar",

--- a/pkg/registry/apps/application/rest_validation_test.go
+++ b/pkg/registry/apps/application/rest_validation_test.go
@@ -17,10 +17,21 @@ limitations under the License.
 package application
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appsv1alpha1 "github.com/cozystack/cozystack/pkg/apis/apps/v1alpha1"
 	"github.com/cozystack/cozystack/pkg/config"
 )
 
@@ -61,6 +72,85 @@ func TestValidateNameFormat(t *testing.T) {
 				t.Errorf("unexpected error for name %q (kind=%q): %v", tt.appName, tt.kindName, errs)
 			}
 		})
+	}
+}
+
+// TestUpdate_ForceAllowCreate_RejectsTenantDashName pins the wiring from the
+// Update → Create fall-through path. When a user runs `kubectl apply` and
+// the object does not yet exist, Kubernetes routes the request through
+// REST.Update with forceAllowCreate=true, which delegates to REST.Create
+// (rest.go:452). This test ensures tenant name validation fires on that
+// upsert path — otherwise a future refactor could silently regress the
+// fix for #2375 while unit tests of r.validateNameFormat alone keep passing.
+func TestUpdate_ForceAllowCreate_RejectsTenantDashName(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := helmv2.AddToScheme(scheme); err != nil {
+		t.Fatalf("register helmv2 scheme: %v", err)
+	}
+	// Register the dynamic Tenant kind so the Application type round-trips
+	// through the scheme the same way the real aggregated API server wires
+	// it at startup.
+	resourceCfg := &config.ResourceConfig{
+		Resources: []config.Resource{
+			{
+				Application: config.ApplicationConfig{Kind: "Tenant"},
+			},
+		},
+	}
+	if err := appsv1alpha1.RegisterDynamicTypes(scheme, resourceCfg); err != nil {
+		t.Fatalf("register dynamic Tenant type: %v", err)
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	r := &REST{
+		c: fakeClient,
+		gvr: schema.GroupVersionResource{
+			Group:    appsv1alpha1.GroupName,
+			Version:  "v1alpha1",
+			Resource: "tenants",
+		},
+		gvk: schema.GroupVersionKind{
+			Group:   appsv1alpha1.GroupName,
+			Version: "v1alpha1",
+			Kind:    "Tenant",
+		},
+		kindName: "Tenant",
+		releaseConfig: config.ReleaseConfig{
+			Prefix: "tenant-",
+		},
+	}
+
+	newApp := &appsv1alpha1.Application{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps.cozystack.io/v1alpha1",
+			Kind:       "Tenant",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo-bar",
+			Namespace: "tenant-root",
+		},
+	}
+
+	ctx := request.WithNamespace(context.Background(), "tenant-root")
+
+	_, _, err := r.Update(
+		ctx,
+		"foo-bar",
+		rest.DefaultUpdatedObjectInfo(newApp),
+		nil,                      // createValidation
+		nil,                      // updateValidation
+		true,                     // forceAllowCreate → routes through Create on NotFound
+		&metav1.UpdateOptions{},
+	)
+	if err == nil {
+		t.Fatalf("expected Update to reject tenant name with dashes, got no error")
+	}
+	if !apierrors.IsInvalid(err) {
+		t.Errorf("expected Invalid status error, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "tenant names must") {
+		t.Errorf("expected tenant-specific error in %q", err.Error())
 	}
 }
 

--- a/pkg/registry/apps/application/rest_validation_test.go
+++ b/pkg/registry/apps/application/rest_validation_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	appsv1alpha1 "github.com/cozystack/cozystack/pkg/apis/apps/v1alpha1"
+	"github.com/cozystack/cozystack/pkg/apis/apps/validation"
 	"github.com/cozystack/cozystack/pkg/config"
 )
 
@@ -79,9 +81,10 @@ func TestValidateNameFormat(t *testing.T) {
 // Update → Create fall-through path. When a user runs `kubectl apply` and
 // the object does not yet exist, Kubernetes routes the request through
 // REST.Update with forceAllowCreate=true, which delegates to REST.Create
-// (rest.go:452). This test ensures tenant name validation fires on that
-// upsert path — otherwise a future refactor could silently regress the
-// fix for #2375 while unit tests of r.validateNameFormat alone keep passing.
+// (rest.go:452). Without this test, a future refactor could quietly reroute
+// that delegation and bypass the tenant name check — unit tests of the
+// pure r.validateNameFormat method would still pass while upsert-style
+// kubectl apply regressed back to accepting tenant names with dashes.
 func TestUpdate_ForceAllowCreate_RejectsTenantDashName(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := helmv2.AddToScheme(scheme); err != nil {
@@ -152,6 +155,67 @@ func TestUpdate_ForceAllowCreate_RejectsTenantDashName(t *testing.T) {
 	if !strings.Contains(err.Error(), "tenant names must") {
 		t.Errorf("expected tenant-specific error in %q", err.Error())
 	}
+}
+
+// TestConvertHelmReleaseToApplication_TenantNamespaceKindGate pins the
+// behavior that convertHelmReleaseToApplication fills Status.Namespace only
+// when the kind is Tenant. This path is gated on r.kindName matching a
+// specific literal — the test uses the validation.TenantKind constant so
+// that if the source of truth for the tenant kind string is ever renamed,
+// the gate and the constant drift together (or the test fails).
+func TestConvertHelmReleaseToApplication_TenantNamespaceKindGate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := helmv2.AddToScheme(scheme); err != nil {
+		t.Fatalf("register helmv2 scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("register corev1 scheme: %v", err)
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	hr := &helmv2.HelmRelease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tenant-foo",
+			Namespace: "tenant-root",
+		},
+	}
+
+	t.Run("tenant kind fills Status.Namespace", func(t *testing.T) {
+		r := &REST{
+			c:        fakeClient,
+			kindName: validation.TenantKind,
+			releaseConfig: config.ReleaseConfig{
+				Prefix: "tenant-",
+			},
+		}
+
+		app, err := r.convertHelmReleaseToApplication(context.Background(), hr)
+		if err != nil {
+			t.Fatalf("convertHelmReleaseToApplication: %v", err)
+		}
+		if app.Status.Namespace == "" {
+			t.Errorf("expected Status.Namespace to be populated for tenant kind, got empty")
+		}
+	})
+
+	t.Run("non-tenant kind leaves Status.Namespace empty", func(t *testing.T) {
+		r := &REST{
+			c:        fakeClient,
+			kindName: "MySQL",
+			releaseConfig: config.ReleaseConfig{
+				Prefix: "mysql-",
+			},
+		}
+
+		app, err := r.convertHelmReleaseToApplication(context.Background(), hr)
+		if err != nil {
+			t.Fatalf("convertHelmReleaseToApplication: %v", err)
+		}
+		if app.Status.Namespace != "" {
+			t.Errorf("expected Status.Namespace to be empty for non-tenant kind, got %q", app.Status.Namespace)
+		}
+	})
 }
 
 func TestValidateNameLength(t *testing.T) {


### PR DESCRIPTION
## What this PR does

The aggregated API previously accepted tenant names containing hyphens (e.g. `foo-bar`) because `ValidateApplicationName` delegated entirely to `IsDNS1035Label`, which permits them. The tenant Helm chart's `tenant.name` helper then rejected the release at template time — so users saw a successful `kubectl apply` followed by a confusing Flux/HelmRelease reconciliation error.

This PR extends `ValidateApplicationName` with a `kindName` parameter and enforces an alphanumeric-only rule (`^[a-z][a-z0-9]*$`) for the Tenant kind. A `TenantKind` constant centralizes the kind string, and `REST.validateNameFormat` wraps the check symmetrically with the existing `validateNameLength`. The tenant chart README is updated to match the already-correct website documentation.

Test coverage includes:
- Unit tests for the validation package (format + error message contract)
- REST wrapper and Update→Create fall-through path tests with a fake client
- E2E BATS regression test with explicit exit-code checks and cleanup

Fixes #2375

### Release note

```release-note
[api] Tenant names containing dashes are now rejected at API level during creation, with a specific error message, instead of being silently accepted and failing later during Helm reconciliation.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tenant names now require lowercase letters and digits only, must start with a letter; dashes are rejected with a tenant-specific error.

* **Documentation**
  * Tenant naming guidelines updated to reflect the stricter alphanumeric-only requirement.

* **Tests**
  * New unit and end-to-end tests added to verify tenant naming enforcement and tenant-specific error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->