### PR TITLE
chore(hetzner-robotlb): update robotlb chart to appVersion 0.0.6

### DIFF
--- a/packages/system/hetzner-robotlb/charts/robotlb/Chart.yaml
+++ b/packages/system/hetzner-robotlb/charts/robotlb/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.0.5
+appVersion: 0.0.6
 description: A Helm chart for robotlb (loadbalancer on hetzner cloud).
 name: robotlb
 type: application

--- a/packages/system/hetzner-robotlb/charts/robotlb/templates/deployment.yaml
+++ b/packages/system/hetzner-robotlb/charts/robotlb/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "robotlb.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicas }}
+  replicas: 1
   selector:
     matchLabels:
       {{- include "robotlb.selectorLabels" . | nindent 6 }}

--- a/packages/system/hetzner-robotlb/charts/robotlb/templates/role.yaml
+++ b/packages/system/hetzner-robotlb/charts/robotlb/templates/role.yaml
@@ -3,7 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "robotlb.fullname" . }}-cr
-rules: {{- toYaml .Values.serviceAccount.permissions | nindent 2 }}
+rules:
+ {{- toYaml .Values.serviceAccount.permissions | nindent 2 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/packages/system/hetzner-robotlb/charts/robotlb/values.yaml
+++ b/packages/system/hetzner-robotlb/charts/robotlb/values.yaml
@@ -36,6 +36,9 @@ serviceAccount:
   - apiGroups: [""]
     resources: [nodes, pods]
     verbs: [get, list, watch]
+  - apiGroups: [discovery.k8s.io]
+    resources: [endpointslices]
+    verbs: [get, list, watch]
 
 podAnnotations: {}
 podLabels: {}


### PR DESCRIPTION
## What this PR does

Bumps the vendored `robotlb` chart to the latest upstream build.
Chart version remains `0.1.3`; the bundled `appVersion` moves from
`0.0.5` to `0.0.6`.

The new `robotlb` release adds RBAC permissions for
`discovery.k8s.io/endpointslices` (`get`, `list`, `watch`), which are
required to manage services backed by `EndpointSlice` — notably
KubeVirt-exposed workloads that do not publish classic `Endpoints`.

Notes:
- Upstream also replaced `replicas: {{ .Values.replicas }}` with a
  hardcoded `replicas: 1` in `templates/deployment.yaml`. The
  effective replica count is unchanged (we already set `1`), but the
  value is no longer overridable via chart values. A minor cosmetic
  reformat was applied to `templates/role.yaml`.

Closes #2256

### Release note

```release-note
chore(hetzner-robotlb): update robotlb to 0.0.6 — adds RBAC for EndpointSlices so services backed by EndpointSlice (e.g. KubeVirt) are supported.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended service account permissions to access Kubernetes endpoint slices from the discovery API.

* **Bug Fixes**
  * Deployment replica configuration now fixed to single instance.

* **Style**
  * Improved YAML formatting in role template declarations.

* **Chores**
  * Updated application version metadata to 0.0.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->