### PR TITLE
fix(backups): move velero-configmap Role to velero chart

### DIFF
--- a/packages/system/backupstrategy-controller/templates/rbac-bind.yaml
+++ b/packages/system/backupstrategy-controller/templates/rbac-bind.yaml
@@ -10,17 +10,3 @@ subjects:
 - kind: ServiceAccount
   name: backupstrategy-controller
   namespace: {{ .Release.Namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: backups.cozystack.io:strategy-controller:velero-configmaps
-  namespace: cozy-velero
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: backups.cozystack.io:strategy-controller:velero-configmaps
-subjects:
-- kind: ServiceAccount
-  name: backupstrategy-controller
-  namespace: {{ .Release.Namespace }}

--- a/packages/system/backupstrategy-controller/templates/rbac.yaml
+++ b/packages/system/backupstrategy-controller/templates/rbac.yaml
@@ -27,7 +27,9 @@ rules:
   resources: ["pods"]
   verbs: ["get", "list", "watch"]
 # ConfigMaps: controller-runtime cache requires cluster-scoped list/watch;
-# create/update/delete is scoped to cozy-velero via the Role below.
+# create/update/delete is scoped to cozy-velero via a Role shipped by the
+# velero chart (packages/system/velero/templates/backupstrategy-controller-rbac.yaml)
+# so it is only created when velero is installed.
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get", "list", "watch"]
@@ -78,14 +80,3 @@ rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["get", "list", "watch", "create", "update", "patch"]
----
-# To create ResourceModifiers in ConfigMaps for Restore in Velero install namespace.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: backups.cozystack.io:strategy-controller:velero-configmaps
-  namespace: cozy-velero
-rules:
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["create", "get", "list", "delete", "deletecollection", "patch", "update"]

--- a/packages/system/velero/templates/backupstrategy-controller-rbac.yaml
+++ b/packages/system/velero/templates/backupstrategy-controller-rbac.yaml
@@ -1,0 +1,26 @@
+# Grants the backupstrategy-controller permission to manage ResourceModifier
+# ConfigMaps in the Velero install namespace. Lives here (not in the
+# backupstrategy-controller chart) so that the Role is only created when
+# velero is actually installed — otherwise the chart would try to create it
+# in a namespace that does not exist.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backups.cozystack.io:strategy-controller:velero-configmaps
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["create", "get", "list", "delete", "deletecollection", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backups.cozystack.io:strategy-controller:velero-configmaps
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backups.cozystack.io:strategy-controller:velero-configmaps
+subjects:
+- kind: ServiceAccount
+  name: backupstrategy-controller
+  namespace: cozy-backup-controller


### PR DESCRIPTION
## What this PR does

The `backupstrategy-controller` chart declared a `Role` and `RoleBinding` scoped to the `cozy-velero` namespace (for managing `ResourceModifier` ConfigMaps consumed by Velero Restore). Because `cozystack.velero` is an optional package, that namespace does not exist in bundles that do not enable velero — and `backupstrategy-controller` is a **default** package. Helm install aborted with:

```
namespaces "cozy-velero" not found
```

which blocked the entire `cozy-backup-controller/backupstrategy-controller` HelmRelease on any cluster where velero was not explicitly enabled (including the E2E environment).

This PR moves that Role/RoleBinding into the velero chart (`packages/system/velero/templates/backupstrategy-controller-rbac.yaml`), so the permission grant only exists when velero is actually installed — where it is useful. The RoleBinding subject points to the stable `backupstrategy-controller` ServiceAccount in `cozy-backup-controller`.

### Release note

```release-note
fix(backups): moved the velero-namespaced ResourceModifier ConfigMap Role and RoleBinding from the backupstrategy-controller chart into the velero chart. This unblocks installs of backupstrategy-controller on bundles that do not enable velero (previously the HelmRelease failed with `namespaces "cozy-velero" not found`).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized RBAC configuration for the backup strategy controller by consolidating namespace-scoped role definitions in the Velero chart template
  * Updated role bindings and permissions structure across system packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->