### PR TITLE
fix(ci): generate changelog from release tag, not from main

### DIFF
--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -331,7 +331,7 @@ jobs:
           VERSION: ${{ steps.tag.outputs.version }}
         run: |
           copilot \
-            --prompt "Generate the release changelog for tag v${VERSION}. The repository is checked out at the v${VERSION} tag commit, so HEAD == the release commit. Use v${VERSION} (or HEAD) as the upper bound when comparing against the previous version — never assume HEAD is on main, because patch releases are cut from release-X.Y branches. Follow the instructions in @docs/agents/changelog.md exactly, including the 'Scope and boundaries' section at the top. Your deliverable is the single file docs/changelogs/v${VERSION}.md — write it and exit; this workflow handles branching, committing, pushing, and opening the PR." \
+            --prompt "Generate the release changelog for tag v${VERSION}. The repository is checked out at the v${VERSION} tag commit. Use v${VERSION} as the upper bound when comparing against the previous version — never use HEAD, because if the tag is missing locally HEAD may diverge from the release commit. Follow the instructions in @docs/agents/changelog.md exactly, including the 'Scope and boundaries' section at the top. Your deliverable is the single file docs/changelogs/v${VERSION}.md — write it and exit; this workflow handles branching, committing, pushing, and opening the PR." \
             --allow-all-tools --allow-all-paths < /dev/null
 
       - name: Create changelog branch and commit

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -286,10 +286,16 @@ jobs:
             core.setOutput('version', version);
             core.setOutput('tag', ref);
 
-      - name: Checkout main branch
+      # Check out the tag commit, not main. Patch releases are cut from
+      # release-X.Y branches, so HEAD-on-main contains commits that are
+      # NOT in the release tag. Running the AI against the tag commit
+      # makes `git log v<prev>..HEAD` correspond to the actual release
+      # contents. The Create changelog branch step below resets the file
+      # onto a fresh branch from origin/main for the PR.
+      - name: Checkout release tag
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ steps.tag.outputs.tag }}
           fetch-depth: 0
           fetch-tags: true
           token: ${{ steps.app-token.outputs.token }}
@@ -325,7 +331,7 @@ jobs:
           VERSION: ${{ steps.tag.outputs.version }}
         run: |
           copilot \
-            --prompt "Generate the release changelog for tag v${VERSION}. Follow the instructions in @docs/agents/changelog.md exactly, including the 'Scope and boundaries' section at the top. Your deliverable is the single file docs/changelogs/v${VERSION}.md — write it and exit; this workflow handles branching, committing, pushing, and opening the PR." \
+            --prompt "Generate the release changelog for tag v${VERSION}. The repository is checked out at the v${VERSION} tag commit, so HEAD == the release commit. Use v${VERSION} (or HEAD) as the upper bound when comparing against the previous version — never assume HEAD is on main, because patch releases are cut from release-X.Y branches. Follow the instructions in @docs/agents/changelog.md exactly, including the 'Scope and boundaries' section at the top. Your deliverable is the single file docs/changelogs/v${VERSION}.md — write it and exit; this workflow handles branching, committing, pushing, and opening the PR." \
             --allow-all-tools --allow-all-paths < /dev/null
 
       - name: Create changelog branch and commit

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -300,16 +300,24 @@ jobs:
           fetch-tags: true
           token: ${{ steps.app-token.outputs.token }}
 
+      # Check whether the changelog already exists on origin/main.
+      # The previous step checked out the tag commit, which never has the
+      # changelog (the changelog PR merges to main AFTER the tag is cut).
+      # Looking at origin/main is what the gate is supposed to do — skip
+      # generation on workflow reruns when the changelog has already merged.
       - name: Check if changelog already exists
         id: check_changelog
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
         run: |
-          CHANGELOG_FILE="docs/changelogs/v${{ steps.tag.outputs.version }}.md"
-          if [ -f "$CHANGELOG_FILE" ]; then
+          CHANGELOG_FILE="docs/changelogs/v${VERSION}.md"
+          git fetch origin main --depth=1
+          if git cat-file -e "origin/main:${CHANGELOG_FILE}" 2>/dev/null; then
             echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Changelog file $CHANGELOG_FILE already exists"
+            echo "Changelog file $CHANGELOG_FILE already exists on origin/main"
           else
             echo "exists=false" >> $GITHUB_OUTPUT
-            echo "Changelog file $CHANGELOG_FILE does not exist"
+            echo "Changelog file $CHANGELOG_FILE does not exist on origin/main"
           fi
 
       - name: Setup Node.js

--- a/docs/agents/changelog.md
+++ b/docs/agents/changelog.md
@@ -511,8 +511,11 @@ Create a new changelog file in the format matching previous versions:
    
    **Get all previous contributors (to identify new ones):**
    ```bash
-   # Extract GitHub usernames from all previous changelogs (filtering out bot/CI accounts)
-   grep -hoE '\[\*\*@[a-zA-Z0-9_/-]+\*\*\]' docs/changelogs/v*.md | \
+   # Extract GitHub usernames from all previous changelogs (filtering out bot/CI accounts).
+   # Exclude the current release file (v<version>.md) — otherwise current contributors
+   # would also appear in the "previous" set, hiding real first-time contributors.
+   find docs/changelogs -maxdepth 1 -name 'v*.md' ! -name 'v<version>.md' -print0 | \
+     xargs -0 grep -hoE '\[\*\*@[a-zA-Z0-9_/-]+\*\*\]' | \
      sed -E 's|\[\*\*@||; s|\*\*\]||' | \
      grep -viE '^(app/|.*\[bot\]$|cozystack-ci$|github-actions$|dependabot$|renovate$)' | \
      sort -u > /tmp/previous_contributors.txt
@@ -526,8 +529,10 @@ Create a new changelog file in the format matching previous versions:
      grep -viE '^(app/|.*\[bot\]$|cozystack-ci$|github-actions$|dependabot$|renovate$)' | \
      sort -u > /tmp/current_contributors.txt
    
-   # Get all previous contributors (filtering out bot/CI accounts)
-   grep -hoE '\[\*\*@[a-zA-Z0-9_/-]+\*\*\]' docs/changelogs/v*.md | \
+   # Get all previous contributors, excluding the current release file
+   # (filtering out bot/CI accounts)
+   find docs/changelogs -maxdepth 1 -name 'v*.md' ! -name 'v<version>.md' -print0 | \
+     xargs -0 grep -hoE '\[\*\*@[a-zA-Z0-9_/-]+\*\*\]' | \
      sed -E 's|\[\*\*@||; s|\*\*\]||' | \
      grep -viE '^(app/|.*\[bot\]$|cozystack-ci$|github-actions$|dependabot$|renovate$)' | \
      sort -u > /tmp/all_previous_contributors.txt

--- a/docs/agents/changelog.md
+++ b/docs/agents/changelog.md
@@ -112,7 +112,7 @@ Get the list of commits between the previous patch tag and the new tag:
 
 ```bash
 # Get all commits including merge commits (backports), bounded by the new tag
-git log <previous_version>..v<new_version> --pretty=format:"%h - %s (%an, %ar)"
+git log v<previous_version>..v<new_version> --pretty=format:"%h - %s (%an, %ar)"
 ```
 
 For example, if generating changelog for `v0.37.2`:
@@ -274,7 +274,7 @@ Cozystack release may include changes from related repositories. Check and inclu
 
 ```bash
 # Extract all PR numbers from commit messages in the release range (including merge commits)
-git log <previous_version>..<new_version> --format="%s%n%b" | grep -oE '#[0-9]+' | sort -u | tr -d '#'
+git log v<previous_version>..v<new_version> --format="%s%n%b" | grep -oE '#[0-9]+' | sort -u | tr -d '#'
 ```
 
 **⚠️ IMPORTANT: Handle backports correctly:**
@@ -283,7 +283,6 @@ git log <previous_version>..<new_version> --format="%s%n%b" | grep -oE '#[0-9]+'
 - For backport entries in changelog, use the original PR author (not the backport PR author)
 - **MUST** combine the original and backport PR into a **single changelog entry** with both PR numbers (e.g. `#1606, backport #1609`). NEVER list the original and the backport as two separate entries — that produces visible duplicates and was the primary defect that motivated this rule.
 - To find original PR from backport: Check the backport PR description or commit message for "Backport of #ORIGINAL_PR"
-- If a release range contains a backport but its original PR is **not** in the same range (because the original was merged earlier and already shipped in a previous release), drop the entry entirely — it has already been changelog'd.
 
 **For each PR number, get the author:**
    
@@ -296,7 +295,7 @@ git log <previous_version>..<new_version> --format="%s%n%b" | grep -oE '#[0-9]+'
    ```bash
    # Usage: Get PR author - MANDATORY for EVERY PR
    # Loop through ALL PR numbers and get PR author (including backports)
-   git log <previous_version>..<new_version> --format="%s%n%b" | grep -oE '#[0-9]+' | sort -u | tr -d '#' | while read PR_NUMBER; do
+   git log v<previous_version>..v<new_version> --format="%s%n%b" | grep -oE '#[0-9]+' | sort -u | tr -d '#' | while read PR_NUMBER; do
      # Check if this is a backport PR
      BACKPORT_INFO=$(gh pr view "$PR_NUMBER" --json body --jq '.body' 2>/dev/null | grep -i "backport of #" || echo "")
      if [ -n "$BACKPORT_INFO" ]; then
@@ -512,21 +511,25 @@ Create a new changelog file in the format matching previous versions:
    
    **Get all previous contributors (to identify new ones):**
    ```bash
-   # Extract GitHub usernames from all previous changelogs
-   grep -hE '\[@[a-zA-Z0-9_-]+\]' docs/changelogs/v*.md | \
-     grep -oE '@[a-zA-Z0-9_-]+' | \
+   # Extract GitHub usernames from all previous changelogs (filtering out bot/CI accounts)
+   grep -hoE '\[\*\*@[a-zA-Z0-9_/-]+\*\*\]' docs/changelogs/v*.md | \
+     sed -E 's|\[\*\*@||; s|\*\*\]||' | \
+     grep -viE '^(app/|.*\[bot\]$|cozystack-ci$|github-actions$|dependabot$|renovate$)' | \
      sort -u > /tmp/previous_contributors.txt
    ```
    
    **Identify new contributors (first-time contributors):**
    ```bash
-   # Get current release contributors from the changelog
-   grep -oE '@[a-zA-Z0-9_-]+' docs/changelogs/v<version>.md | \
+   # Get current release contributors from the changelog (filtering out bot/CI accounts)
+   grep -oE '\[\*\*@[a-zA-Z0-9_/-]+\*\*\]' docs/changelogs/v<version>.md | \
+     sed -E 's|\[\*\*@||; s|\*\*\]||' | \
+     grep -viE '^(app/|.*\[bot\]$|cozystack-ci$|github-actions$|dependabot$|renovate$)' | \
      sort -u > /tmp/current_contributors.txt
    
-   # Get all previous contributors
-   grep -hE '@[a-zA-Z0-9_-]+' docs/changelogs/v*.md | \
-     grep -oE '@[a-zA-Z0-9_-]+' | \
+   # Get all previous contributors (filtering out bot/CI accounts)
+   grep -hoE '\[\*\*@[a-zA-Z0-9_/-]+\*\*\]' docs/changelogs/v*.md | \
+     sed -E 's|\[\*\*@||; s|\*\*\]||' | \
+     grep -viE '^(app/|.*\[bot\]$|cozystack-ci$|github-actions$|dependabot$|renovate$)' | \
      sort -u > /tmp/all_previous_contributors.txt
    
    # Find new contributors (those in current but not in previous)

--- a/docs/agents/changelog.md
+++ b/docs/agents/changelog.md
@@ -54,11 +54,18 @@ This is necessary to get up-to-date information about tags and commits from the 
 
 ### 2. Checking current branch
 
-Make sure we are on the `main` branch:
+Verify the working tree is at a sensible starting point. Two configurations are valid:
 
-```bash
-git branch --show-current
-```
+- **Interactive use:** the working tree is on the `main` branch.
+  ```bash
+  git branch --show-current   # should print "main"
+  ```
+- **CI use:** HEAD is detached at the release tag being generated (this is how `.github/workflows/tags.yaml` runs).
+  ```bash
+  git describe --exact-match HEAD   # should print e.g. "v1.3.1"
+  ```
+
+If neither holds, stop — the caller invoked you from the wrong place. Do **not** switch branches yourself; the "Scope and boundaries" section forbids it.
 
 ### 3. Determining release type and previous version
 
@@ -176,7 +183,7 @@ Cozystack release may include changes from related repositories. Check and inclu
    # Get dates for the release period
    cd /path/to/cozystack
    RELEASE_START=$(git log -1 --format=%ai v<previous_version>)
-   RELEASE_END=$(git log -1 --format=%ai HEAD)
+   RELEASE_END=$(git log -1 --format=%ai v<new_version>)
    ```
 
 2. **Check for commits in website repository (always required):**
@@ -219,7 +226,7 @@ Cozystack release may include changes from related repositories. Check and inclu
    ```bash
    # Get release period dates
    RELEASE_START=$(git log -1 --format=%ai v<previous_version>)
-   RELEASE_END=$(git log -1 --format=%ai HEAD)
+   RELEASE_END=$(git log -1 --format=%ai v<new_version>)
    
    # Run the script to check all optional repositories
    ./docs/changelogs/hack/check-optional-repos.sh "$RELEASE_START" "$RELEASE_END"

--- a/docs/agents/changelog.md
+++ b/docs/agents/changelog.md
@@ -103,40 +103,42 @@ git branch --show-current
 
 **Important**: Determine if you're generating a changelog for a **minor release** (vX.Y.0) or a **patch release** (vX.Y.Z where Z > 0).
 
+**⚠️ CRITICAL — use the tag, not HEAD:** Always compare the previous version against the **tag for the release you are generating** (e.g. `v1.3.1`), never against `HEAD`. Patch releases are cut from `release-X.Y` branches, so when CI checks out the tag and runs `git log v<prev>..HEAD` you might get the right answer — but if the tag is missing locally, or if a developer runs this on `main`, `HEAD` will contain commits merged to main that are NOT in the release. Using the tag explicitly removes this footgun.
+
 **For patch releases (vX.Y.Z where Z > 0):**
-Get the list of commits starting from the previous patch version to HEAD:
+Get the list of commits between the previous patch tag and the new tag:
 
 **⚠️ CRITICAL: Do NOT use --first-parent flag! It will skip merge commits including backports!**
 
 ```bash
-# Get all commits including merge commits (backports)
-git log <previous_version>..HEAD --pretty=format:"%h - %s (%an, %ar)"
+# Get all commits including merge commits (backports), bounded by the new tag
+git log <previous_version>..v<new_version> --pretty=format:"%h - %s (%an, %ar)"
 ```
 
 For example, if generating changelog for `v0.37.2`:
 ```bash
-git log v0.37.1..HEAD --pretty=format:"%h - %s (%an, %ar)"
+git log v0.37.1..v0.37.2 --pretty=format:"%h - %s (%an, %ar)"
 ```
 
 **⚠️ IMPORTANT: Check for backports:**
 - Look for commits with "[Backport release-X.Y]" in the commit message
 - For backport PRs, find the original PR number mentioned in the backport commit message or PR description
 - Use the original PR author (not the backport PR author) when creating changelog entries
-- Include both the original PR number and backport PR number in the changelog entry (e.g., `#1606, #1609`)
+- **MUST** combine the original and backport into a **single entry** with both PR numbers (e.g. `#1606, backport #1609`). Do NOT list the original and the backport as two separate entries — that produces duplicates in the changelog.
 
 **For minor releases (vX.Y.0):**
-Minor releases must include **all changes** from patch releases of the previous minor version. Get commits from the previous minor release:
+Minor releases must include **all changes** from patch releases of the previous minor version. Get commits from the previous minor release tag up to the new tag:
 
 **⚠️ CRITICAL: Do NOT use --first-parent flag! It will skip merge commits including backports!**
 
 ```bash
 # For v0.38.0, get all commits since v0.37.0 (including all patch releases v0.37.1, v0.37.2, etc.)
-git log v<previous_minor_version>..HEAD --pretty=format:"%h - %s (%an, %ar)"
+git log v<previous_minor_version>..v<new_version> --pretty=format:"%h - %s (%an, %ar)"
 ```
 
 For example, if generating changelog for `v0.38.0`:
 ```bash
-git log v0.37.0..HEAD --pretty=format:"%h - %s (%an, %ar)"
+git log v0.37.0..v0.38.0 --pretty=format:"%h - %s (%an, %ar)"
 ```
 
 This will include all commits from v0.37.1, v0.37.2, v0.37.3, etc., up to v0.38.0.
@@ -279,8 +281,9 @@ git log <previous_version>..<new_version> --format="%s%n%b" | grep -oE '#[0-9]+'
 - Backport PRs have format: `[Backport release-X.Y] <original title> (#BACKPORT_PR_NUMBER)`
 - The backport commit message or PR description usually mentions the original PR number
 - For backport entries in changelog, use the original PR author (not the backport PR author)
-- Include both original and backport PR numbers in the changelog entry (e.g., `#1606, #1609`)
+- **MUST** combine the original and backport PR into a **single changelog entry** with both PR numbers (e.g. `#1606, backport #1609`). NEVER list the original and the backport as two separate entries — that produces visible duplicates and was the primary defect that motivated this rule.
 - To find original PR from backport: Check the backport PR description or commit message for "Backport of #ORIGINAL_PR"
+- If a release range contains a backport but its original PR is **not** in the same range (because the original was merged earlier and already shipped in a previous release), drop the entry entirely — it has already been changelog'd.
 
 **For each PR number, get the author:**
    
@@ -437,6 +440,8 @@ Create a new changelog file in the format matching previous versions:
 
 3. **Entry format:**
    - Use the format: `* **Brief description**: detailed description ([**@username**](https://github.com/username) in #PR_NUMBER)`
+   - **⚠️ The brief description and the detailed description MUST NOT be the same string.** The brief description is typically the conventional-commit subject (e.g. `fix(api): drop legacy field`); the detailed description is a one-or-two-sentence explanation of what the change means for users — what is fixed, what is now possible, what behavior changed. If you find yourself writing `* **fix(foo): X**: fix(foo): X (...)` you have not done the second half of the work — go read the PR body or commit diff and write the user-facing description.
+   - **⚠️ Do NOT invent entries.** Every entry must correspond to a commit in the `git log v<previous>..v<new>` range. If you can't find a commit for an entry you wrote, drop the entry. PR numbers from outside the release range (e.g. PRs from years ago, or PRs that were merged after the tag commit) MUST NOT appear in the changelog.
    - **CRITICAL - Get authorship correctly**: 
      - **ALWAYS use PR author, not commit author**: Extract PR number from commit message, then use `gh pr view` to get the PR author. The commit author (especially for squash/merge commits) is usually the person who merged the PR (or GitHub bot), NOT the person who wrote the code.
        ```bash
@@ -494,19 +499,16 @@ Create a new changelog file in the format matching previous versions:
    Since you've already generated the changelog with all PR authors correctly identified, simply extract GitHub usernames from the changelog entries:
    
    ```bash
-   # Extract all GitHub usernames from the current release changelog
-   # This method is simpler and more reliable than extracting from git history
-   
-   # For patch releases: extract from the current changelog file
-   grep -oE '\[@[a-zA-Z0-9_-]+\]' docs/changelogs/v<version>.md | \
-     sed 's/\[@/@/' | sed 's/\]//' | \
-     sort -u
-   
-   # For minor releases: extract from the current changelog file
-   grep -oE '\[@[a-zA-Z0-9_-]+\]' docs/changelogs/v<version>.md | \
-     sed 's/\[@/@/' | sed 's/\]//' | \
+   # Extract all GitHub usernames from the current release changelog,
+   # filtering out CI/bot accounts that should not appear as human contributors.
+   # This method is simpler and more reliable than extracting from git history.
+   grep -oE '\[\*\*@[a-zA-Z0-9_/-]+\*\*\]' docs/changelogs/v<version>.md | \
+     sed -E 's|\[\*\*@||; s|\*\*\]||' | \
+     grep -viE '^(app/|.*\[bot\]$|cozystack-ci$|github-actions$|dependabot$|renovate$)' | \
      sort -u
    ```
+   
+   **⚠️ MANDATORY: Exclude bot/CI accounts from the human Contributors list.** Accounts whose login starts with `app/`, ends with `[bot]`, or matches `cozystack-ci`, `github-actions`, `dependabot`, or `renovate` represent automation, not human contributions, and must NOT appear under "Contributors". They may legitimately appear in **entry attribution** (e.g. a Renovate PR is attributed to `@app/renovate`) — but never in the contributors list.
    
    **Get all previous contributors (to identify new ones):**
    ```bash


### PR DESCRIPTION
## What this PR does

The `generate-changelog` job in `.github/workflows/tags.yaml` previously checked out `main` and ran the AI agent there. The agent followed `docs/agents/changelog.md`, which instructed it to compute the release range with `git log <previous_version>..HEAD`. That works for minor releases (cut from `main`), but it breaks for any patch release cut from a `release-X.Y` branch — `HEAD-on-main` is a strict superset of the tag and contains commits that were merged to `main` both before and after the tag.

The v1.3.1 changelog generated by this workflow (#2480) demonstrated the failure mode: 8 PRs that were merged to `main` but never shipped in v1.3.1, 6 backport PRs that landed on `release-1.3` *after* v1.3.1 was tagged, both originals and their backports as separate entries, a hallucinated 2024 PR (#435), and the `cozystack-ci` bot in the contributors list. The corrected v1.3.1 changelog is in #2480.

This PR fixes the root cause and tightens the agent guardrails:

* **`tags.yaml`** — check out the release tag commit (`ref: ${{ steps.tag.outputs.tag }}`) instead of `main`, so `HEAD == release commit` and `git log v<prev>..HEAD` corresponds to what the tag actually contains. The "Create changelog branch" step still creates the PR branch from `origin/main`, so PRs continue to merge cleanly.
* **`tags.yaml`** — the AI prompt now states explicitly that `HEAD` is the release commit and that the upper bound of the range is the new tag, never `main`.
* **`docs/agents/changelog.md`** — every example replaces `..HEAD` with `..v<new_version>`, so the instruction is unambiguous regardless of which branch is checked out.
* **`docs/agents/changelog.md`** — hard rule: backport PRs MUST be combined with the original into a single entry (`#1606, backport #1609`), never listed as a second entry. Documented edge case: if the original isn't in the range, drop the entry entirely (it shipped in a previous release).
* **`docs/agents/changelog.md`** — forbid using the brief description verbatim as the detailed description (the failure was `* **fix(foo): X**: fix(foo): X (...)`), and forbid inventing entries for PRs outside the release range.
* **`docs/agents/changelog.md`** — filter bot/CI accounts (`app/*`, `*[bot]`, `cozystack-ci`, `github-actions`, `dependabot`, `renovate`) out of the human Contributors list. Bot attribution on individual entries is still valid.

The v1.3.1 changelog correction itself lives in #2480 (separate scope).

### Release note

```release-note
fix(ci): tags.yaml now generates the release changelog from the tag commit instead of `main`, fixing patch-release changelogs (e.g. v1.3.1) that previously included unrelated commits from `main`. The AI prompt and `docs/agents/changelog.md` were tightened to forbid duplicate backport entries, title-as-description, fabricated PRs, and bot accounts in the Contributors list.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Changelog generation now checks out the release tag commit and verifies whether the release changelog already exists on main before generating.
  * Updated prompts and tooling to treat the release tag as the upper bound and avoid using HEAD when computing diffs.
  * Enforced combining original and backport PRs into single changelog entries with explicit “backport #…”.

* **Documentation**
  * Strengthened authoring rules (distinct brief/detail, forbid invented entries, PRs must fall within tag-to-tag ranges).
  * Updated examples and guidance to use tag-to-tag comparisons and improved contributor extraction to use bold @user attribution while excluding automation accounts and the current release file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->