### PR TITLE
fix(installer): bootstrap cozy-system via --create-namespace + label hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,19 +41,30 @@ build: build-deps
 manifests:
 	mkdir -p _out/assets
 	cat internal/crdinstall/manifests/*.yaml > _out/assets/cozystack-crds.yaml
+	# kubectl-apply install path: render the bare Namespace resource alongside
+	# the operator. bareNamespace=true gates a Namespace cozy-system with PSA +
+	# identity labels (see packages/core/installer/templates/cozy-system-namespace.yaml).
+	# helm install/upgrade users keep the default (false) and use --create-namespace
+	# + the pre-install labeler hook.
 	# Talos variant (default)
 	helm template installer packages/core/installer -n cozy-system \
+		--set bareNamespace=true \
+		--show-only templates/cozy-system-namespace.yaml \
 		--show-only templates/cozystack-operator.yaml \
 		> _out/assets/cozystack-operator-talos.yaml
 	# Generic Kubernetes variant (k3s, kubeadm, RKE2)
 	helm template installer packages/core/installer -n cozy-system \
+		--set bareNamespace=true \
 		--set cozystackOperator.variant=generic \
 		--set cozystack.apiServerHost=REPLACE_ME \
+		--show-only templates/cozy-system-namespace.yaml \
 		--show-only templates/cozystack-operator.yaml \
 		> _out/assets/cozystack-operator-generic.yaml
 	# Hosted variant (managed Kubernetes)
 	helm template installer packages/core/installer -n cozy-system \
+		--set bareNamespace=true \
 		--set cozystackOperator.variant=hosted \
+		--show-only templates/cozy-system-namespace.yaml \
 		--show-only templates/cozystack-operator.yaml \
 		> _out/assets/cozystack-operator-hosted.yaml
 

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -16,6 +16,13 @@
     --wait \
     --timeout 2m
 
+  # The pre-install hook (cozy-system-labeler) must have stamped the PSA and
+  # cozystack identity labels onto cozy-system. Operator pods need
+  # enforce=privileged for hostNetwork=true; a silent regression in the hook
+  # would let helm install succeed but break operator admission downstream.
+  kubectl get ns cozy-system -o jsonpath='{.metadata.labels.pod-security\.kubernetes\.io/enforce}' | grep -qx privileged
+  kubectl get ns cozy-system -o jsonpath='{.metadata.labels.cozystack\.io/system}' | grep -qx true
+
   # Verify the operator deployment is available
   kubectl wait deployment/cozystack-operator -n cozy-system --timeout=1m --for=condition=Available
 

--- a/packages/core/installer/templates/cozy-system-labels.yaml
+++ b/packages/core/installer/templates/cozy-system-labels.yaml
@@ -31,7 +31,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-200"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -40,7 +40,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-180"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -54,7 +54,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-160"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
 subjects:
 - kind: ServiceAccount
   name: cozy-system-labeler
@@ -72,7 +72,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-100"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
 spec:
   backoffLimit: 6
   template:
@@ -93,10 +93,24 @@ spec:
         operator: "Exists"
       - key: "node.cloudprovider.kubernetes.io/uninitialized"
         operator: "Exists"
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: kubectl
-        image: alpine/k8s:1.32.0
+        image: alpine/k8s:1.32.0@sha256:4c28b0f0c6accfa07fa449493ea936291e4ff1270500571d73f75bb406676c3b
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
         {{- if eq .Values.cozystackOperator.variant "talos" }}
         env:
         # Talos KubePrism endpoint — same as cozystack-operator uses to reach
@@ -111,6 +125,9 @@ spec:
           value: {{ required "cozystack.apiServerHost is required in generic mode" .Values.cozystack.apiServerHost | quote }}
         - name: KUBERNETES_SERVICE_PORT
           value: {{ .Values.cozystack.apiServerPort | quote }}
+        {{- else if eq .Values.cozystackOperator.variant "hosted" }}
+        # Hosted: use in-cluster service account, no env override needed.
+        env: []
         {{- end }}
         command:
         - kubectl

--- a/packages/core/installer/templates/cozy-system-labels.yaml
+++ b/packages/core/installer/templates/cozy-system-labels.yaml
@@ -1,0 +1,122 @@
+{{/*
+  Pre-install/upgrade hook that labels the cozy-system namespace with the
+  PodSecurity and cozystack identity labels.
+
+  Two chicken-and-egg constraints to thread:
+
+  1. helm v3 cannot adopt a namespace pre-created by --create-namespace
+     because it lacks helm meta annotations; without --create-namespace,
+     helm fails to write its release-secret because the namespace does
+     not exist yet. The chart no longer ships a Namespace cozy-system
+     resource; callers run helm with --create-namespace and the namespace
+     is born bare (no labels).
+
+  2. The operator pod needs hostNetwork=true (no CNI yet at install time),
+     which violates PodSecurity baseline. So cozy-system needs
+     enforce=privileged before the operator pod is admitted. But a labeler
+     pod inside cozy-system would itself need hostNetwork=true and hit
+     the same admission denial. The hook therefore lives in kube-system,
+     which is PSA-exempt on Talos (defaults.exemptions.namespaces in the
+     apiserver PodSecurityConfiguration) and unlabeled on vanilla
+     kubeadm/kind/k3s. The Job's SA is bound to a ClusterRole scoped via
+     resourceNames to "cozy-system" only, so the cluster permission grant
+     is minimal.
+*/}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cozy-system-labeler
+  namespace: kube-system
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-200"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cozy-system-labeler
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-180"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  resourceNames: ["cozy-system"]
+  verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cozy-system-labeler
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-160"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+subjects:
+- kind: ServiceAccount
+  name: cozy-system-labeler
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: cozy-system-labeler
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cozy-system-labeler
+  namespace: kube-system
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-100"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 6
+  template:
+    spec:
+      serviceAccountName: cozy-system-labeler
+      restartPolicy: OnFailure
+      # The hook runs BEFORE Cilium / kube-ovn / any CNI is installed, so the
+      # cluster's nodes are NotReady-NoSchedule and have no pod network. Mirror
+      # the cozystack-operator deployment's scheduling: hostNetwork=true so the
+      # pod doesn't need CNI, plus the same tolerations the operator uses.
+      hostNetwork: true
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+      - key: "node.cilium.io/agent-not-ready"
+        operator: "Exists"
+      - key: "node.cloudprovider.kubernetes.io/uninitialized"
+        operator: "Exists"
+      containers:
+      - name: kubectl
+        image: alpine/k8s:1.32.0
+        imagePullPolicy: IfNotPresent
+        {{- if eq .Values.cozystackOperator.variant "talos" }}
+        env:
+        # Talos KubePrism endpoint — same as cozystack-operator uses to reach
+        # the apiserver before CNI is up.
+        - name: KUBERNETES_SERVICE_HOST
+          value: "localhost"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "7445"
+        {{- else if eq .Values.cozystackOperator.variant "generic" }}
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: {{ required "cozystack.apiServerHost is required in generic mode" .Values.cozystack.apiServerHost | quote }}
+        - name: KUBERNETES_SERVICE_PORT
+          value: {{ .Values.cozystack.apiServerPort | quote }}
+        {{- end }}
+        command:
+        - kubectl
+        - label
+        - --overwrite
+        - namespace
+        - cozy-system
+        - cozystack.io/system=true
+        - pod-security.kubernetes.io/enforce=privileged

--- a/packages/core/installer/templates/cozy-system-labels.yaml
+++ b/packages/core/installer/templates/cozy-system-labels.yaml
@@ -11,16 +11,22 @@
      resource; callers run helm with --create-namespace and the namespace
      is born bare (no labels).
 
-  2. The operator pod needs hostNetwork=true (no CNI yet at install time),
-     which violates PodSecurity baseline. So cozy-system needs
-     enforce=privileged before the operator pod is admitted. But a labeler
-     pod inside cozy-system would itself need hostNetwork=true and hit
-     the same admission denial. The hook therefore lives in kube-system,
-     which is PSA-exempt on Talos (defaults.exemptions.namespaces in the
-     apiserver PodSecurityConfiguration) and unlabeled on vanilla
-     kubeadm/kind/k3s. The Job's SA is bound to a ClusterRole scoped via
-     resourceNames to "cozy-system" only, so the cluster permission grant
-     is minimal.
+  2. On talos / generic, the operator pod needs hostNetwork=true (no CNI
+     yet at install time), which violates PodSecurity baseline. So
+     cozy-system needs enforce=privileged before the operator pod is
+     admitted. But a labeler pod inside cozy-system would itself need
+     hostNetwork=true and hit the same admission denial. The hook
+     therefore lives in kube-system, which is PSA-exempt on Talos
+     (defaults.exemptions.namespaces in the apiserver
+     PodSecurityConfiguration) and unlabeled on vanilla kubeadm/kind/k3s.
+     The Job's SA is bound to a ClusterRole scoped via resourceNames to
+     "cozy-system" only, so the cluster permission grant is minimal.
+
+  Hosted variant: the platform CNI is already up, so the labeler runs
+  without hostNetwork and without the not-ready/CNI-not-ready tolerations.
+  This also keeps the pod admissible on managed clusters
+  (EKS/GKE/AKS/OpenShift) where kube-system may carry strict PSA labels
+  (enforce=baseline or stricter) that would reject hostNetwork pods.
 */}}
 ---
 apiVersion: v1
@@ -79,10 +85,16 @@ spec:
     spec:
       serviceAccountName: cozy-system-labeler
       restartPolicy: OnFailure
+      {{- if ne .Values.cozystackOperator.variant "hosted" }}
       # The hook runs BEFORE Cilium / kube-ovn / any CNI is installed, so the
       # cluster's nodes are NotReady-NoSchedule and have no pod network. Mirror
       # the cozystack-operator deployment's scheduling: hostNetwork=true so the
       # pod doesn't need CNI, plus the same tolerations the operator uses.
+      # dnsPolicy left at the default (ClusterFirst). With hostNetwork=true that
+      # downgrades to "node DNS only", which is fine: kubectl talks to the
+      # apiserver via KubePrism / explicit IP / kubelet-injected env, no DNS
+      # lookups happen. ClusterFirstWithHostNet would not help anyway because
+      # cluster DNS is not yet up at install time.
       hostNetwork: true
       tolerations:
       - key: "node.kubernetes.io/not-ready"
@@ -93,12 +105,13 @@ spec:
         operator: "Exists"
       - key: "node.cloudprovider.kubernetes.io/uninitialized"
         operator: "Exists"
+      {{- end }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault
       containers:
       - name: kubectl
-        image: alpine/k8s:1.32.0@sha256:4c28b0f0c6accfa07fa449493ea936291e4ff1270500571d73f75bb406676c3b
+        image: docker.io/alpine/k8s:1.33.4@sha256:b0523f0a244ddc4c8e055aa335c040d3d78b3ead5528f4544395f7f9f69c7b68
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/packages/core/installer/templates/cozy-system-namespace.yaml
+++ b/packages/core/installer/templates/cozy-system-namespace.yaml
@@ -1,0 +1,25 @@
+{{/*
+  Bare Namespace resource for the kubectl-apply install path only
+  (the rendered _out/assets/cozystack-operator-*.yaml release artifacts).
+
+  Helm install/upgrade callers must NOT render this — it conflicts with
+  `helm --create-namespace`, which is the chicken-and-egg this PR fixes.
+  Helm callers leave `bareNamespace` at its default (false) and let the
+  pre-install labeler hook (cozy-system-labels.yaml) stamp the namespace
+  after `--create-namespace` has created it bare.
+
+  Top-level Makefile passes `--set bareNamespace=true` together with
+  `--show-only` for the manifest render only.
+*/}}
+{{- if .Values.bareNamespace }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cozy-system
+  labels:
+    cozystack.io/system: "true"
+    pod-security.kubernetes.io/enforce: privileged
+  annotations:
+    helm.sh/resource-policy: keep
+{{- end }}

--- a/packages/core/installer/templates/cozystack-operator.yaml
+++ b/packages/core/installer/templates/cozystack-operator.yaml
@@ -4,16 +4,6 @@
 {{- end -}}
 ---
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: cozy-system
-  labels:
-    cozystack.io/system: "true"
-    pod-security.kubernetes.io/enforce: privileged
-  annotations:
-    helm.sh/resource-policy: keep
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cozystack

--- a/packages/core/installer/values.yaml
+++ b/packages/core/installer/values.yaml
@@ -1,3 +1,10 @@
+# Render a bare `Namespace cozy-system` resource (with PSA + identity labels).
+# Off by default: helm install/upgrade callers create the namespace via
+# `--create-namespace` and let the pre-install labeler hook stamp the labels.
+# The top-level Makefile turns this on for the kubectl-apply release artifacts
+# (_out/assets/cozystack-operator-*.yaml).
+bareNamespace: false
+
 cozystackOperator:
   # Deployment variant: talos, generic, hosted
   variant: talos


### PR DESCRIPTION
## Why

helm v3 has a chicken-and-egg with charts that ship their own Namespace resource:

- **With `--create-namespace`** on the install: helm pre-creates the namespace via plain kubectl-create (no helm meta annotations); the chart's own Namespace apply then fails with `already exists`.
- **Without `--create-namespace`**: helm fails immediately because it can't write its release-secret to a non-existent namespace.

The cozy-installer chart shipped a `Namespace cozy-system` resource since the chart's introduction (December 2025). Every cold install since has hit this conflict. It was masked by the 3× retry on `Install Cozystack` in `.github/workflows/pull-requests.yaml`: attempt 1 fails with the conflict, attempt 2 sees the existing failed release and takes the upgrade code path which patch-merges instead of strict-create.

Surfaced when retries on the install step were dropped.

## What

- Remove `Namespace cozy-system` from `packages/core/installer/templates/cozystack-operator.yaml`.
- Add `packages/core/installer/templates/cozy-system-labels.yaml`: a pre-install/pre-upgrade hook (ServiceAccount + ClusterRole + ClusterRoleBinding + Job) that patches `cozystack.io/system=true` and `pod-security.kubernetes.io/enforce=privileged` onto the namespace.
- Hook RBAC is scoped to `verbs: [get, patch]` on `resourceNames: [cozy-system]` only.
- `hook-delete-policy: before-hook-creation,hook-succeeded` so the hook surface only exists during install/upgrade.

Install commands now use `helm upgrade --install --namespace cozy-system --create-namespace …` — standard pattern, matches kube-prometheus-stack / argo-cd / cert-manager.

## Verification

End-to-end on a kind cluster:
- Cold install: 3.3s clean, no retries needed
- Upgrade (re-run): 3.0s, idempotent, namespace stays labeled
- Helm uninstall + re-install: clean

## Test plan

- [ ] CI on this PR passes E2E
- [ ] Existing clusters: namespace already labeled correctly, hook re-asserts on next upgrade — no migration needed

```release-note
fix(installer): cold installs no longer fail on the chart's Namespace resource colliding with `helm --create-namespace`; cozy-system is now bootstrapped via a pre-install hook.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated pre-install/pre-upgrade step that applies system identity and pod-security labels to the system namespace during deployment, run in a hardened one-shot task before normal workloads start.

* **Chores**
  * Separated namespace initialization from the operator install flow so the operator no longer renders or retains the system namespace directly, improving installation sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

