### PR TITLE
fix(objectstorage-controller): retry on Bucket conflict during BucketAccess reconcile

### DIFF
--- a/packages/system/objectstorage-controller/images/objectstorage/Dockerfile
+++ b/packages/system/objectstorage-controller/images/objectstorage/Dockerfile
@@ -2,11 +2,14 @@
 
 FROM alpine AS source
 ARG COMMIT_REF=v0.2.2
-RUN apk add --no-cache curl tar
+RUN apk add --no-cache curl tar git
 WORKDIR /src
 
 RUN curl -sSL https://github.com/kubernetes-sigs/container-object-storage-interface/archive/${COMMIT_REF}.tar.gz \
         | tar -xz --strip-components=1
+
+COPY patches /patches
+RUN git apply /patches/*.diff
 
 FROM --platform=$BUILDPLATFORM docker.io/golang:1.24 AS builder
 ARG TARGETOS

--- a/packages/system/objectstorage-controller/images/objectstorage/patches/91-bucketaccess-conflict-retry.diff
+++ b/packages/system/objectstorage-controller/images/objectstorage/patches/91-bucketaccess-conflict-retry.diff
@@ -1,0 +1,39 @@
+diff --git a/sidecar/pkg/bucketaccess/bucketaccess_controller.go b/sidecar/pkg/bucketaccess/bucketaccess_controller.go
+index a4db5c4..b351f9e 100644
+--- a/sidecar/pkg/bucketaccess/bucketaccess_controller.go
++++ b/sidecar/pkg/bucketaccess/bucketaccess_controller.go
+@@ -31,6 +31,7 @@ import (
+ 	kube "k8s.io/client-go/kubernetes"
+ 	kubecorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+ 	"k8s.io/client-go/tools/record"
++	"k8s.io/client-go/util/retry"
+ 	"k8s.io/klog/v2"
+ 	cosiapi "sigs.k8s.io/container-object-storage-interface/client/apis"
+ 	"sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/consts"
+@@ -273,11 +274,22 @@ func (bal *BucketAccessListener) Add(ctx context.Context, inputBucketAccess *v1a
+ 		}
+ 	}
+ 
+-	if controllerutil.AddFinalizer(bucket, consts.BABucketFinalizer) {
+-		_, err = bal.buckets().Update(ctx, bucket, metav1.UpdateOptions{})
+-		if err != nil {
+-			return bal.recordError(inputBucketAccess, v1.EventTypeWarning, v1alpha1.FailedGrantAccess, err)
++	// Re-fetch and update inside RetryOnConflict to handle the case where the Bucket
++	// reconciler in the same controller process mutates the Bucket between our Get
++	// and Update, which surfaces as "the object has been modified" on the parent
++	// Bucket and emits FailedGrantAccess on the BucketAccess.
++	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
++		latest, getErr := bal.buckets().Get(ctx, bucketClaim.Status.BucketName, metav1.GetOptions{})
++		if getErr != nil {
++			return getErr
++		}
++		if !controllerutil.AddFinalizer(latest, consts.BABucketFinalizer) {
++			return nil
+ 		}
++		_, updateErr := bal.buckets().Update(ctx, latest, metav1.UpdateOptions{})
++		return updateErr
++	}); err != nil {
++		return bal.recordError(inputBucketAccess, v1.EventTypeWarning, v1alpha1.FailedGrantAccess, err)
+ 	}
+ 
+ 	if controllerutil.AddFinalizer(bucketAccess, consts.BAFinalizer) {


### PR DESCRIPTION
## What this PR does

Carries an upstream-bound patch against COSI v0.2.2's BucketAccess sidecar reconciler so it survives the optimistic-concurrency race with the central Bucket reconciler running in the same process.

In `sidecar/pkg/bucketaccess/bucketaccess_controller.go`, the `Add` path does:

```go
bucket, _ := buckets().Get(...)
// ...
if controllerutil.AddFinalizer(bucket, BABucketFinalizer) {
    buckets().Update(ctx, bucket, ...)   // <-- 409 here
}
```

Between `Get` and `Update` the Bucket reconciler in the same binary can mutate the object and bump `resourceVersion`, producing:

```
Operation cannot be fulfilled on buckets.objectstorage.k8s.io "bucket-...":
the object has been modified; please apply your changes to the latest
version and try again
```

surfaced to users as a `FailedGrantAccess` event on the BucketAccess.

This patch wraps the Bucket finalizer add in `retry.RetryOnConflict(retry.DefaultRetry, ...)` and re-`Get`s the Bucket inside the closure so each retry mutates the freshest version.

Patch is held as `91-bucketaccess-conflict-retry.diff` and consumed at image build time (re-introduces `git` to the source stage and the `COPY patches /patches` + `git apply /patches/*.diff` steps that existed before `c29d501b` dropped them when 89/90 were upstreamed). The convention is identical: drop the local patch the moment the upstream PR merges and ships in a tagged release.

### Release note

~~~release-note
[objectstorage-controller] Carry a patch that retries on Bucket update conflict during BucketAccess reconcile, eliminating the "object has been modified" FailedGrantAccess event seen in CI.
~~~

## Test plan

- [x] `make image` for `system/objectstorage-controller` and verify `values.yaml` picks up the new digest.
- [x] Re-run the cozystack-e2e suite that emitted the `FailedGrantAccess: ... object has been modified` event on `tenant-test/BucketAccess/bucket-test-admin` and confirm it no longer fires.
- [ ] Verify `kubectl describe bucketaccess` reports `AccessGranted=true` on first reconcile, no requeue from the conflict path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced bucket access update reliability with improved conflict handling during concurrent operations. The system now automatically retries operations and refetches data to prevent update conflicts.

* **Chores**
  * Improved Docker build process with automatic patch application support for source customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->