### PR TITLE
fix(kube-ovn): resolve kubeovn-plunger RBAC forbidden on deployments

### DIFF
--- a/cmd/kubeovn-plunger/main.go
+++ b/cmd/kubeovn-plunger/main.go
@@ -29,6 +29,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -131,6 +132,11 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "29a0338b.cozystack.io",
+		Cache: cache.Options{
+			DefaultNamespaces: map[string]cache.Config{
+				kubeOVNNamespace: {},
+			},
+		},
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/packages/system/kubeovn-plunger/templates/deployment.yaml
+++ b/packages/system/kubeovn-plunger/templates/deployment.yaml
@@ -29,6 +29,8 @@ spec:
         {{- end }}
         - --metrics-bind-address=:8080
         - --metrics-secure=false
+        - --kube-ovn-namespace={{ .Release.Namespace }}
+        - --ovn-central-name={{ .Values.ovnCentralName }}
         ports:
         - name: metrics
           containerPort: 8080

--- a/packages/system/kubeovn-plunger/templates/rbac.yaml
+++ b/packages/system/kubeovn-plunger/templates/rbac.yaml
@@ -22,8 +22,6 @@ rules:
   - get
   - list
   - watch
-  resourceNames:
-  - {{ .Values.ovnCentralName }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## What this PR does

Fixes an RBAC failure in `kube-ovn-plunger` that prevented it from reconciling the `ovn-central` Deployment:

```
deployments.apps is forbidden: User "system:serviceaccount:cozy-kubeovn:kube-ovn-plunger"
cannot list resource "deployments" in API group "apps" at the cluster scope
```

Two causes addressed:

- The controller-runtime cache issued cluster-wide list/watch for Deployments and Pods by default. The manager cache is now scoped to the kube-ovn namespace, so requests go to the namespaced endpoints covered by the Role.
- The Role's deployments rule used `resourceNames`, which does not apply to list/watch in Kubernetes RBAC. The restriction is removed; the Role is still namespace-scoped via RoleBinding to the `cozy-kubeovn` namespace.

`--kube-ovn-namespace` and `--ovn-central-name` are now passed to the binary from chart values so the previously unused value is wired up.

### Release note

```release-note
fix(kube-ovn): fix kubeovn-plunger RBAC forbidden error on ovn-central Deployment reconcile
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable parameters for KubeOVN namespace and OVN central name in deployment configuration.

* **Improvements**
  * Enhanced cache configuration with namespace-scoped resource management capabilities.
  * Updated RBAC permissions to remove resource-specific constraints, enabling broader deployment access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->