### PR TITLE
feat(seaweedfs): limit single PUT request size to 5GB

### DIFF
--- a/packages/extra/seaweedfs/templates/seaweedfs.yaml
+++ b/packages/extra/seaweedfs/templates/seaweedfs.yaml
@@ -240,7 +240,10 @@ spec:
           className: {{ $ingress }}
           host: {{ .Values.host | default (printf "s3.%s" $host) }}
           annotations:
-            nginx.ingress.kubernetes.io/proxy-body-size: "0"
+            # Limit single PUT request to 5GB to enforce multipart uploads for large files.
+            # This prevents issues with large file uploads and reduces support load.
+            # For files >5GB, clients must use S3 multipart upload API.
+            nginx.ingress.kubernetes.io/proxy-body-size: "5g"
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
             {{- if eq $solver "http01" }}
             acme.cert-manager.io/http01-ingress-class: {{ $ingress }}

--- a/packages/extra/seaweedfs/templates/seaweedfs.yaml
+++ b/packages/extra/seaweedfs/templates/seaweedfs.yaml
@@ -244,7 +244,14 @@ spec:
             # This prevents issues with large file uploads and reduces support load.
             # For files >5GB, clients must use S3 multipart upload API.
             nginx.ingress.kubernetes.io/proxy-body-size: "5g"
+            nginx.ingress.kubernetes.io/proxy-buffering: "off"
+            nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+            nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+            nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+            nginx.ingress.kubernetes.io/client-body-timeout: "3600"
+            nginx.ingress.kubernetes.io/client-header-timeout: "120"
+            nginx.ingress.kubernetes.io/service-upstream: "true"
             {{- if eq $solver "http01" }}
             acme.cert-manager.io/http01-ingress-class: {{ $ingress }}
             {{- end }}

--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -102,7 +102,10 @@ seaweedfs:
       className: "tenant-root"
       host: "seaweedfs.demo.cozystack.io"
       annotations:
-        nginx.ingress.kubernetes.io/proxy-body-size: "0"
+        # Limit single PUT request to 5GB to enforce multipart uploads for large files.
+        # This prevents issues with large file uploads and reduces support load.
+        # For files >5GB, clients must use S3 multipart upload API.
+        nginx.ingress.kubernetes.io/proxy-body-size: "5g"
         nginx.ingress.kubernetes.io/proxy-buffering: "off"
         nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
         nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"


### PR DESCRIPTION
## Summary

Limit single PUT request body size to 5GB for SeaweedFS S3 endpoints to enforce multipart upload usage for large files.

## Motivation

Large monolithic file uploads via single PUT requests (files >5GB) frequently cause issues in production environments:
- Connection timeouts during long uploads
- Memory pressure on proxy/gateway components  
- Incomplete uploads resulting in corrupted data
- High support load from users experiencing these failures

AWS S3 and other object storage providers recommend using multipart uploads for files larger than 100MB, with multipart being mandatory for files >5GB.

## Changes

- Set `nginx.ingress.kubernetes.io/proxy-body-size: "5g"` in system SeaweedFS configuration
- Set `nginx.ingress.kubernetes.io/proxy-body-size: "5g"` in tenant SeaweedFS template (hardcoded, non-overridable)
- Add explanatory comments documenting the limitation and rationale

## Impact

**For users:**
- Single PUT requests are limited to 5GB maximum
- Files >5GB must be uploaded using S3 multipart upload API
- All standard S3 clients (aws-cli, boto3, MinIO client, etc.) automatically use multipart for large files
- No breaking changes for properly configured S3 clients

**Platform benefits:**
- Reduced support load from large file upload failures
- Better resource utilization (memory, connections)
- More reliable upload experience for end users
- Aligns with industry best practices (AWS, MinIO, etc.)

## Testing

- Verify small files (<5GB) upload successfully via PUT
- Verify large files (>5GB) via PUT return HTTP 413
- Verify multipart upload works for any file size
- Test with common S3 clients (aws-cli, s3cmd, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated SeaweedFS S3 ingress configuration to enforce a 5GB maximum for single requests; files larger than 5GB should use multipart upload.
  * Disabled response/request buffering and extended NGINX timeouts, and enabled upstream service handling to improve reliability of large uploads and long-lived connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->