### PR TITLE
docs(agents): retry CI via empty commit, not gh run rerun

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,10 @@ working with the **Cozystack** project.
   - Read: [`overview.md`](./docs/agents/overview.md)
   - Action: Read relevant sections to understand project structure and conventions
 
+- **Retrying CI after a flake** (e.g., "rerun CI", "retry the failed run", "the build flaked, kick it again")
+  - Read: [`contributing.md`](./docs/agents/contributing.md), section "Retrying a CI run after a flake"
+  - Action: Push an empty commit with `git commit --allow-empty`. Do NOT use `gh run rerun` — it bypasses the concurrency group and leaves duplicate runs in flight
+
 - **General questions about contributing**
   - Read: [`contributing.md`](./docs/agents/contributing.md)
   - Action: Read the file to understand git workflow, commit format, PR process

--- a/docs/agents/contributing.md
+++ b/docs/agents/contributing.md
@@ -86,6 +86,19 @@ Fill in the template at [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_
 
 Create the PR with `gh pr create --title "type(scope): brief description" --body-file <file>`.
 
+## Retrying a CI run after a flake
+
+Do NOT use `gh run rerun --failed` (or the "Re-run failed jobs" button) on a PR branch. Push an empty commit instead:
+
+```bash
+git commit --allow-empty --message "chore: retry CI after <flake-name>"
+git push origin <branch>
+```
+
+The `.github/workflows/pull-requests.yaml` workflow is configured with `concurrency.cancel-in-progress: true`, which cancels older runs when a new push arrives on the same PR. A rerun restarts jobs under the *same* `run_id` as a new attempt, which does not re-register into the concurrency group — so if a real fix-commit lands while the rerun is in flight, both runs race to completion and operators pay twice. The empty-commit path participates in the concurrency group cleanly, so the next real push cancels it as expected.
+
+If you already fired `gh run rerun` and need to push a follow-up, cancel the old run manually before pushing: `gh run cancel <run-id> --repo cozystack/cozystack`.
+
 ## Fetching Unresolved Review Comments
 
 Cozystack uses GitHub review threads with resolution status. Only unresolved threads are actionable — resolved threads are already handled.


### PR DESCRIPTION
## What this PR does

Document the correct way to retry a CI run after a flake on a PR branch: push an empty commit, not `gh run rerun`.

### Why

`.github/workflows/pull-requests.yaml` sets `concurrency.cancel-in-progress: true`, which cancels older in-progress runs when a new push arrives on the same PR. Rerun attempts (`gh run rerun --failed` or the "Re-run failed jobs" button) restart jobs under the same `run_id` as a new attempt, which does not re-register the run into the concurrency group. If a real fix-commit lands while a rerun is in flight, the two runs race to completion and CI minutes are spent twice.

Pushing an empty commit creates a fresh workflow run that participates in the concurrency group cleanly, so the next real push cancels it as designed.

### Changes

- `docs/agents/contributing.md` — new section "Retrying a CI run after a flake" with the empty-commit recipe and a manual-cancel fallback for when a rerun is already in flight.
- `AGENTS.md` — new trigger entry for "rerun CI" / "retry the failed run" that routes to the new section.

No runtime code or chart changes.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for safely retrying CI after flaky test failures on pull requests.
  * Recommends pushing an empty commit instead of using the rerun UI to prevent duplicate concurrent runs.
  * Includes fallback procedure for canceling in-progress runs when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->