### PR TITLE
build(linstor): include linstor-gui in root image build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ build: build-deps
 	make -C packages/system/lineage-controller-webhook image
 	make -C packages/system/cilium image
 	make -C packages/system/linstor image
+	make -C packages/system/linstor-gui image
 	make -C packages/system/kubeovn-webhook image
 	make -C packages/system/kubeovn-plunger image
 	make -C packages/system/dashboard image

--- a/packages/system/linstor-gui/Makefile
+++ b/packages/system/linstor-gui/Makefile
@@ -12,18 +12,13 @@ image: image-linstor-gui
 
 image-linstor-gui:
 	docker buildx build images/linstor-gui \
-		--provenance false \
-		--builder=$(BUILDER) \
-		--platform=linux/amd64,linux/arm64 \
 		--build-arg LINSTOR_GUI_VERSION=$(LINSTOR_GUI_VERSION) \
 		--tag $(REGISTRY)/linstor-gui:$(call settag,$(LINSTOR_GUI_VERSION)) \
 		--tag $(REGISTRY)/linstor-gui:$(call settag,$(LINSTOR_GUI_VERSION)-$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/linstor-gui:latest \
 		--cache-to type=inline \
 		--metadata-file images/linstor-gui.json \
-		--push=$(PUSH) \
-		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
-		--load=$(LOAD)
+		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/linstor-gui" \
 		yq -i '.image.repository = strenv(REPOSITORY)' values.yaml
 	TAG="$(call settag,$(LINSTOR_GUI_VERSION))@$$(yq e '."containerimage.digest"' images/linstor-gui.json -o json -r)" \


### PR DESCRIPTION
## What this PR does

The `linstor-gui` package (added in #2382) was never wired into the root `Makefile`'s `build:` target, so the image is not built or published by CI. `ghcr.io/cozystack/cozystack/linstor-gui` returns `NAME_UNKNOWN` from the GHCR API, and `values.yaml` still pins `tag: 2.3.0` without a digest because the per-package Makefile that rewrites the tag after a successful push has never run in CI.

This PR adds the missing line so the next build publishes the image and digest-pins `values.yaml` automatically.

### Release note

```release-note
build(linstor): include linstor-gui in root image build target so the image is built and published by CI (the chart previously referenced an image that did not exist in the registry)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integrated the linstor-gui container image build into the main image build workflow so the GUI image is produced as part of standard builds.
  * Streamlined the GUI image build configuration to use consolidated build arguments, improving consistency and maintainability of automated image builds and metadata updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->