### PR TITLE
fix: prevent DataStore creation failure during etcd install

### DIFF
--- a/packages/apps/tenant/templates/etcd.yaml
+++ b/packages/apps/tenant/templates/etcd.yaml
@@ -20,6 +20,7 @@ spec:
   interval: 5m
   timeout: 30m
   install:
+    atomic: true
     remediation:
       retries: -1
   upgrade:

--- a/packages/extra/etcd/templates/datastore.yaml
+++ b/packages/extra/etcd/templates/datastore.yaml
@@ -3,6 +3,9 @@ apiVersion: kamaji.clastix.io/v1alpha1
 kind: DataStore
 metadata:
   name: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "10"
 spec:
   driver: etcd
   endpoints:


### PR DESCRIPTION
## Problem

When a new tenant is created, the `etcd` HelmRelease installs successfully but the **DataStore resource is not created**, causing all Kubernetes cluster deployments in that tenant to fail with:

```
Message: cannot create or update TenantControlPlane: admission webhook
  "vtenantcontrolplane.kb.io" denied the request:
  <tenant-name> DataStore does not exist
```

### Root Cause

**Race condition** between cert-manager and Helm resource creation:

1. Helm creates empty TLS Secrets as `pre-install` hooks
2. Helm creates Certificate CRs (cert-manager will populate Secrets)
3. Helm creates DataStore immediately (references the Secrets)
4. cert-manager **asynchronously** populates Secrets
5. Kamaji webhook validates DataStore TLS config
6. **Validation fails** if Secrets are still empty
7. DataStore creation fails, but Helm ignores the error and marks release as `deployed`

### Evidence

- Helm install completes in ~728ms (too fast for 17 resources)
- All etcd resources exist (StatefulSet, Services, Certificates) except DataStore
- `helm get manifest etcd` shows DataStore in the template
- `kubectl get datastore <tenant-name>` returns NotFound

## Solution

This PR implements two complementary fixes:

### 1. Add `atomic: true` to etcd HelmRelease (tenant chart)

Ensures Helm fails the install if any resource fails to create, triggering proper retry via `install.remediation.retries: -1`.

### 2. Use `post-install` hook for DataStore creation (etcd chart)

Creates DataStore **AFTER** all other resources (including Certificates), giving cert-manager time to populate the TLS Secrets before DataStore references them.

```yaml
annotations:
  helm.sh/hook: post-install,post-upgrade
  helm.sh/hook-weight: "10"
```

## Testing

Verified on production cluster:
- Created new nested tenant (`tenant-whmcs-oojyzknp`)
- etcd installed successfully
- DataStore was missing (reproduced the bug)
- Manually applied `helm get manifest etcd | kubectl apply -f -`
- DataStore created successfully, Kubernetes cluster deployed

These fixes prevent the race condition from occurring in the first place.

## Related

Fixes #2412 (DataStore-missing variant described by @tym83)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Deployment reliability strengthened through atomic installation behavior, ensuring all installations complete successfully or fail cleanly without leaving systems in partial deployment states
  * Resource initialization robustness enhanced with post-deployment hooks, guaranteeing all components are properly configured and initialized following installation and upgrade operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->