### PR TITLE
fix(kube-ovn): bump kube-ovn to v1.15.10 with port-group regression fix

### DIFF
--- a/packages/system/kubeovn/charts/kube-ovn/Chart.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v1.15.3
+version: v1.15.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.15.3"
+appVersion: "1.15.10"
 
 kubeVersion: ">= 1.29.0-0"

--- a/packages/system/kubeovn/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -1353,6 +1353,77 @@ spec:
                         type: string
                     type: object
                   type: array
+                resources:
+                  description: |-
+                    `resources` are the compute resources required by this container.
+                    For more information, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                  properties:
+                    claims:
+                      description: |-
+                        Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.
+
+                        This field depends on the DynamicResourceAllocation feature gate.
+
+                        This field is immutable. It can only be set for containers.
+                      items:
+                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                        properties:
+                          name:
+                            description: |-
+                              Name must match the name of one entry in pod.spec.resourceClaims of
+                              the Pod where this field is used. It makes that resource available
+                              inside a container.
+                            type: string
+                          request:
+                            description: |-
+                              Request is the name chosen for a request in the referenced claim.
+                              If empty, everything from the claim is made available, otherwise
+                              only the result of this request.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: |-
+                        Limits describes the maximum amount of compute resources allowed.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: |-
+                        Requests describes the minimum amount of compute resources required.
+                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      type: object
+                  type: object
+                bandwidth:
+                  type: object
+                  description: Optional bandwidth limit for each egress gateway instance in both ingress and egress directions.
+                  properties:
+                    ingress:
+                      type: integer
+                      format: int64
+                      description: ingress bandwidth limit in Mbps
+                    egress:
+                      type: integer
+                      format: int64
+                      description: egress bandwidth limit in Mbps
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/packages/system/kubeovn/charts/kube-ovn/templates/ovncni-ds.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/ovncni-ds.yaml
@@ -126,6 +126,9 @@ spec:
           - --enable-ovn-ipsec={{- .Values.func.ENABLE_OVN_IPSEC }}
           - --set-vxlan-tx-off={{- .Values.func.SET_VXLAN_TX_OFF }}
           - --non-primary-cni-mode={{- .Values.cni_conf.NON_PRIMARY_CNI }}
+          {{- with .Values.mtu }}
+          - --mtu={{ . }}
+          {{- end }}
         securityContext:
           runAsUser: 0
           privileged: false

--- a/packages/system/kubeovn/charts/kube-ovn/templates/pre-upgrade-ovs-ovn.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/pre-upgrade-ovs-ovn.yaml
@@ -1,0 +1,129 @@
+{{- if include "kubeovn.ovn.versionCompatibility" . -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovs-ovn-pre-upgrade
+  namespace: {{ .Values.namespace }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.k8s.io/system-only: "true"
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": hook-succeeded
+  name: system:ovs-ovn-pre-upgrade
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ovs-ovn-pre-upgrade
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": hook-succeeded
+roleRef:
+  name: system:ovs-ovn-pre-upgrade
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: ovs-ovn-pre-upgrade
+    namespace: {{ .Values.namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Chart.Name }}-pre-upgrade-hook"
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "4"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  completions: 1
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        app: pre-upgrade
+        component: job
+    spec:
+      tolerations:
+        - key: ""
+          operator: "Exists"
+          effect: "NoSchedule"
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - pre-upgrade
+                  - key: component
+                    operator: In
+                    values:
+                      - job
+      restartPolicy: Never
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: "linux"
+      serviceAccountName: ovs-ovn-pre-upgrade
+      automountServiceAccountToken: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ovs-ovn-pre-upgrade
+          image: "{{ .Values.global.registry.address}}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}"
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - bash
+            - -eo
+            - pipefail
+            - -c
+            - bash /kube-ovn/pre-upgrade-ovs.sh 2>&1 | tee -a /var/log/kube-ovn/pre-upgrade-ovs.log
+          volumeMounts:
+            - mountPath: /var/log/kube-ovn
+              name: kube-ovn-log
+      volumes:
+        - name: kube-ovn-log
+          hostPath:
+            path: {{ .Values.log_conf.LOG_DIR }}/kube-ovn
+{{- end -}}

--- a/packages/system/kubeovn/charts/kube-ovn/values.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/values.yaml
@@ -8,11 +8,11 @@ global:
   images:
     kubeovn:
       repository: kube-ovn
-      tag: v1.15.3
+      tag: v1.15.10
     natgateway:
       repository: vpc-nat-gateway
       # Falls back to the same tag as kubeovn if empty
-      tag: v1.15.3
+      tag: v1.15.10
 
 image:
   pullPolicy: IfNotPresent

--- a/packages/system/kubeovn/values.yaml
+++ b/packages/system/kubeovn/values.yaml
@@ -65,4 +65,4 @@ global:
   images:
     kubeovn:
       repository: kubeovn
-      tag: v1.15.3@sha256:fa53d5f254f640cb626329ad35d9e7aad647dd8e1e645e68f3f13c3659472a30
+      tag: v1.15.10@sha256:741299cbd0081a786a6b60c460fa3156b3a42a38141c559dd8ac031f50c5504f


### PR DESCRIPTION
## What this PR does

Bumps `packages/system/kubeovn` to `cozystack/kubeovn-chart` tag `v1.15.10-cozy.1`, which:

1. Updates upstream kube-ovn from v1.15.3 to v1.15.10 (latest patch in the v1.15 series).
2. Carries a patch over `pkg/controller/pod.go` that preserves a VM LSP's port-group memberships when kubernetes GCs a completed virt-launcher pod while another virt-launcher pod of the same VM is still running.

Without the patch, the destination pod of a successful live migration loses its security groups, network policies and node-scoped routing after kubernetes cleans up the source pod, and only recovers after a `kube-ovn-controller` restart. The buggy code path is identical between v1.15.3, v1.15.10, release-1.15 HEAD and master HEAD — confirmed by diff and by reproduction on a cozystack cluster.

- Upstream issue: kubeovn/kube-ovn#6665
- Upstream fix PR: kubeovn/kube-ovn#6666
- Chart carry: cozystack/kubeovn-chart#4

### Release note

```release-note
fix(kube-ovn): bump kube-ovn to v1.15.10 and carry upstream fix that keeps VM LSP port-group memberships when kubernetes GCs a completed virt-launcher pod (post-migration regression)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VpcEgressGateway CRD extended with optional resources (claims/limits/requests) and bandwidth (ingress/egress) fields.
  * Added a pre-upgrade hook to run compatibility steps before upgrades.
  * CNI DaemonSet now optionally respects MTU when configured.

* **Bug Fixes**
  * Updated Kube-OVN and NAT gateway container images to the latest maintenance release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->