### PR TITLE
fix(ci): pass app token to Publish draft release step

### DIFF
--- a/.github/workflows/pull-requests-release.yaml
+++ b/.github/workflows/pull-requests-release.yaml
@@ -122,6 +122,7 @@ jobs:
       - name: Publish draft release
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const tag = '${{ steps.get_tag.outputs.tag }}';
             const m = tag.match(/^v(\d+\.\d+\.\d+)(-(?:alpha|beta|rc)\.\d+)?$/);


### PR DESCRIPTION
## What this PR does

Adds an explicit `github-token: ${{ steps.app-token.outputs.token }}` to the `Publish draft release` step in `.github/workflows/pull-requests-release.yaml`.

Without this, the step uses the workflow's default `GITHUB_TOKEN`, which does not return draft releases via `listReleases`. As a result the script throws `Draft release for vX.Y.Z not found` on every release-X.Y.Z PR merge — see e.g. the recent v1.3.1 finalize run https://github.com/cozystack/cozystack/actions/runs/25102689625, plus identical failures on v1.3.0, v1.0.0-beta.5, v1.0.0-alpha.2, v0.39.4, v0.32.x, v0.31.x. Maintainers have been undrafting each release manually.

This bug was fixed once before in 4db55ac5eb18 (`[ci] Add Github token to fetch draft releases`) by setting `github-token: ${{ secrets.GH_PAT }}` on the listing step. It was lost in the refactor in 66a756b6 (`fix(ci): ensure correct latest release after backport publishing`), which collapsed the separate `Find draft release` / `Calculate publish flags` / `Publish draft release` steps into one combined step without carrying the `github-token` over. The April 2026 App-token migration in f96b2da1 only updated steps that already had a `github-token:` field, so the publish step was left with the default token.

### Release note

```release-note
fix(ci): release finalization now uses the cozystack-ci App token to publish drafts, fixing "Draft release not found" errors on every release tag.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow authentication mechanism to enhance security protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->