### PR TITLE
fix(tests): increase Bootstrap Talos cluster timeout to 60s

### DIFF
--- a/hack/e2e-prepare-cluster.bats
+++ b/hack/e2e-prepare-cluster.bats
@@ -235,8 +235,11 @@ EOF
 }
 
 @test "Bootstrap Talos cluster" {
-  # Bootstrap etcd on the first node
-  timeout 10 sh -ec 'until talosctl bootstrap -n 192.168.123.11 -e 192.168.123.11; do sleep 1; done'
+  # Bootstrap etcd on the first node.
+  # Retry for up to 60s: talosctl bootstrap refuses with "time is not in
+  # sync yet" until NTP converges on a freshly booted node, which on fast
+  # ephemeral runners can take several attempts of ~5s each.
+  timeout 60 sh -ec 'until talosctl bootstrap -n 192.168.123.11 -e 192.168.123.11; do sleep 2; done'
 
   # Wait until etcd is healthy
   if ! timeout 180 sh -ec 'until talosctl etcd members -n 192.168.123.11,192.168.123.12,192.168.123.13 -e 192.168.123.10 >/dev/null 2>&1; do sleep 1; done'; then


### PR DESCRIPTION
## What this PR does

The `Bootstrap Talos cluster` step in `hack/e2e-prepare-cluster.bats` wraps `talosctl bootstrap` in `timeout 10 sh -ec 'until talosctl bootstrap ...; do sleep 1; done'`. On a freshly booted Talos node NTP has not yet converged, so `talosctl bootstrap` returns `FailedPrecondition: time is not in sync yet` after ~5-6s. With the 10s outer timeout the embedded `until/sleep 1` loop only completes a single attempt before it is killed, and the E2E job fails during `Prepare environment`.

On slower self-hosted runners NTP typically converges before the first attempt. On fast ephemeral runners (Oracle VMs) it does not, producing a consistent flake that only the outer workflow-level 3-attempt retry can paper over.

Bump the outer timeout to 60s and the inter-attempt sleep to 2s. This aligns with the other bootstrap gates in the same test (etcd members check at 180s, drain RPC errors at 60s, node registration at 60s) and gives NTP plenty of time to converge.

### Release note

```release-note
fix(tests): increase `Bootstrap Talos cluster` timeout in E2E from 10s to 60s to accommodate NTP convergence on fast ephemeral runners.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced cluster bootstrap process resilience by extending retry mechanisms and adjusting timing intervals to better tolerate transient failures during system initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->