### PR TITLE
feat(operator): expose HelmRelease generation knobs (interval, retry-interval, timeouts, max-history)

### DIFF
--- a/cmd/cozystack-operator/main.go
+++ b/cmd/cozystack-operator/main.go
@@ -85,6 +85,9 @@ func main() {
 	var telemetryInterval string
 	var helmReleaseInterval string
 	var helmReleaseRetryInterval string
+	var helmReleaseInstallTimeout string
+	var helmReleaseUpgradeTimeout string
+	var helmReleaseMaxHistory int
 	var cozyValuesSecretName string
 	var cozyValuesSecretNamespace string
 	var cozyValuesNamespaceSelector string
@@ -119,6 +122,18 @@ func main() {
 			"controller waits between failed install/upgrade attempts. Decoupled from --helmrelease-interval "+
 			"(which is the healthy reconcile cadence) so failures recover fast without polling healthy "+
 			"releases at the same fast cadence.")
+	flag.StringVar(&helmReleaseInstallTimeout, "helmrelease-install-timeout", "10m",
+		"Timeout for the Helm install action of HelmReleases created by the Package reconciler "+
+			"(Spec.Install.Timeout). Bounds how long an individual Kubernetes operation (Job/hook/wait) "+
+			"may take during install.")
+	flag.StringVar(&helmReleaseUpgradeTimeout, "helmrelease-upgrade-timeout", "10m",
+		"Timeout for the Helm upgrade action of HelmReleases created by the Package reconciler "+
+			"(Spec.Upgrade.Timeout). Bounds how long an individual Kubernetes operation (Job/hook/wait) "+
+			"may take during upgrade.")
+	flag.IntVar(&helmReleaseMaxHistory, "helmrelease-max-history", 5,
+		"Number of release revisions Helm keeps for HelmReleases created by the Package reconciler "+
+			"(Spec.MaxHistory). 0 means unlimited; 5 matches Helm's default. Lower values reduce "+
+			"per-release Secret accumulation in clusters that bounce HRs frequently (e.g. E2E sandboxes).")
 	flag.StringVar(&platformSourceURL, "platform-source-url", "", "Platform source URL (oci:// or https://). If specified, generates OCIRepository or GitRepository resource.")
 	flag.StringVar(&platformSourceName, "platform-source-name", "cozystack-platform", "Name for the generated platform source resource and PackageSource")
 	flag.StringVar(&platformSourceRef, "platform-source-ref", "", "Reference specification as key=value pairs (e.g., 'branch=main' or 'digest=sha256:...,tag=v1.0'). For OCI: digest, semver, semverFilter, tag. For Git: branch, tag, semver, name, commit.")
@@ -142,6 +157,20 @@ func main() {
 	hrRetryIntervalDuration, err := time.ParseDuration(helmReleaseRetryInterval)
 	if err != nil {
 		setupLog.Error(err, "invalid --helmrelease-retry-interval value", "value", helmReleaseRetryInterval)
+		os.Exit(1)
+	}
+	hrInstallTimeoutDuration, err := time.ParseDuration(helmReleaseInstallTimeout)
+	if err != nil {
+		setupLog.Error(err, "invalid --helmrelease-install-timeout value", "value", helmReleaseInstallTimeout)
+		os.Exit(1)
+	}
+	hrUpgradeTimeoutDuration, err := time.ParseDuration(helmReleaseUpgradeTimeout)
+	if err != nil {
+		setupLog.Error(err, "invalid --helmrelease-upgrade-timeout value", "value", helmReleaseUpgradeTimeout)
+		os.Exit(1)
+	}
+	if helmReleaseMaxHistory < 0 {
+		setupLog.Error(fmt.Errorf("--helmrelease-max-history must be >= 0"), "invalid value", "value", helmReleaseMaxHistory)
 		os.Exit(1)
 	}
 
@@ -281,10 +310,13 @@ func main() {
 
 	// Setup Package reconciler
 	if err := (&operator.PackageReconciler{
-		Client:                   mgr.GetClient(),
-		Scheme:                   mgr.GetScheme(),
-		HelmReleaseInterval:      hrIntervalDuration,
-		HelmReleaseRetryInterval: hrRetryIntervalDuration,
+		Client:                    mgr.GetClient(),
+		Scheme:                    mgr.GetScheme(),
+		HelmReleaseInterval:       hrIntervalDuration,
+		HelmReleaseRetryInterval:  hrRetryIntervalDuration,
+		HelmReleaseInstallTimeout: hrInstallTimeoutDuration,
+		HelmReleaseUpgradeTimeout: hrUpgradeTimeoutDuration,
+		HelmReleaseMaxHistory:     helmReleaseMaxHistory,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Package")
 		os.Exit(1)

--- a/cmd/cozystack-operator/main.go
+++ b/cmd/cozystack-operator/main.go
@@ -84,6 +84,7 @@ func main() {
 	var telemetryEndpoint string
 	var telemetryInterval string
 	var helmReleaseInterval string
+	var helmReleaseRetryInterval string
 	var cozyValuesSecretName string
 	var cozyValuesSecretNamespace string
 	var cozyValuesNamespaceSelector string
@@ -112,6 +113,12 @@ func main() {
 		"Reconcile interval applied to HelmReleases created by the Package reconciler. "+
 			"Lower values speed up dependency-blocked retries (e.g. during E2E install) at the cost of "+
 			"controller load. Production default 5m matches existing behaviour.")
+	flag.StringVar(&helmReleaseRetryInterval, "helmrelease-retry-interval", "30s",
+		"Retry interval applied to Install.Strategy and Upgrade.Strategy of HelmReleases created "+
+			"by the Package reconciler. With Strategy.Name=RetryOnFailure, this controls how long the "+
+			"controller waits between failed install/upgrade attempts. Decoupled from --helmrelease-interval "+
+			"(which is the healthy reconcile cadence) so failures recover fast without polling healthy "+
+			"releases at the same fast cadence.")
 	flag.StringVar(&platformSourceURL, "platform-source-url", "", "Platform source URL (oci:// or https://). If specified, generates OCIRepository or GitRepository resource.")
 	flag.StringVar(&platformSourceName, "platform-source-name", "cozystack-platform", "Name for the generated platform source resource and PackageSource")
 	flag.StringVar(&platformSourceRef, "platform-source-ref", "", "Reference specification as key=value pairs (e.g., 'branch=main' or 'digest=sha256:...,tag=v1.0'). For OCI: digest, semver, semverFilter, tag. For Git: branch, tag, semver, name, commit.")
@@ -130,6 +137,11 @@ func main() {
 	hrIntervalDuration, err := time.ParseDuration(helmReleaseInterval)
 	if err != nil {
 		setupLog.Error(err, "invalid --helmrelease-interval value", "value", helmReleaseInterval)
+		os.Exit(1)
+	}
+	hrRetryIntervalDuration, err := time.ParseDuration(helmReleaseRetryInterval)
+	if err != nil {
+		setupLog.Error(err, "invalid --helmrelease-retry-interval value", "value", helmReleaseRetryInterval)
 		os.Exit(1)
 	}
 
@@ -269,9 +281,10 @@ func main() {
 
 	// Setup Package reconciler
 	if err := (&operator.PackageReconciler{
-		Client:              mgr.GetClient(),
-		Scheme:              mgr.GetScheme(),
-		HelmReleaseInterval: hrIntervalDuration,
+		Client:                   mgr.GetClient(),
+		Scheme:                   mgr.GetScheme(),
+		HelmReleaseInterval:      hrIntervalDuration,
+		HelmReleaseRetryInterval: hrRetryIntervalDuration,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Package")
 		os.Exit(1)

--- a/cmd/cozystack-operator/main.go
+++ b/cmd/cozystack-operator/main.go
@@ -83,6 +83,7 @@ func main() {
 	var disableTelemetry bool
 	var telemetryEndpoint string
 	var telemetryInterval string
+	var helmReleaseInterval string
 	var cozyValuesSecretName string
 	var cozyValuesSecretNamespace string
 	var cozyValuesNamespaceSelector string
@@ -107,6 +108,10 @@ func main() {
 		"Endpoint for sending telemetry data")
 	flag.StringVar(&telemetryInterval, "telemetry-interval", "15m",
 		"Interval between telemetry data collection (e.g. 15m, 1h)")
+	flag.StringVar(&helmReleaseInterval, "helmrelease-interval", "5m",
+		"Reconcile interval applied to HelmReleases created by the Package reconciler. "+
+			"Lower values speed up dependency-blocked retries (e.g. during E2E install) at the cost of "+
+			"controller load. Production default 5m matches existing behaviour.")
 	flag.StringVar(&platformSourceURL, "platform-source-url", "", "Platform source URL (oci:// or https://). If specified, generates OCIRepository or GitRepository resource.")
 	flag.StringVar(&platformSourceName, "platform-source-name", "cozystack-platform", "Name for the generated platform source resource and PackageSource")
 	flag.StringVar(&platformSourceRef, "platform-source-ref", "", "Reference specification as key=value pairs (e.g., 'branch=main' or 'digest=sha256:...,tag=v1.0'). For OCI: digest, semver, semverFilter, tag. For Git: branch, tag, semver, name, commit.")
@@ -121,6 +126,12 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	hrIntervalDuration, err := time.ParseDuration(helmReleaseInterval)
+	if err != nil {
+		setupLog.Error(err, "invalid --helmrelease-interval value", "value", helmReleaseInterval)
+		os.Exit(1)
+	}
 
 	config := ctrl.GetConfigOrDie()
 
@@ -258,8 +269,9 @@ func main() {
 
 	// Setup Package reconciler
 	if err := (&operator.PackageReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		HelmReleaseInterval: hrIntervalDuration,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Package")
 		os.Exit(1)

--- a/cmd/cozystack-operator/main.go
+++ b/cmd/cozystack-operator/main.go
@@ -149,26 +149,18 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	// time.ParseDuration accepts "0s" and negative values, but Flux HelmRelease
-	// fields (Interval, Timeout, RetryInterval) require strictly positive
-	// durations to function. Reject non-positive values at startup so a
-	// misconfigured flag fails fast instead of propagating into every HR.
-	parsePositiveDuration := func(flagName, raw string) time.Duration {
-		d, err := time.ParseDuration(raw)
+	parseFlag := func(flagName, raw string) time.Duration {
+		d, err := parsePositiveDuration(flagName, raw)
 		if err != nil {
-			setupLog.Error(err, "invalid duration flag", "flag", flagName, "value", raw)
-			os.Exit(1)
-		}
-		if d <= 0 {
-			setupLog.Error(fmt.Errorf("%s must be > 0", flagName), "invalid duration flag", "flag", flagName, "value", raw)
+			setupLog.Error(err, "invalid duration flag")
 			os.Exit(1)
 		}
 		return d
 	}
-	hrIntervalDuration := parsePositiveDuration("--helmrelease-interval", helmReleaseInterval)
-	hrRetryIntervalDuration := parsePositiveDuration("--helmrelease-retry-interval", helmReleaseRetryInterval)
-	hrInstallTimeoutDuration := parsePositiveDuration("--helmrelease-install-timeout", helmReleaseInstallTimeout)
-	hrUpgradeTimeoutDuration := parsePositiveDuration("--helmrelease-upgrade-timeout", helmReleaseUpgradeTimeout)
+	hrIntervalDuration := parseFlag("--helmrelease-interval", helmReleaseInterval)
+	hrRetryIntervalDuration := parseFlag("--helmrelease-retry-interval", helmReleaseRetryInterval)
+	hrInstallTimeoutDuration := parseFlag("--helmrelease-install-timeout", helmReleaseInstallTimeout)
+	hrUpgradeTimeoutDuration := parseFlag("--helmrelease-upgrade-timeout", helmReleaseUpgradeTimeout)
 	if helmReleaseMaxHistory < 0 {
 		setupLog.Error(fmt.Errorf("--helmrelease-max-history must be >= 0"), "invalid value", "value", helmReleaseMaxHistory)
 		os.Exit(1)
@@ -445,6 +437,21 @@ func installPlatformSourceResource(ctx context.Context, k8sClient client.Client,
 	}
 
 	return nil
+}
+
+// parsePositiveDuration parses raw as a time.Duration and rejects malformed
+// or non-positive values. Flux HelmRelease fields (Interval, Timeout,
+// RetryInterval) require strictly positive durations, so a misconfigured
+// flag must fail fast at startup rather than propagating into every HR.
+func parsePositiveDuration(flagName, raw string) (time.Duration, error) {
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration for %s=%q: %w", flagName, raw, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("%s must be > 0 (got %q)", flagName, raw)
+	}
+	return d, nil
 }
 
 // parsePlatformSourceURL parses the source URL and returns the source type and repository URL.

--- a/cmd/cozystack-operator/main.go
+++ b/cmd/cozystack-operator/main.go
@@ -149,26 +149,26 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	hrIntervalDuration, err := time.ParseDuration(helmReleaseInterval)
-	if err != nil {
-		setupLog.Error(err, "invalid --helmrelease-interval value", "value", helmReleaseInterval)
-		os.Exit(1)
+	// time.ParseDuration accepts "0s" and negative values, but Flux HelmRelease
+	// fields (Interval, Timeout, RetryInterval) require strictly positive
+	// durations to function. Reject non-positive values at startup so a
+	// misconfigured flag fails fast instead of propagating into every HR.
+	parsePositiveDuration := func(flagName, raw string) time.Duration {
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			setupLog.Error(err, "invalid duration flag", "flag", flagName, "value", raw)
+			os.Exit(1)
+		}
+		if d <= 0 {
+			setupLog.Error(fmt.Errorf("%s must be > 0", flagName), "invalid duration flag", "flag", flagName, "value", raw)
+			os.Exit(1)
+		}
+		return d
 	}
-	hrRetryIntervalDuration, err := time.ParseDuration(helmReleaseRetryInterval)
-	if err != nil {
-		setupLog.Error(err, "invalid --helmrelease-retry-interval value", "value", helmReleaseRetryInterval)
-		os.Exit(1)
-	}
-	hrInstallTimeoutDuration, err := time.ParseDuration(helmReleaseInstallTimeout)
-	if err != nil {
-		setupLog.Error(err, "invalid --helmrelease-install-timeout value", "value", helmReleaseInstallTimeout)
-		os.Exit(1)
-	}
-	hrUpgradeTimeoutDuration, err := time.ParseDuration(helmReleaseUpgradeTimeout)
-	if err != nil {
-		setupLog.Error(err, "invalid --helmrelease-upgrade-timeout value", "value", helmReleaseUpgradeTimeout)
-		os.Exit(1)
-	}
+	hrIntervalDuration := parsePositiveDuration("--helmrelease-interval", helmReleaseInterval)
+	hrRetryIntervalDuration := parsePositiveDuration("--helmrelease-retry-interval", helmReleaseRetryInterval)
+	hrInstallTimeoutDuration := parsePositiveDuration("--helmrelease-install-timeout", helmReleaseInstallTimeout)
+	hrUpgradeTimeoutDuration := parsePositiveDuration("--helmrelease-upgrade-timeout", helmReleaseUpgradeTimeout)
 	if helmReleaseMaxHistory < 0 {
 		setupLog.Error(fmt.Errorf("--helmrelease-max-history must be >= 0"), "invalid value", "value", helmReleaseMaxHistory)
 		os.Exit(1)

--- a/cmd/cozystack-operator/main_test.go
+++ b/cmd/cozystack-operator/main_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"testing"
+	"time"
 
 	cozyv1alpha1 "github.com/cozystack/cozystack/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -570,5 +571,40 @@ func TestGenerateGitRepository_InvalidRef(t *testing.T) {
 	_, err := generateGitRepository("my-repo", "https://github.com/user/repo", map[string]string{"digest": "sha256:abc"})
 	if err == nil {
 		t.Fatal("expected error for invalid Git ref key, got nil")
+	}
+}
+
+func TestParsePositiveDuration(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "valid seconds", raw: "30s", want: 30 * time.Second},
+		{name: "valid minutes", raw: "5m", want: 5 * time.Minute},
+		{name: "valid compound", raw: "1h30m", want: 90 * time.Minute},
+		{name: "zero rejected", raw: "0s", wantErr: true},
+		{name: "negative rejected", raw: "-5m", wantErr: true},
+		{name: "malformed rejected", raw: "5x", wantErr: true},
+		{name: "empty rejected", raw: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePositiveDuration("--test-flag", tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got nil", tt.raw)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -155,16 +155,7 @@ EOF
   timeout 60 sh -ec 'until kubectl get hr -n tenant-root etcd ingress monitoring seaweedfs tenant-root >/dev/null 2>&1; do sleep 1; done'
   kubectl wait hr/etcd hr/ingress hr/tenant-root hr/seaweedfs -n tenant-root --timeout=4m --for=condition=ready
 
-  # TODO: Workaround ingress unvailability issue
-  if ! kubectl wait hr/monitoring -n tenant-root --timeout=2m --for=condition=ready; then
-    flux reconcile hr monitoring -n tenant-root --force
-    kubectl wait hr/monitoring -n tenant-root --timeout=2m --for=condition=ready
-  fi
-
-  if ! kubectl wait hr/seaweedfs-system -n tenant-root --timeout=2m --for=condition=ready; then
-    flux reconcile hr seaweedfs-system -n tenant-root --force
-    kubectl wait hr/seaweedfs-system -n tenant-root --timeout=2m --for=condition=ready
-  fi
+  kubectl wait hr/monitoring hr/seaweedfs-system -n tenant-root --timeout=2m --for=condition=ready
 
 
   # Expose Cozystack services through ingress

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -13,6 +13,7 @@
     --install \
     --namespace cozy-system \
     --create-namespace \
+    --set cozystackOperator.helmReleaseInterval=30s \
     --wait \
     --timeout 2m
 

--- a/internal/operator/package_reconciler.go
+++ b/internal/operator/package_reconciler.go
@@ -67,6 +67,36 @@ type PackageReconciler struct {
 	HelmReleaseMaxHistory     int
 }
 
+// buildHelmReleaseSpec assembles the Spec applied to every generated
+// HelmRelease. RetryInterval drives recovery from failed install/upgrade
+// attempts; Interval polls healthy releases.
+func (r *PackageReconciler) buildHelmReleaseSpec(componentInstall *cozyv1alpha1.ComponentInstall, artifactName string) helmv2.HelmReleaseSpec {
+	return helmv2.HelmReleaseSpec{
+		Interval:   metav1.Duration{Duration: r.HelmReleaseInterval},
+		MaxHistory: &r.HelmReleaseMaxHistory,
+		ChartRef: &helmv2.CrossNamespaceSourceReference{
+			Kind:      "ExternalArtifact",
+			Name:      artifactName,
+			Namespace: "cozy-system",
+		},
+		Install: &helmv2.Install{
+			Timeout: &metav1.Duration{Duration: r.HelmReleaseInstallTimeout},
+			Strategy: &helmv2.InstallStrategy{
+				Name:          string(helmv2.ActionStrategyRetryOnFailure),
+				RetryInterval: &metav1.Duration{Duration: r.HelmReleaseRetryInterval},
+			},
+		},
+		Upgrade: &helmv2.Upgrade{
+			Timeout: &metav1.Duration{Duration: r.HelmReleaseUpgradeTimeout},
+			Strategy: &helmv2.UpgradeStrategy{
+				Name:          string(helmv2.ActionStrategyRetryOnFailure),
+				RetryInterval: &metav1.Duration{Duration: r.HelmReleaseRetryInterval},
+			},
+			CRDs: parseCRDPolicy(componentInstall),
+		},
+	}
+}
+
 // +kubebuilder:rbac:groups=cozystack.io,resources=packages,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cozystack.io,resources=packages/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=cozystack.io,resources=packagesources,verbs=get;list;watch
@@ -219,35 +249,7 @@ func (r *PackageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				Namespace: namespace,
 				Labels:    labels,
 			},
-			Spec: helmv2.HelmReleaseSpec{
-				Interval:   metav1.Duration{Duration: r.HelmReleaseInterval},
-				MaxHistory: &r.HelmReleaseMaxHistory,
-				ChartRef: &helmv2.CrossNamespaceSourceReference{
-					Kind:      "ExternalArtifact",
-					Name:      artifactName,
-					Namespace: "cozy-system",
-				},
-				Install: &helmv2.Install{
-					Timeout: &metav1.Duration{Duration: r.HelmReleaseInstallTimeout},
-					// Strategy=RetryOnFailure (with RetryInterval) replaces the previous
-					// Remediation{Retries:-1} setup. Functionally equivalent ("retry forever
-					// on failure"), but decouples retry timing from spec.Interval so failed
-					// installs recover at HelmReleaseRetryInterval (default 30s) without
-					// also polling healthy releases at the same fast cadence.
-					Strategy: &helmv2.InstallStrategy{
-						Name:          string(helmv2.ActionStrategyRetryOnFailure),
-						RetryInterval: &metav1.Duration{Duration: r.HelmReleaseRetryInterval},
-					},
-				},
-				Upgrade: &helmv2.Upgrade{
-					Timeout: &metav1.Duration{Duration: r.HelmReleaseUpgradeTimeout},
-					Strategy: &helmv2.UpgradeStrategy{
-						Name:          string(helmv2.ActionStrategyRetryOnFailure),
-						RetryInterval: &metav1.Duration{Duration: r.HelmReleaseRetryInterval},
-					},
-					CRDs: parseCRDPolicy(component.Install),
-				},
-			},
+			Spec: r.buildHelmReleaseSpec(component.Install, artifactName),
 		}
 
 		// Add valuesFrom for cozystack-values secret unless disabled by annotation on PackageSource

--- a/internal/operator/package_reconciler.go
+++ b/internal/operator/package_reconciler.go
@@ -59,8 +59,9 @@ func parseCRDPolicy(install *cozyv1alpha1.ComponentInstall) helmv2.CRDsPolicy {
 // PackageReconciler reconciles Package resources
 type PackageReconciler struct {
 	client.Client
-	Scheme              *runtime.Scheme
-	HelmReleaseInterval time.Duration
+	Scheme                   *runtime.Scheme
+	HelmReleaseInterval      time.Duration
+	HelmReleaseRetryInterval time.Duration
 }
 
 // +kubebuilder:rbac:groups=cozystack.io,resources=packages,verbs=get;list;watch;create;update;patch;delete
@@ -223,15 +224,22 @@ func (r *PackageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 					Namespace: "cozy-system",
 				},
 				Install: &helmv2.Install{
-					Timeout: &metav1.Duration{Duration: 10 * 60 * 1000000000}, // 10m
-					Remediation: &helmv2.InstallRemediation{
-						Retries: -1,
+					Timeout: &metav1.Duration{Duration: 10 * time.Minute},
+					// Strategy=RetryOnFailure (with RetryInterval) replaces the previous
+					// Remediation{Retries:-1} setup. Functionally equivalent ("retry forever
+					// on failure"), but decouples retry timing from spec.Interval so failed
+					// installs recover at HelmReleaseRetryInterval (default 30s) without
+					// also polling healthy releases at the same fast cadence.
+					Strategy: &helmv2.InstallStrategy{
+						Name:          string(helmv2.ActionStrategyRetryOnFailure),
+						RetryInterval: &metav1.Duration{Duration: r.HelmReleaseRetryInterval},
 					},
 				},
 				Upgrade: &helmv2.Upgrade{
-					Timeout: &metav1.Duration{Duration: 10 * 60 * 1000000000}, // 10m
-					Remediation: &helmv2.UpgradeRemediation{
-						Retries: -1,
+					Timeout: &metav1.Duration{Duration: 10 * time.Minute},
+					Strategy: &helmv2.UpgradeStrategy{
+						Name:          string(helmv2.ActionStrategyRetryOnFailure),
+						RetryInterval: &metav1.Duration{Duration: r.HelmReleaseRetryInterval},
 					},
 					CRDs: parseCRDPolicy(component.Install),
 				},

--- a/internal/operator/package_reconciler.go
+++ b/internal/operator/package_reconciler.go
@@ -71,9 +71,10 @@ type PackageReconciler struct {
 // HelmRelease. RetryInterval drives recovery from failed install/upgrade
 // attempts; Interval polls healthy releases.
 func (r *PackageReconciler) buildHelmReleaseSpec(componentInstall *cozyv1alpha1.ComponentInstall, artifactName string) helmv2.HelmReleaseSpec {
+	maxHistory := r.HelmReleaseMaxHistory
 	return helmv2.HelmReleaseSpec{
 		Interval:   metav1.Duration{Duration: r.HelmReleaseInterval},
-		MaxHistory: &r.HelmReleaseMaxHistory,
+		MaxHistory: &maxHistory,
 		ChartRef: &helmv2.CrossNamespaceSourceReference{
 			Kind:      "ExternalArtifact",
 			Name:      artifactName,

--- a/internal/operator/package_reconciler.go
+++ b/internal/operator/package_reconciler.go
@@ -59,9 +59,12 @@ func parseCRDPolicy(install *cozyv1alpha1.ComponentInstall) helmv2.CRDsPolicy {
 // PackageReconciler reconciles Package resources
 type PackageReconciler struct {
 	client.Client
-	Scheme                   *runtime.Scheme
-	HelmReleaseInterval      time.Duration
-	HelmReleaseRetryInterval time.Duration
+	Scheme                    *runtime.Scheme
+	HelmReleaseInterval       time.Duration
+	HelmReleaseRetryInterval  time.Duration
+	HelmReleaseInstallTimeout time.Duration
+	HelmReleaseUpgradeTimeout time.Duration
+	HelmReleaseMaxHistory     int
 }
 
 // +kubebuilder:rbac:groups=cozystack.io,resources=packages,verbs=get;list;watch;create;update;patch;delete
@@ -217,14 +220,15 @@ func (r *PackageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				Labels:    labels,
 			},
 			Spec: helmv2.HelmReleaseSpec{
-				Interval: metav1.Duration{Duration: r.HelmReleaseInterval},
+				Interval:   metav1.Duration{Duration: r.HelmReleaseInterval},
+				MaxHistory: &r.HelmReleaseMaxHistory,
 				ChartRef: &helmv2.CrossNamespaceSourceReference{
 					Kind:      "ExternalArtifact",
 					Name:      artifactName,
 					Namespace: "cozy-system",
 				},
 				Install: &helmv2.Install{
-					Timeout: &metav1.Duration{Duration: 10 * time.Minute},
+					Timeout: &metav1.Duration{Duration: r.HelmReleaseInstallTimeout},
 					// Strategy=RetryOnFailure (with RetryInterval) replaces the previous
 					// Remediation{Retries:-1} setup. Functionally equivalent ("retry forever
 					// on failure"), but decouples retry timing from spec.Interval so failed
@@ -236,7 +240,7 @@ func (r *PackageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 					},
 				},
 				Upgrade: &helmv2.Upgrade{
-					Timeout: &metav1.Duration{Duration: 10 * time.Minute},
+					Timeout: &metav1.Duration{Duration: r.HelmReleaseUpgradeTimeout},
 					Strategy: &helmv2.UpgradeStrategy{
 						Name:          string(helmv2.ActionStrategyRetryOnFailure),
 						RetryInterval: &metav1.Duration{Duration: r.HelmReleaseRetryInterval},

--- a/internal/operator/package_reconciler.go
+++ b/internal/operator/package_reconciler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	cozyv1alpha1 "github.com/cozystack/cozystack/api/v1alpha1"
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
@@ -58,7 +59,8 @@ func parseCRDPolicy(install *cozyv1alpha1.ComponentInstall) helmv2.CRDsPolicy {
 // PackageReconciler reconciles Package resources
 type PackageReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme              *runtime.Scheme
+	HelmReleaseInterval time.Duration
 }
 
 // +kubebuilder:rbac:groups=cozystack.io,resources=packages,verbs=get;list;watch;create;update;patch;delete
@@ -214,7 +216,7 @@ func (r *PackageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				Labels:    labels,
 			},
 			Spec: helmv2.HelmReleaseSpec{
-				Interval: metav1.Duration{Duration: 5 * 60 * 1000000000}, // 5m
+				Interval: metav1.Duration{Duration: r.HelmReleaseInterval},
 				ChartRef: &helmv2.CrossNamespaceSourceReference{
 					Kind:      "ExternalArtifact",
 					Name:      artifactName,

--- a/internal/operator/package_reconciler_test.go
+++ b/internal/operator/package_reconciler_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	cozyv1alpha1 "github.com/cozystack/cozystack/api/v1alpha1"
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
@@ -68,6 +69,91 @@ func TestParseCRDPolicy(t *testing.T) {
 				t.Errorf("parseCRDPolicy() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestBuildHelmReleaseSpec(t *testing.T) {
+	r := &PackageReconciler{
+		HelmReleaseInterval:       42 * time.Second,
+		HelmReleaseRetryInterval:  17 * time.Second,
+		HelmReleaseInstallTimeout: 11 * time.Minute,
+		HelmReleaseUpgradeTimeout: 13 * time.Minute,
+		HelmReleaseMaxHistory:     7,
+	}
+	componentInstall := &cozyv1alpha1.ComponentInstall{UpgradeCRDs: "Skip"}
+
+	spec := r.buildHelmReleaseSpec(componentInstall, "ps-variant-component")
+
+	if spec.Interval.Duration != 42*time.Second {
+		t.Errorf("Interval = %v, want 42s", spec.Interval.Duration)
+	}
+	if spec.MaxHistory == nil {
+		t.Fatal("MaxHistory is nil, want pointer to 7")
+	}
+	if *spec.MaxHistory != 7 {
+		t.Errorf("MaxHistory = %d, want 7", *spec.MaxHistory)
+	}
+
+	if spec.ChartRef == nil {
+		t.Fatal("ChartRef is nil")
+	}
+	if spec.ChartRef.Kind != "ExternalArtifact" {
+		t.Errorf("ChartRef.Kind = %q, want ExternalArtifact", spec.ChartRef.Kind)
+	}
+	if spec.ChartRef.Name != "ps-variant-component" {
+		t.Errorf("ChartRef.Name = %q, want ps-variant-component", spec.ChartRef.Name)
+	}
+	if spec.ChartRef.Namespace != "cozy-system" {
+		t.Errorf("ChartRef.Namespace = %q, want cozy-system", spec.ChartRef.Namespace)
+	}
+
+	if spec.Install == nil {
+		t.Fatal("Install is nil")
+	}
+	if spec.Install.Timeout == nil || spec.Install.Timeout.Duration != 11*time.Minute {
+		t.Errorf("Install.Timeout = %v, want 11m", spec.Install.Timeout)
+	}
+	if spec.Install.Strategy == nil {
+		t.Fatal("Install.Strategy is nil")
+	}
+	if spec.Install.Strategy.Name != string(helmv2.ActionStrategyRetryOnFailure) {
+		t.Errorf("Install.Strategy.Name = %q, want %q", spec.Install.Strategy.Name, helmv2.ActionStrategyRetryOnFailure)
+	}
+	if spec.Install.Strategy.RetryInterval == nil || spec.Install.Strategy.RetryInterval.Duration != 17*time.Second {
+		t.Errorf("Install.Strategy.RetryInterval = %v, want 17s", spec.Install.Strategy.RetryInterval)
+	}
+
+	if spec.Upgrade == nil {
+		t.Fatal("Upgrade is nil")
+	}
+	if spec.Upgrade.Timeout == nil || spec.Upgrade.Timeout.Duration != 13*time.Minute {
+		t.Errorf("Upgrade.Timeout = %v, want 13m", spec.Upgrade.Timeout)
+	}
+	if spec.Upgrade.Strategy == nil {
+		t.Fatal("Upgrade.Strategy is nil")
+	}
+	if spec.Upgrade.Strategy.Name != string(helmv2.ActionStrategyRetryOnFailure) {
+		t.Errorf("Upgrade.Strategy.Name = %q, want %q", spec.Upgrade.Strategy.Name, helmv2.ActionStrategyRetryOnFailure)
+	}
+	if spec.Upgrade.Strategy.RetryInterval == nil || spec.Upgrade.Strategy.RetryInterval.Duration != 17*time.Second {
+		t.Errorf("Upgrade.Strategy.RetryInterval = %v, want 17s", spec.Upgrade.Strategy.RetryInterval)
+	}
+	if spec.Upgrade.CRDs != helmv2.Skip {
+		t.Errorf("Upgrade.CRDs = %q, want Skip", spec.Upgrade.CRDs)
+	}
+}
+
+// TestBuildHelmReleaseSpecZeroMaxHistory pins that MaxHistory=0 (unlimited
+// history per Helm semantics) survives the spec build — i.e. is set as a
+// non-nil pointer to 0 rather than dropped or replaced with a default.
+func TestBuildHelmReleaseSpecZeroMaxHistory(t *testing.T) {
+	r := &PackageReconciler{HelmReleaseMaxHistory: 0}
+	spec := r.buildHelmReleaseSpec(nil, "x")
+	if spec.MaxHistory == nil {
+		t.Fatal("MaxHistory is nil for HelmReleaseMaxHistory=0; want pointer to 0")
+	}
+	if *spec.MaxHistory != 0 {
+		t.Errorf("MaxHistory = %d, want 0", *spec.MaxHistory)
 	}
 }
 

--- a/internal/operator/package_reconciler_test.go
+++ b/internal/operator/package_reconciler_test.go
@@ -122,6 +122,13 @@ func TestBuildHelmReleaseSpec(t *testing.T) {
 	if spec.Install.Strategy.RetryInterval == nil || spec.Install.Strategy.RetryInterval.Duration != 17*time.Second {
 		t.Errorf("Install.Strategy.RetryInterval = %v, want 17s", spec.Install.Strategy.RetryInterval)
 	}
+	// Remediation must remain nil: helm-controller's XValidation rule rejects
+	// Strategy.Name=RetryOnFailure with RetryInterval set alongside a
+	// Remediation entry, so a future "for safety" re-introduction of
+	// Remediation{Retries: -1} would silently break every HR.
+	if spec.Install.Remediation != nil {
+		t.Errorf("Install.Remediation = %+v, want nil", spec.Install.Remediation)
+	}
 
 	if spec.Upgrade == nil {
 		t.Fatal("Upgrade is nil")
@@ -137,6 +144,9 @@ func TestBuildHelmReleaseSpec(t *testing.T) {
 	}
 	if spec.Upgrade.Strategy.RetryInterval == nil || spec.Upgrade.Strategy.RetryInterval.Duration != 17*time.Second {
 		t.Errorf("Upgrade.Strategy.RetryInterval = %v, want 17s", spec.Upgrade.Strategy.RetryInterval)
+	}
+	if spec.Upgrade.Remediation != nil {
+		t.Errorf("Upgrade.Remediation = %+v, want nil", spec.Upgrade.Remediation)
 	}
 	if spec.Upgrade.CRDs != helmv2.Skip {
 		t.Errorf("Upgrade.CRDs = %q, want Skip", spec.Upgrade.CRDs)

--- a/packages/core/installer/templates/cozystack-operator.yaml
+++ b/packages/core/installer/templates/cozystack-operator.yaml
@@ -68,6 +68,9 @@ spec:
         {{- if .Values.cozystackOperator.disableTelemetry }}
         - --disable-telemetry
         {{- end }}
+        {{- if .Values.cozystackOperator.helmReleaseInterval }}
+        - --helmrelease-interval={{ .Values.cozystackOperator.helmReleaseInterval }}
+        {{- end }}
         - --platform-source-name=cozystack-platform
         - --platform-source-url={{ .Values.cozystackOperator.platformSourceUrl }}
         {{- if .Values.cozystackOperator.platformSourceRef }}

--- a/packages/core/installer/templates/cozystack-operator.yaml
+++ b/packages/core/installer/templates/cozystack-operator.yaml
@@ -68,19 +68,19 @@ spec:
         {{- if .Values.cozystackOperator.disableTelemetry }}
         - --disable-telemetry
         {{- end }}
-        {{- if .Values.cozystackOperator.helmReleaseInterval }}
+        {{- if ne (toString .Values.cozystackOperator.helmReleaseInterval) "" }}
         - --helmrelease-interval={{ .Values.cozystackOperator.helmReleaseInterval }}
         {{- end }}
-        {{- if .Values.cozystackOperator.helmReleaseRetryInterval }}
+        {{- if ne (toString .Values.cozystackOperator.helmReleaseRetryInterval) "" }}
         - --helmrelease-retry-interval={{ .Values.cozystackOperator.helmReleaseRetryInterval }}
         {{- end }}
-        {{- if .Values.cozystackOperator.helmReleaseInstallTimeout }}
+        {{- if ne (toString .Values.cozystackOperator.helmReleaseInstallTimeout) "" }}
         - --helmrelease-install-timeout={{ .Values.cozystackOperator.helmReleaseInstallTimeout }}
         {{- end }}
-        {{- if .Values.cozystackOperator.helmReleaseUpgradeTimeout }}
+        {{- if ne (toString .Values.cozystackOperator.helmReleaseUpgradeTimeout) "" }}
         - --helmrelease-upgrade-timeout={{ .Values.cozystackOperator.helmReleaseUpgradeTimeout }}
         {{- end }}
-        {{- if .Values.cozystackOperator.helmReleaseMaxHistory }}
+        {{- if ne (toString .Values.cozystackOperator.helmReleaseMaxHistory) "" }}
         - --helmrelease-max-history={{ .Values.cozystackOperator.helmReleaseMaxHistory }}
         {{- end }}
         - --platform-source-name=cozystack-platform

--- a/packages/core/installer/templates/cozystack-operator.yaml
+++ b/packages/core/installer/templates/cozystack-operator.yaml
@@ -74,6 +74,15 @@ spec:
         {{- if .Values.cozystackOperator.helmReleaseRetryInterval }}
         - --helmrelease-retry-interval={{ .Values.cozystackOperator.helmReleaseRetryInterval }}
         {{- end }}
+        {{- if .Values.cozystackOperator.helmReleaseInstallTimeout }}
+        - --helmrelease-install-timeout={{ .Values.cozystackOperator.helmReleaseInstallTimeout }}
+        {{- end }}
+        {{- if .Values.cozystackOperator.helmReleaseUpgradeTimeout }}
+        - --helmrelease-upgrade-timeout={{ .Values.cozystackOperator.helmReleaseUpgradeTimeout }}
+        {{- end }}
+        {{- if .Values.cozystackOperator.helmReleaseMaxHistory }}
+        - --helmrelease-max-history={{ .Values.cozystackOperator.helmReleaseMaxHistory }}
+        {{- end }}
         - --platform-source-name=cozystack-platform
         - --platform-source-url={{ .Values.cozystackOperator.platformSourceUrl }}
         {{- if .Values.cozystackOperator.platformSourceRef }}

--- a/packages/core/installer/templates/cozystack-operator.yaml
+++ b/packages/core/installer/templates/cozystack-operator.yaml
@@ -71,6 +71,9 @@ spec:
         {{- if .Values.cozystackOperator.helmReleaseInterval }}
         - --helmrelease-interval={{ .Values.cozystackOperator.helmReleaseInterval }}
         {{- end }}
+        {{- if .Values.cozystackOperator.helmReleaseRetryInterval }}
+        - --helmrelease-retry-interval={{ .Values.cozystackOperator.helmReleaseRetryInterval }}
+        {{- end }}
         - --platform-source-name=cozystack-platform
         - --platform-source-url={{ .Values.cozystackOperator.platformSourceUrl }}
         {{- if .Values.cozystackOperator.platformSourceRef }}

--- a/packages/core/installer/values.yaml
+++ b/packages/core/installer/values.yaml
@@ -7,6 +7,10 @@ cozystackOperator:
   # When non-empty, overrides the operator's --helmrelease-interval flag
   # (operator default: 5m). E2E sets this to 30s; production should leave empty.
   helmReleaseInterval: ""
+  # When non-empty, overrides the operator's --helmrelease-retry-interval flag
+  # (operator default: 30s). Controls how fast failed install/upgrade attempts
+  # are retried. Decoupled from helmReleaseInterval (healthy reconcile cadence).
+  helmReleaseRetryInterval: ""
 # Generic variant configuration (only used when cozystackOperator.variant=generic)
 cozystack:
   # Kubernetes API server host (IP only, no protocol/port)

--- a/packages/core/installer/values.yaml
+++ b/packages/core/installer/values.yaml
@@ -11,6 +11,18 @@ cozystackOperator:
   # (operator default: 30s). Controls how fast failed install/upgrade attempts
   # are retried. Decoupled from helmReleaseInterval (healthy reconcile cadence).
   helmReleaseRetryInterval: ""
+  # When non-empty, overrides the operator's --helmrelease-install-timeout flag
+  # (operator default: 10m). Bounds individual k8s operations (job/hook/wait)
+  # during Helm install. Charts with long-running install hooks may need longer.
+  helmReleaseInstallTimeout: ""
+  # When non-empty, overrides the operator's --helmrelease-upgrade-timeout flag
+  # (operator default: 10m). Same semantics as helmReleaseInstallTimeout, for
+  # the Helm upgrade action.
+  helmReleaseUpgradeTimeout: ""
+  # When non-empty, overrides the operator's --helmrelease-max-history flag
+  # (operator default: 5). Number of release revisions Helm keeps per HR.
+  # Use 0 for unlimited; lower values reduce Secret accumulation in test clusters.
+  helmReleaseMaxHistory: ""
 # Generic variant configuration (only used when cozystackOperator.variant=generic)
 cozystack:
   # Kubernetes API server host (IP only, no protocol/port)

--- a/packages/core/installer/values.yaml
+++ b/packages/core/installer/values.yaml
@@ -4,6 +4,9 @@ cozystackOperator:
   image: ghcr.io/cozystack/cozystack/cozystack-operator:v1.3.0@sha256:62574f12486bb40c901cf5ed484cca264405ce5810196d86555cbb27cce1ba48
   platformSourceUrl: 'oci://ghcr.io/cozystack/cozystack/cozystack-packages'
   platformSourceRef: 'digest=sha256:a0b9ef938446b3132d3d22ad2262beb1027c48c9037b6c2346fdc2f19acd3036'
+  # When non-empty, overrides the operator's --helmrelease-interval flag
+  # (operator default: 5m). E2E sets this to 30s; production should leave empty.
+  helmReleaseInterval: ""
 # Generic variant configuration (only used when cozystackOperator.variant=generic)
 cozystack:
   # Kubernetes API server host (IP only, no protocol/port)


### PR DESCRIPTION
## Why

The `cozystack-operator` Package reconciler builds every `HelmRelease` it generates with a handful of hardcoded values. Three of those have caused recurring pain across the project:

- **`Spec.Interval = 5m`** (line 220 before this PR) — too long for E2E install where dependent HRs reconcile out of order; previously addressed by a manual `flux reconcile --force` workaround in `hack/e2e-install-cozystack.bats`.
- **`Install.Remediation{Retries: -1}` + `Upgrade.Remediation{Retries: -1}`** — semantically "retry forever, never remediate", but the retry-on-failure timing was tied to `Spec.Interval` (5m). Audit of the last 30 successful PR runs found that **every** run hit `kubectl wait hr/seaweedfs-system` timeouts at the 2-min mark, recovering only after the inline `flux reconcile --force` workaround.
- **`Install.Timeout = 10m` / `Upgrade.Timeout = 10m`** — directly contradicts the per-Application timeout work in `pkg/config/config.go` + `pkg/registry/apps/application/rest.go` (commit `7b146cbe`). `packages/apps/tenant/templates/etcd.yaml` hand-rolls its HR YAML to bypass this for cert rotation; harbor has had multiple commits chasing the same problem.
- **`Spec.MaxHistory`** unset → Helm default 5. Test clusters bounce HRs frequently and accumulate release-history Secrets.

This PR exposes all four as operator flags + helm chart values, with defaults that preserve current behavior.

## What

### New operator flags

| Flag | Default | HR field |
|---|---|---|
| `--helmrelease-interval` | `5m` | `Spec.Interval` |
| `--helmrelease-retry-interval` | `30s` | `Spec.{Install,Upgrade}.Strategy.RetryInterval` |
| `--helmrelease-install-timeout` | `10m` | `Spec.Install.Timeout` |
| `--helmrelease-upgrade-timeout` | `10m` | `Spec.Upgrade.Timeout` |
| `--helmrelease-max-history` | `5` | `Spec.MaxHistory` |

### Strategy switch

`Install.Strategy.Name` and `Upgrade.Strategy.Name` are now set to `RetryOnFailure` (instead of leaving the default `RemediateOnFailure`), with `RetryInterval` set from the new flag. Functionally equivalent to the previous `Remediation{Retries:-1}` ("retry forever") since remediation never fired anyway, but **decouples retry-on-failure timing from `Spec.Interval`** so failed releases recover at 30s without polling healthy releases at the same fast cadence.

### Chart exposure

`packages/core/installer/values.yaml` gets five new optional values (`cozystackOperator.helmRelease{Interval,RetryInterval,InstallTimeout,UpgradeTimeout,MaxHistory}`), each defaulting to empty so the operator's own default applies. The chart conditionally renders the corresponding flag only when the value is set.

## Production safety

- All static defaults match the previous hardcoded values (5m / 10m / 10m / 5). No new code path runs until an admin explicitly sets a flag.
- **One intentional behavior change: failed-release retry cadence** drops from ~5m (previously coupled to `Spec.Interval`) to 30s (`RetryInterval` default). This is the whole motivation for the strategy switch — the recurring `kubectl wait hr/seaweedfs-system` flakes documented above were caused by the previous coupling. Healthy-release reconcile cadence is unchanged at 5m in production; CI overrides this to 30s via `--set cozystackOperator.helmReleaseInterval=30s` in `hack/e2e-install-cozystack.bats` for faster convergence on E2E clusters.
- `RetryOnFailure` is functionally equivalent to `RemediateOnFailure + Retries:-1` since neither ever triggers remediation.
- Empty value in the chart → flag not rendered → operator falls back to its built-in default. (`helmReleaseMaxHistory: 0` — unlimited history per Helm semantics — is also honored; the chart guards on `ne (toString …) ""` rather than truthiness so int `0` is not silently dropped.)

## Verification

- `go build ./...` clean
- `go test ./internal/operator/...` passes (covers `Interval`, `MaxHistory`, `Install/Upgrade.Timeout`, `Strategy.Name`, `RetryInterval`, `ChartRef` propagation, plus a regression test for `MaxHistory=0`)
- `helm template installer packages/core/installer` renders cleanly with default and overridden values; `--set cozystackOperator.helmReleaseMaxHistory=0` correctly emits `--helmrelease-max-history=0`

## Followups (deliberately not bundled)

- **Per-component timeout overrides** on `ComponentInstall` (mirroring the `UpgradeCRDs` pattern from #2427). Charts like etcd that need a 30m timeout would set it on their `Component` rather than tuning a global flag. Touches the Package CR API + codegen — bigger lift, separate PR.
- **`Remediation.Retries` as a flag.** No current pain; skip.
- **`createOrUpdateHelmRelease` field preservation.** Currently preserves `Suspend` but not `Test`/`Rollback`/`Uninstall`. Would silently overwrite an SRE's manual edit. Minor cleanliness, separate PR.

## Test plan

- [ ] CI passes E2E with `helmReleaseInterval=30s` set in install bats (existing T1 test path)
- [ ] No regression on production install path (default values)
- [ ] HR objects in a healthy cluster render with `Strategy.Name=RetryOnFailure` and `RetryInterval=30s`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator and Helm chart now accept CLI flags and Helm values to configure HelmRelease reconciliation intervals, retry behavior, install/upgrade timeouts, and history retention.

* **Bug Fixes**
  * Operator now validates HelmRelease timing/history inputs on startup and will exit if values are invalid or non-positive.

* **Tests**
  * Added unit and e2e coverage to verify HelmRelease configuration and a chart install path using a custom reconciliation interval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

