### PR TITLE
fix(seaweedfs): wait for ingress-nginx-system before creating Ingress

### DIFF
--- a/packages/extra/seaweedfs/templates/seaweedfs.yaml
+++ b/packages/extra/seaweedfs/templates/seaweedfs.yaml
@@ -104,6 +104,11 @@ metadata:
   labels:
     sharding.fluxcd.io/key: tenants
 spec:
+  {{- if $ingress }}
+  # Ensure the ingress-nginx admission webhook is ready before creating Ingress resources.
+  dependsOn:
+  - name: ingress-nginx-system
+  {{- end }}
   chartRef:
     kind: ExternalArtifact
     name: cozystack-seaweedfs-application-default-seaweedfs-system

--- a/packages/extra/seaweedfs/templates/seaweedfs.yaml
+++ b/packages/extra/seaweedfs/templates/seaweedfs.yaml
@@ -104,10 +104,14 @@ metadata:
   labels:
     sharding.fluxcd.io/key: tenants
 spec:
-  {{- if $ingress }}
+  {{- if eq $ingress .Release.Namespace }}
   # Ensure the ingress-nginx admission webhook is ready before creating Ingress resources.
+  # Only when this tenant owns its ingress; sub-tenants inherit ingress from a parent
+  # namespace where ingress-nginx-system already runs, and the dependency would deadlock
+  # because the HR doesn't exist locally.
   dependsOn:
   - name: ingress-nginx-system
+    namespace: {{ .Release.Namespace }}
   {{- end }}
   chartRef:
     kind: ExternalArtifact


### PR DESCRIPTION
## What this PR does

Stacks on top of #2258. Adds `dependsOn: ingress-nginx-system` to the inner `seaweedfs-system` HelmRelease so flux blocks its install until the ingress chart is Ready.

## Why

In #2258's E2E run (and the `cozyreport-2258` bundle from this morning), `seaweedfs-system` failed to install with:

```
Helm install failed for release tenant-root/seaweedfs-system: 1 error occurred:
* Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io":
  failed to call webhook: Post "https://root-ingress-controller-admission.tenant-root.svc:443/networking/v1/ingresses?timeout=10s":
  dial tcp 10.96.33.42:443: connect: operation not permitted
```

### Root cause class

The outer tenant HelmReleases (`apps/tenant/templates/*.yaml`) render one inner HR per subsystem and let flux reconcile them. Both `seaweedfs` and `ingress` outer HRs get applied in parallel, and each of them spawns its own inner HR — which flux then installs in parallel too.

When `seaweedfs-system` gets to the `creating 39 resource(s)` step, it tries to create the tenant Ingress. The apiserver calls the ingress-nginx `ValidatingWebhookConfiguration` (which uses `failurePolicy: Fail` by default). If the nginx controller pod/Service/endpoint state hasn't finished reconciling on the CNI yet, the connect to the ClusterIP fails with `EPERM`, the webhook errors, Helm aborts, and flux rolls back.

E2E recovers via the `flux reconcile --force` retry loop in `hack/e2e-install-cozystack.bats`, but it's flaky and adds minutes.

### Fix

Introduce an explicit ordering dependency at the inner HR layer:

```yaml
{{- if $ingress }}
dependsOn:
- name: ingress-nginx-system
{{- end }}
```

Flux waits for `ingress-nginx-system` to reach `Ready=true` before installing seaweedfs — which, under Flux's wait semantics, means the ingress-nginx Deployment is Available and its webhook endpoint is routable. The race disappears.

Guarded by `{{- if $ingress }}` so this only kicks in for tenants that actually have ingress enabled.

## Test plan

- [ ] Rerun E2E on #2258 — `seaweedfs-system` should install on the first try without a `Retry install` iteration.
- [ ] Verify rendered template still matches expectations when `$ingress` is unset (no `dependsOn` block).

### Release note

```release-note
[seaweedfs] Make tenant seaweedfs wait for ingress-nginx to be Ready before creating its Ingress resource, avoiding a webhook race that intermittently failed install on fresh clusters.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment sequencing so the system now waits for the Ingress controller to be ready before creating or updating resources that include Ingress. This prevents premature deployments and related failures, reduces rollout errors, and provides more reliable, predictable deployments for applications relying on Ingress resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->