### PR TITLE
[Backport release-1.1] fix(platform): migrate ACME HTTP-01 to ingressClassName API

### DIFF
--- a/packages/apps/harbor/templates/ingress.yaml
+++ b/packages/apps/harbor/templates/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     {{- if eq $solver "http01" }}
-    acme.cert-manager.io/http01-ingress-class: {{ $ingress }}
+    acme.cert-manager.io/http01-ingress-ingressclassname: {{ $ingress }}
     {{- end }}
     cert-manager.io/cluster-issuer: {{ $clusterIssuer }}
 spec:

--- a/packages/extra/bootbox/templates/matchbox/ingress.yaml
+++ b/packages/extra/bootbox/templates/matchbox/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     app: bootbox
   annotations:
     {{- if eq $solver "http01" }}
-    acme.cert-manager.io/http01-ingress-class: {{ $ingress }}
+    acme.cert-manager.io/http01-ingress-ingressclassname: {{ $ingress }}
     {{- end }}
     cert-manager.io/cluster-issuer: {{ $clusterIssuer }}
     {{- if .Values.whitelistHTTP }}

--- a/packages/extra/seaweedfs/templates/seaweedfs.yaml
+++ b/packages/extra/seaweedfs/templates/seaweedfs.yaml
@@ -243,7 +243,7 @@ spec:
             nginx.ingress.kubernetes.io/proxy-body-size: "0"
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
             {{- if eq $solver "http01" }}
-            acme.cert-manager.io/http01-ingress-class: {{ $ingress }}
+            acme.cert-manager.io/http01-ingress-ingressclassname: {{ $ingress }}
             {{- end }}
             cert-manager.io/cluster-issuer: {{ $clusterIssuer }}
           tls:

--- a/packages/system/bucket/templates/ingress.yaml
+++ b/packages/system/bucket/templates/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "99999"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "99999"
     {{- if eq $solver "http01" }}
-    acme.cert-manager.io/http01-ingress-class: {{ $ingress }}
+    acme.cert-manager.io/http01-ingress-ingressclassname: {{ $ingress }}
     {{- end }}
     cert-manager.io/cluster-issuer: {{ $clusterIssuer }}
 spec:

--- a/packages/system/cert-manager-issuers/templates/cluster-issuers.yaml
+++ b/packages/system/cert-manager-issuers/templates/cluster-issuers.yaml
@@ -1,6 +1,7 @@
 {{- $solver := (index .Values._cluster "solver") | default "http01" }}
+{{- $exposeIngress := (index .Values._cluster "expose-ingress") | default "tenant-root" }}
 
-apiVersion: cert-manager.io/v1 
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer  
 metadata:  
   name: letsencrypt-prod  
@@ -17,9 +18,9 @@ spec:
               name: cloudflare-api-token-secret  
               key: api-token  
       {{- else }}  
-        http01:  
-          ingress:  
-            class: nginx  
+        http01:
+          ingress:
+            ingressClassName: {{ $exposeIngress }}
       {{- end }}  
 
 ---  
@@ -41,9 +42,9 @@ spec:
               name: cloudflare-api-token-secret  
               key: api-token  
       {{- else }}  
-        http01:  
-          ingress:  
-            class: nginx  
+        http01:
+          ingress:
+            ingressClassName: {{ $exposeIngress }}
       {{- end }}  
 
 ---  

--- a/packages/system/dashboard/templates/ingress.yaml
+++ b/packages/system/dashboard/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: {{ $clusterIssuer }}
     {{- if eq $solver "http01" }}
-    acme.cert-manager.io/http01-ingress-class: {{ $exposeIngress }}
+    acme.cert-manager.io/http01-ingress-ingressclassname: {{ $exposeIngress }}
     {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/client-max-body-size: 100m

--- a/packages/system/keycloak/templates/ingress.yaml
+++ b/packages/system/keycloak/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- if eq $solver "http01" }}
-    acme.cert-manager.io/http01-ingress-class: {{ $exposeIngress }}
+    acme.cert-manager.io/http01-ingress-ingressclassname: {{ $exposeIngress }}
     {{- end }}
     cert-manager.io/cluster-issuer: {{ $clusterIssuer }}
     {{- toYaml . | nindent 4 }}

--- a/packages/system/monitoring/templates/alerta/alerta.yaml
+++ b/packages/system/monitoring/templates/alerta/alerta.yaml
@@ -173,7 +173,7 @@ metadata:
     app: alerta
   annotations:
     {{- if eq $solver "http01" }}
-    acme.cert-manager.io/http01-ingress-class: {{ $ingress }}
+    acme.cert-manager.io/http01-ingress-ingressclassname: {{ $ingress }}
     {{- end }}
     cert-manager.io/cluster-issuer: {{ $clusterIssuer }}
 spec:

--- a/packages/system/monitoring/templates/grafana/grafana.yaml
+++ b/packages/system/monitoring/templates/grafana/grafana.yaml
@@ -74,7 +74,7 @@ spec:
     metadata:
       annotations:
         {{- if eq $solver "http01" }}
-        acme.cert-manager.io/http01-ingress-class: "{{ $ingress }}"
+        acme.cert-manager.io/http01-ingress-ingressclassname: "{{ $ingress }}"
         {{- end }}
         cert-manager.io/cluster-issuer: {{ $clusterIssuer }}
     spec:

--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -111,7 +111,7 @@ seaweedfs:
         nginx.ingress.kubernetes.io/client-body-timeout: "3600"
         nginx.ingress.kubernetes.io/client-header-timeout: "120"
         nginx.ingress.kubernetes.io/service-upstream: "true"
-        acme.cert-manager.io/http01-ingress-class: tenant-root
+        acme.cert-manager.io/http01-ingress-ingressclassname: tenant-root
         cert-manager.io/cluster-issuer: letsencrypt-prod
       tls:
         - hosts:


### PR DESCRIPTION
ClusterIssuer solver referenced IngressClass "nginx" which does not exist on cozystack clusters — real classes are named after tenant namespaces (e.g. tenant-root). Cert issuance only worked because every requesting Ingress overrode the ClusterIssuer via the legacy acme.cert-manager.io/http01-ingress-class annotation.

Switch both sides to the modern cert-manager API (available since cert-manager 1.12; cozystack ships 1.19.3):

- ClusterIssuer: http01.ingress.ingressClassName, value parameterized from _cluster.expose-ingress (default "tenant-root")
- Ingress annotation: http01-ingress-ingressclassname

These must migrate together — mixing ingressClassName (ClusterIssuer) with the old http01-ingress-class annotation triggers cert-manager's "fields ingressClassName and class cannot be set at the same time" validation and breaks issuance.

Assisted-By: Claude <noreply@anthropic.com>

(cherry picked from commit 2b6e20cc3f96505ee8abdb40be64f1234a40b29d)

<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes for system components: dashboard, platform, cilium, kube-ovn, linstor, fluxcd, cluster-api
  - Scopes for managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
  - Scopes for development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Screenshots

<!-- REQUIRED for UI changes: attach screenshots or screen recordings demonstrating
the visual impact of your changes. PRs with UI changes without screenshots will not be merged. -->

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note

```