### PR TITLE
fix(seaweedfs): pass filer.replicas and s3.replicas to HelmRelease

### DIFF
--- a/packages/extra/seaweedfs/templates/seaweedfs.yaml
+++ b/packages/extra/seaweedfs/templates/seaweedfs.yaml
@@ -232,10 +232,12 @@ spec:
         {{- else if eq .Values.topology "MultiZone" }}
         defaultReplicaPlacement: "{{ sub .Values.replicationFactor 1 }}00"
         {{- end }}
+        replicas: {{ .Values.filer.replicas }}
         s3:
           domainName: {{ .Values.host | default (printf "s3.%s" $host) }}
         resources: {{- include "cozy-lib.resources.defaultingSanitize" (list .Values.filer.resourcesPreset .Values.filer.resources $) | nindent 10 }}
       s3:
+        replicas: {{ .Values.s3.replicas }}
         ingress:
           className: {{ $ingress }}
           host: {{ .Values.host | default (printf "s3.%s" $host) }}


### PR DESCRIPTION
## What this PR does

The `filer` and `s3` blocks in the seaweedfs HelmRelease values omitted the `replicas:` field, so user-supplied `.Values.filer.replicas` and `.Values.s3.replicas` were silently ignored and the upstream chart defaults took over. As a second-order effect, the `WorkloadMonitor` resources for `filer` and `s3` (which read the same values) diverged from the actual replica count and could trigger spurious alerts when users set non-default values.

This PR mirrors the existing `master` / `volume` / `db` pattern and interpolates `replicas:` into both blocks.

Fixes #2531

### Release note

```release-note
fix(seaweedfs): pass filer.replicas and s3.replicas to HelmRelease so user-supplied values take effect
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * SeaweedFS deployment configuration now supports configurable replica counts for the filer and s3 components, providing flexible cluster scaling through deployment parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->