### PR TITLE
fix(harbor): remove incorrect tenant module flags

### DIFF
--- a/packages/system/harbor-rd/cozyrds/harbor.yaml
+++ b/packages/system/harbor-rd/cozyrds/harbor.yaml
@@ -13,7 +13,6 @@ spec:
     prefix: "harbor-"
     labels:
       sharding.fluxcd.io/key: tenants
-      internal.cozystack.io/tenantmodule: "true"
     chartRef:
       kind: ExternalArtifact
       name: cozystack-harbor-application-default-harbor
@@ -24,7 +23,6 @@ spec:
     plural: Harbor
     name: harbor
     description: Managed Harbor container registry
-    module: true
     tags:
       - registry
       - container


### PR DESCRIPTION
## What this PR does

Harbor is a PaaS service (`category: PaaS`), not a tenant module. It is not deployed automatically into tenant namespaces — there is no corresponding manifest in `packages/apps/tenant/templates/`, unlike actual tenant modules (monitoring, ingress, etcd, info, seaweedfs).

Two flags were incorrectly set on its `ApplicationDefinition`:

- `spec.dashboard.module: true` — caused Harbor to appear in the sidebar "Modules" section and be excluded from its proper PaaS category.
- `spec.release.labels."internal.cozystack.io/tenantmodule": "true"` — caused controllers (`pkg/registry/core/tenantmodule`, dashboard) to treat the Harbor HelmRelease as a tenant module.

Both flags are removed so Harbor is listed correctly under PaaS and handled as an ordinary managed application.

### Release note

```release-note
fix(harbor): remove incorrect tenant module flags from Harbor ApplicationDefinition so it appears under the PaaS category in the dashboard and is no longer treated as a tenant module
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified internal application configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->