### PR TITLE
ci: use cozystack org noreply email for bot commits

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -39,7 +39,7 @@ jobs:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name  "cozystack-ci[bot]"
-          git config user.email "3297617+cozystack-ci[bot]@users.noreply.github.com"
+          git config user.email "274107086+cozystack-ci[bot]@users.noreply.github.com"
           git remote set-url origin https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}
           git config --unset-all http.https://github.com/.extraheader || true
 
@@ -54,7 +54,7 @@ jobs:
 
             // Configure git to use GitHub App token for authentication
             execSync('git config user.name "cozystack-ci[bot]"', { encoding: 'utf8' });
-            execSync('git config user.email "3297617+cozystack-ci[bot]@users.noreply.github.com"', { encoding: 'utf8' });
+            execSync('git config user.email "274107086+cozystack-ci[bot]@users.noreply.github.com"', { encoding: 'utf8' });
             execSync(`git remote set-url origin https://x-access-token:${process.env.APP_TOKEN}@github.com/${process.env.GITHUB_REPOSITORY}`, { encoding: 'utf8' });
             // Remove GITHUB_TOKEN extraheader to ensure App token is used (needed to trigger other workflows)
             execSync('git config --unset-all http.https://github.com/.extraheader || true', { encoding: 'utf8' });

--- a/.github/workflows/pull-requests-release.yaml
+++ b/.github/workflows/pull-requests-release.yaml
@@ -58,7 +58,7 @@ jobs:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name  "cozystack-ci[bot]"
-          git config user.email "3297617+cozystack-ci[bot]@users.noreply.github.com"
+          git config user.email "274107086+cozystack-ci[bot]@users.noreply.github.com"
           git remote set-url origin https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}
           git tag -f ${{ steps.get_tag.outputs.tag }} ${{ github.sha }}
           git push -f origin ${{ steps.get_tag.outputs.tag }}

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -126,7 +126,7 @@ jobs:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name  "cozystack-ci[bot]"
-          git config user.email "3297617+cozystack-ci[bot]@users.noreply.github.com"
+          git config user.email "274107086+cozystack-ci[bot]@users.noreply.github.com"
           git remote set-url origin https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}
           git config --unset-all http.https://github.com/.extraheader || true
           git add .
@@ -141,7 +141,7 @@ jobs:
           VTAG="${{ steps.tag.outputs.tag }}"
           SUBTAG="api/apps/v1alpha1/${VTAG}"
           git config user.name  "cozystack-ci[bot]"
-          git config user.email "3297617+cozystack-ci[bot]@users.noreply.github.com"
+          git config user.email "274107086+cozystack-ci[bot]@users.noreply.github.com"
           git remote set-url origin https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}
           TARGET="$(git rev-parse "${VTAG}^{}")"
           git tag -f "${SUBTAG}" "$TARGET"
@@ -194,7 +194,7 @@ jobs:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name  "cozystack-ci[bot]"
-          git config user.email "3297617+cozystack-ci[bot]@users.noreply.github.com"
+          git config user.email "274107086+cozystack-ci[bot]@users.noreply.github.com"
           git remote set-url origin https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}
           BRANCH="release-${GITHUB_REF#refs/tags/v}"
           git branch -f "$BRANCH"
@@ -316,7 +316,7 @@ jobs:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name  "cozystack-ci[bot]"
-          git config user.email "3297617+cozystack-ci[bot]@users.noreply.github.com"
+          git config user.email "274107086+cozystack-ci[bot]@users.noreply.github.com"
           git remote set-url origin https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}
           
           CHANGELOG_FILE="docs/changelogs/v${{ steps.tag.outputs.version }}.md"
@@ -450,7 +450,7 @@ jobs:
         id: commit
         run: |
           git config user.name  "cozystack-ci[bot]"
-          git config user.email "3297617+cozystack-ci[bot]@users.noreply.github.com"
+          git config user.email "274107086+cozystack-ci[bot]@users.noreply.github.com"
           git add content
           if git diff --cached --quiet; then
             echo "No changes to commit"


### PR DESCRIPTION
## Summary
- Replace `3297617+cozystack-ci[bot]@users.noreply.github.com` with `cozystack@users.noreply.github.com` across all CI workflows
- DCO probot rejects the `[bot]` brackets in email as invalid, causing release PRs to fail DCO checks

## Test plan
- [ ] Verify DCO passes on release PRs after backport to release branches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal Git configuration in CI/CD workflows to use an updated bot account identity for automated commits and tagging operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->