### PR TITLE
[Backport release-1.3] fix(backups): move velero-configmap Role to velero chart

### DIFF
--- a/packages/system/backupstrategy-controller/templates/rbac-bind.yaml
+++ b/packages/system/backupstrategy-controller/templates/rbac-bind.yaml
@@ -10,17 +10,3 @@ subjects:
 - kind: ServiceAccount
   name: backupstrategy-controller
   namespace: {{ .Release.Namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: backups.cozystack.io:strategy-controller:velero-configmaps
-  namespace: cozy-velero
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: backups.cozystack.io:strategy-controller:velero-configmaps
-subjects:
-- kind: ServiceAccount
-  name: backupstrategy-controller
-  namespace: {{ .Release.Namespace }}

--- a/packages/system/backupstrategy-controller/templates/rbac.yaml
+++ b/packages/system/backupstrategy-controller/templates/rbac.yaml
@@ -27,7 +27,9 @@ rules:
   resources: ["pods"]
   verbs: ["get", "list", "watch"]
 # ConfigMaps: controller-runtime cache requires cluster-scoped list/watch;
-# create/update/delete is scoped to cozy-velero via the Role below.
+# create/update/delete is scoped to cozy-velero via a Role shipped by the
+# velero chart (packages/system/velero/templates/backupstrategy-controller-rbac.yaml)
+# so it is only created when velero is installed.
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get", "list", "watch"]
@@ -78,14 +80,3 @@ rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["get", "list", "watch", "create", "update", "patch"]
----
-# To create ResourceModifiers in ConfigMaps for Restore in Velero install namespace.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: backups.cozystack.io:strategy-controller:velero-configmaps
-  namespace: cozy-velero
-rules:
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["create", "get", "list", "delete", "deletecollection", "patch", "update"]

--- a/packages/system/velero/templates/backupstrategy-controller-rbac.yaml
+++ b/packages/system/velero/templates/backupstrategy-controller-rbac.yaml
@@ -1,0 +1,26 @@
+# Grants the backupstrategy-controller permission to manage ResourceModifier
+# ConfigMaps in the Velero install namespace. Lives here (not in the
+# backupstrategy-controller chart) so that the Role is only created when
+# velero is actually installed — otherwise the chart would try to create it
+# in a namespace that does not exist.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backups.cozystack.io:strategy-controller:velero-configmaps
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["create", "get", "list", "delete", "deletecollection", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backups.cozystack.io:strategy-controller:velero-configmaps
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backups.cozystack.io:strategy-controller:velero-configmaps
+subjects:
+- kind: ServiceAccount
+  name: backupstrategy-controller
+  namespace: cozy-backup-controller


### PR DESCRIPTION
## Summary

Backport of #2459 to release-1.3.

Fixes installation failure of `backupstrategy-controller` in bundles without velero.

## Changes

- Move velero-configmap Role/RoleBinding from backupstrategy-controller chart to velero chart
- Prevents "namespaces \"cozy-velero\" not found" error when velero is not installed

## Original Commit

Cherry-pick of c4477259c7e914accaf45238a2b2b591451672a9 from main.