### PR TITLE
feat(cozy-proxy): bump to v0.3.0

### DIFF
--- a/packages/system/cozy-proxy/charts/cozy-proxy/Chart.yaml
+++ b/packages/system/cozy-proxy/charts/cozy-proxy/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cozy-proxy
 description: A simple kube-proxy addon for 1:1 NAT services in Kubernetes using an NFT backend
 type: application
-version: 0.2.0
-appVersion: 0.2.0
+version: 0.3.0
+appVersion: 0.3.0

--- a/packages/system/cozy-proxy/charts/cozy-proxy/values.yaml
+++ b/packages/system/cozy-proxy/charts/cozy-proxy/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/cozystack/cozystack/cozy-proxy
-  tag: v0.2.0
+  tag: v0.3.0
   pullPolicy: IfNotPresent
 
 daemonset:


### PR DESCRIPTION
Bumps the vendored cozy-proxy chart and image tag from v0.2.0 to v0.3.0 by running `make update` in `packages/system/cozy-proxy`.

cozy-proxy v0.3.0 release: https://github.com/cozystack/cozy-proxy/releases/tag/v0.3.0

## Why

cozy-proxy v0.3.0 is the companion of #2501. The chart fix in #2501 finally honors the documented PortList semantics (only `externalPorts` reachable, ICMP preserved by default), but only takes effect once cozy-proxy v0.3.0 is in place — v0.2.0 has no port-aware logic, so the chart fix silently no-ops on it. This PR ships that runtime side.

## Upgrade impact

For cozystack users this is a **bug fix, not a breaking change**. cozy-proxy v0.3.0 introduces two contract changes upstream — (1) label-only selector via `service.kubernetes.io/service-proxy-name: cozy-proxy`, and (2) port-filter as the default ingress mode — both of which are absorbed by the vm-instance chart (label landed in #2357, `wholeIP` + `allowICMP` wired in #2501).

- **`externalMethod: WholeIP`** (default) — chart renders label + `wholeIP: "true"` in both old and new versions. cozy-proxy keeps passthrough. **No change.**
- **`externalMethod: PortList`** — previously the chart always rendered `wholeIP: "true"` regardless of method, and cozy-proxy v0.2.0 had no port-aware logic, so PortList was silently a no-op (all ports reachable). After this bump + #2501, PortList behaves as documented: only ports listed in `externalPorts` reach the VM. Users who configured PortList but reached undeclared ports (relying on the silent no-op) will see those ports become unreachable — that's the documented intent of PortList finally taking effect. ICMP keeps working by default thanks to `externalAllowICMP: true`.
- **DaemonSet rollover** — re-init of the nft table during cozy-proxy pod restart is a brief blip on existing flows; same as any DaemonSet upgrade.

Out-of-tree consumers using cozy-proxy directly (without the `service-proxy-name` label, or relying on the absent-annotation passthrough default) need to migrate per the upstream v0.3.0 release notes — not a cozystack concern.

## Order of operations

This PR is functionally complete on its own (image bump), but the user-facing PortList fix it enables only happens when #2501 also lands. Recommended merge order:

1. #2501 first (chart adapts to the new contract)
2. This PR second (cozy-proxy DaemonSet picks up the new image)

The reverse order is also safe — cozy-proxy v0.3.0 with the unmodified vm-instance chart still produces correct results for `externalMethod: WholeIP` (most common case) and keeps PortList silently broken until #2501 lands.

## Test plan

- [ ] `helm template packages/system/cozy-proxy` — image tag `v0.3.0` rendered
- [ ] `make unit-tests` passes
- [ ] After #2501 lands, end-to-end: `externalMethod: PortList` with `externalPorts: [22]` filters all other ports, ping works
- [ ] WholeIP-method VM Service unchanged after upgrade

## Companion PRs

- #2501 — vm-instance chart wires `wholeIP` / `allowICMP` per `externalMethod`
- cozystack/cozy-proxy#13 (merged) — label-only selector + port-filter default
- cozy-proxy v0.3.0 release notes — https://github.com/cozystack/cozy-proxy/releases/tag/v0.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.3.0 with updated Helm chart metadata and container image configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->