### PR TITLE
fix(build): filter git describe to match only v* tags

### DIFF
--- a/hack/common-envs.mk
+++ b/hack/common-envs.mk
@@ -6,13 +6,13 @@ else
 endif
 
 REGISTRY ?= ghcr.io/cozystack/cozystack
-TAG = $(shell git describe --tags --exact-match 2>/dev/null || echo latest)
+TAG = $(shell git describe --tags --exact-match --match 'v*' 2>/dev/null || echo latest)
 PUSH := 1
 LOAD := 0
 BUILDER ?=
 PLATFORM ?= 
 BUILDX_EXTRA_ARGS ?=
-COZYSTACK_VERSION = $(patsubst v%,%,$(shell git describe --tags))
+COZYSTACK_VERSION = $(patsubst v%,%,$(shell git describe --tags --match 'v*'))
 
 BUILDX_ARGS := --provenance=false --push=$(PUSH) --load=$(LOAD) \
   --label org.opencontainers.image.source=https://github.com/cozystack/cozystack \
@@ -28,6 +28,6 @@ endef
 ifeq ($(COZYSTACK_VERSION),)
     $(shell git remote add upstream https://github.com/cozystack/cozystack.git || true)
     $(shell git fetch upstream --tags)
-    COZYSTACK_VERSION = $(patsubst v%,%,$(shell git describe --tags))
+    COZYSTACK_VERSION = $(patsubst v%,%,$(shell git describe --tags --match 'v*'))
 endif
 


### PR DESCRIPTION
## Summary
- Add `--match 'v*'` to all `git describe` calls in `hack/common-envs.mk`
- The `api/apps/v1alpha1/*` subtags share the same commit as release tags, causing `git describe --exact-match` to pick `api/apps/v1alpha1/vX.Y.Z` instead of `vX.Y.Z`, producing invalid Docker image tags like `ghcr.io/.../image:v1.35-api/apps/v1alpha1/v1.1.6`

## Test plan
- [ ] Rerun Versioned Tag pipelines after merge and backport to release branches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined version and tag derivation in the build system to selectively recognize Git tags, improving consistency in how release versions are identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->