### PR TITLE
ci(docs): promote next/ trunk on new minor/major releases

### DIFF
--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -441,17 +441,58 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           ref: main
 
+      # Decide whether this release promotes the `next/` trunk to a new released
+      # version directory. Per the website repo's contract (see website#495):
+      #   - `make release-next` runs only for new minor/major final releases
+      #     (tag matches `vX.Y.Z` with no prerelease suffix AND `vX.Y/` does
+      #     not yet exist on disk).
+      #   - Prereleases and patch releases skip this step and let
+      #     `make update-all` handle routing on its own.
+      - name: Determine if this release promotes next/
+        id: promote
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          if [[ ! "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "promote=false" >> "$GITHUB_OUTPUT"
+            echo "Prerelease tag '$TAG' — skipping release-next."
+            exit 0
+          fi
+          MAJOR="${BASH_REMATCH[1]}"
+          MINOR="${BASH_REMATCH[2]}"
+          if [[ "$MAJOR" == "0" ]]; then
+            DOC_VERSION="v0"
+          else
+            DOC_VERSION="v${MAJOR}.${MINOR}"
+          fi
+          if [[ -d "content/en/docs/${DOC_VERSION}" ]]; then
+            echo "promote=false" >> "$GITHUB_OUTPUT"
+            echo "content/en/docs/${DOC_VERSION}/ already exists — patch release, skipping release-next."
+          else
+            echo "promote=true" >> "$GITHUB_OUTPUT"
+            echo "New minor/major release ${DOC_VERSION} — will promote next/ → ${DOC_VERSION}/."
+          fi
+
+      - name: Promote next/ to released version
+        if: steps.promote.outputs.promote == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: make release-next RELEASE_TAG="$TAG"
+
       - name: Update docs from release branch
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: make update-all BRANCH=release-${{ steps.tag.outputs.version }} RELEASE_TAG=${{ steps.tag.outputs.tag }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: make update-all BRANCH="release-$VERSION" RELEASE_TAG="$TAG"
 
       - name: Commit and push
         id: commit
         run: |
           git config user.name  "cozystack-ci[bot]"
           git config user.email "274107086+cozystack-ci[bot]@users.noreply.github.com"
-          git add content
+          git add content hugo.yaml
           if git diff --cached --quiet; then
             echo "No changes to commit"
             echo "changed=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What this PR does

Updates the `update-website-docs` job in `.github/workflows/tags.yaml` to match the new docs-versioning contract introduced in cozystack/website#495.

The website repo replaces the old "pre-create `vX.Y/` draft directory" scheme with a permanent `content/en/docs/next/` trunk. Released version directories are no longer implicitly pre-created — the upstream release workflow owns the explicit decision of when to promote `next/` → `vX.Y/`.

### Changes

- **New step `Determine if this release promotes next/`** — parses the tag and only sets `promote=true` for final `vX.Y.Z` tags where `content/en/docs/vX.Y/` does not already exist. Prereleases (`vX.Y.Z-rc.N`, etc.) and patch releases skip promotion.
- **New step `Promote next/ to released version`** — gated on `promote=true`; runs `make release-next RELEASE_TAG=<tag>`.
- **Step order**: `release-next` runs **before** `update-all`. This way `update-all` routes into the freshly-created `vX.Y/` directory (per the website Makefile's routing logic), and `next/` stays untouched as the trunk for the following release.
- **`git add content hugo.yaml`** — `release-next` registers the new version in `hugo.yaml` via `register_version.sh`, so the commit step must stage it.
- Converted the existing `update-all` step to use `env:` vars for consistency with the new step and workflow-injection hardening.

### Behaviour by tag

| Tag | `release-next`? | `update-all` targets |
|-----|-----------------|----------------------|
| `v1.3.0` (v1.3 does not exist) | yes — promotes next/ → v1.3/ | v1.3/ |
| `v1.3.1` (v1.3 exists) | no — skipped | v1.3/ |
| `v1.3.0-rc.1` | no — skipped (prerelease) | next/ |
| `v2.0.0` (v2.0 does not exist) | yes — promotes next/ → v2.0/ | v2.0/ |

### Release note

```release-note
Release tagging now promotes the website's `next/` docs trunk to `vX.Y/` when cutting a new minor or major release (requires cozystack/website#495 to be merged first).
```

### Dependency

Must not merge until cozystack/website#495 is merged on `main` of the website repo, otherwise `make release-next` won't exist there and new-minor release tags will fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to apply conditional logic for version promotion based on tag patterns and documentation availability. Modified documentation staging behavior in release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->