### PR TITLE
fix(linstor): increase satellite startup probe failure threshold

### DIFF
--- a/packages/system/linstor/templates/satellites-cozy.yaml
+++ b/packages/system/linstor/templates/satellites-cozy.yaml
@@ -17,6 +17,7 @@ spec:
         startupProbe:
           tcpSocket:
             port: linstor
+          periodSeconds: 10
           failureThreshold: 30
         securityContext:
           # real-world installations need some debugging from time to time

--- a/packages/system/linstor/templates/satellites-cozy.yaml
+++ b/packages/system/linstor/templates/satellites-cozy.yaml
@@ -14,6 +14,10 @@ spec:
       containers:
       - name: linstor-satellite
         image: {{ .Values.piraeusServer.image.repository }}:{{ .Values.piraeusServer.image.tag }}
+        startupProbe:
+          tcpSocket:
+            port: linstor
+          failureThreshold: 30
         securityContext:
           # real-world installations need some debugging from time to time
           readOnlyRootFilesystem: false


### PR DESCRIPTION
## What this PR does

Increases the LINSTOR satellite startup probe `failureThreshold` from the Kubernetes default of 3 (30 seconds) to 30 (300 seconds / 5 minutes).

The default startup probe is too aggressive for nodes with slow storage initialization — satellites get killed and restarted before they have a chance to come up. This adds an explicit `startupProbe` override in the `LinstorSatelliteConfiguration` pod template, keeping the same `tcpSocket` check on the `linstor` port but giving satellites significantly more time to start.

### Release note

```release-note
fix(linstor): increase satellite startup probe failure threshold from 3 to 30 (5 minutes to start)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a startup health check for the LINSTOR satellite container to improve pod reliability and ensure the service fully initializes before accepting traffic.
  * This change only introduces container startup probing behavior and does not alter other runtime behavior or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->