### PR TITLE
fix(linstor): retry drbdadm secondary after mkfs on transient EBUSY

### DIFF
--- a/packages/system/linstor/images/piraeus-server/patches/README.md
+++ b/packages/system/linstor/images/piraeus-server/patches/README.md
@@ -15,3 +15,6 @@ Custom patches for piraeus-server (linstor-server) v1.33.2.
 - **retry-adjust-after-stale-bitmap.diff** — Retry `drbdadm adjust` after detaching a stale local bitmap state
   - Source PR: [#491](https://github.com/LINBIT/linstor-server/pull/491)
   - Backported from commit: [`51ae50a84`](https://github.com/kvaps/linstor-server/commit/51ae50a84dcb98093f543b819652c750a94d96c9)
+- **retry-secondary-after-mkfs.diff** — Retry `drbdadm secondary` after mkfs when DRBD reports the device as held open by an external probe (Talos block-controller, udev, multipathd, etc.). Without this retry, a transient `Device is held open by someone` aborts resource initialization, leaves the satellite in an intermediate state, and prevents the controller from receiving the final `UpToDate` event — orphan PVs in `Released` then cannot be cleaned up.
+  - Related upstream issue: [#268](https://github.com/LINBIT/linstor-server/issues/268)
+  - Related upstream issue: [drbd #74](https://github.com/LINBIT/drbd/issues/74) (same EBUSY pattern with multipathd)

--- a/packages/system/linstor/images/piraeus-server/patches/retry-secondary-after-mkfs.diff
+++ b/packages/system/linstor/images/piraeus-server/patches/retry-secondary-after-mkfs.diff
@@ -1,0 +1,104 @@
+diff --git a/satellite/src/main/java/com/linbit/linstor/layer/drbd/utils/DrbdAdm.java b/satellite/src/main/java/com/linbit/linstor/layer/drbd/utils/DrbdAdm.java
+index 71c1df6..f91903b 100644
+--- a/satellite/src/main/java/com/linbit/linstor/layer/drbd/utils/DrbdAdm.java
++++ b/satellite/src/main/java/com/linbit/linstor/layer/drbd/utils/DrbdAdm.java
+@@ -62,6 +62,10 @@ public class DrbdAdm
+     private static final long FORCE_DETACH_RETRY_WAIT_MS = 250;
+     private static final String BITMAP_LEAK_ERR_MSG = "already has a bitmap, this should not happen";
+     private static final Pattern BITMAP_LEAK_MINOR_PATTERN = Pattern.compile("\\bminor\\s+(\\d+)\\b");
++    private static final int SECONDARY_RETRY_MAX_ATTEMPTS = 7;
++    private static final long SECONDARY_RETRY_INITIAL_BACKOFF_MS = 250L;
++    private static final long SECONDARY_RETRY_MAX_BACKOFF_MS = 2000L;
++    private static final String DEVICE_HELD_OPEN_ERR_MSG = "Device is held open by someone";
+ 
+     private final ExtCmdFactory extCmdFactory;
+     private final AccessContext sysCtx;
+@@ -945,6 +949,79 @@ public class DrbdAdm
+         return true;
+     }
+ 
++    /**
++     * Switches a resource to secondary mode after mkfs, retrying when DRBD reports the device as held
++     * open by another process. On Talos and other systems with active block-device probing
++     * (machined/udev), the kernel uevent for a freshly-promoted device may cause an external probe
++     * to open the device just before LINSTOR demotes it back to Secondary, producing
++     * "Device is held open by someone" (errno -12) and aborting resource initialization.
++     * Probes typically release the fd within milliseconds, so a short retry with exponential backoff
++     * is sufficient to win the race without changing the contract of {@link #secondary}.
++     */
++    public void secondaryAfterMkfs(DrbdRscData<Resource> drbdRscData) throws ExtCmdFailedException
++    {
++        String[] commandArr = new String[] {
++            DRBDADM_UTIL, "-vvv", "secondary", drbdRscData.getSuffixedResourceName()
++        };
++
++        File nullDevice = new File(Platform.nullDevice());
++
++        OutputData lastOutput = null;
++        for (int attempt = 1; attempt <= SECONDARY_RETRY_MAX_ATTEMPTS; attempt++)
++        {
++            try
++            {
++                ExtCmd extCmd = extCmdFactory.create();
++                if (Platform.isWindows())
++                {
++                    extCmd.setTimeout(TimeoutType.WAIT, 5 * 60 * 1000);
++                }
++
++                lastOutput = extCmd.pipeExec(ProcessBuilder.Redirect.from(nullDevice), commandArr);
++                if (lastOutput.exitCode == 0)
++                {
++                    return;
++                }
++                if (!isDeviceHeldOpenError(lastOutput) || attempt == SECONDARY_RETRY_MAX_ATTEMPTS)
++                {
++                    throw new ExtCmdFailedException(commandArr, lastOutput);
++                }
++            }
++            catch (ChildProcessTimeoutException timeoutExc)
++            {
++                throw new ExtCmdFailedException(commandArr, timeoutExc);
++            }
++            catch (IOException ioExc)
++            {
++                throw new ExtCmdFailedException(commandArr, ioExc);
++            }
++
++            long sleepMs = Math.min(
++                SECONDARY_RETRY_INITIAL_BACKOFF_MS * (1L << (attempt - 1)),
++                SECONDARY_RETRY_MAX_BACKOFF_MS
++            );
++            try
++            {
++                Thread.sleep(sleepMs);
++            }
++            catch (InterruptedException ie)
++            {
++                Thread.currentThread().interrupt();
++                throw new ExtCmdFailedException(commandArr, lastOutput);
++            }
++        }
++    }
++
++    static boolean isDeviceHeldOpenError(OutputData outputData)
++    {
++        if (outputData == null || outputData.stderrData == null)
++        {
++            return false;
++        }
++        String stderr = new String(outputData.stderrData, StandardCharsets.UTF_8);
++        return stderr.contains(DEVICE_HELD_OPEN_ERR_MSG);
++    }
++
+     public static class DrbdPrimary implements AutoCloseable
+     {
+         private final DrbdAdm drbdAdm;
+@@ -963,7 +1040,7 @@ public class DrbdAdm
+         @Override
+         public void close() throws ExtCmdFailedException
+         {
+-            drbdAdm.secondary(drbdRscData);
++            drbdAdm.secondaryAfterMkfs(drbdRscData);
+         }
+     }
+ }


### PR DESCRIPTION
## What this PR does

Adds a fifth piraeus-server patch that retries `drbdadm secondary` after `mkfs` when DRBD reports the device as held open by an external process.

### Problem

On Talos (and any system with active block-device probing — udev, multipathd, etc.) the kernel uevent for a freshly-promoted DRBD device causes an external probe to `open()` the device for superblock inspection. If LINSTOR satellite issues `drbdadm secondary` while the probe still holds the fd, DRBD returns `(-12) Device is held open by someone` and aborts initialization with `StorageException: Failed to become secondary again after creating filesystem`.

The satellite never reports the final `UpToDate` event to the controller, so the controller view stays in `SyncTarget(N%) / Inconsistent / DELETING` permanently — even though the DRBD kernel state on the satellite is `Established/UpToDate`. This blocks cleanup of orphan PVs in `Released` phase and accumulates with every PVC creation.

Observed in production on Talos 1.10 / LINSTOR 1.33.2: 4 occurrences in 24 hours across 3 nodes for different PVCs. Manual recovery requires `drbdadm down/up` on the Primary to force the satellite to re-report state.

### Fix

New `secondaryAfterMkfs()` wrapper in `DrbdAdm.java`:

- 7 attempts of `drbdadm secondary` with exponential backoff (250 ms → 2 s, capped)
- Retry only triggers when stderr contains `Device is held open by someone`; any other failure fails fast as before
- Existing `secondary()` contract is unchanged — only `DrbdPrimary.close()` (the post-mkfs demotion path) is rerouted to the new wrapper

The retry window covers ~10 s in the worst case, which comfortably exceeds typical probe durations (probes release the fd within milliseconds).

### Related upstream

- [LINBIT/linstor-server#268](https://github.com/LINBIT/linstor-server/issues/268) — open since 2022, identical symptom, no upstream fix
- [LINBIT/drbd#74](https://github.com/LINBIT/drbd/issues/74) — same EBUSY pattern with multipathd holding the fd

### Validation

- `git apply *.diff` on a fresh `v1.33.2` checkout applies all five patches cleanly in alphabetical order
- Java brace/paren/bracket balance verified on the patched file
- `helm template packages/system/linstor` renders without errors

### Release note

```release-note
fix(linstor): retry `drbdadm secondary` after mkfs on transient `Device is held open by someone` errors. Prevents orphan PVs in `Released` phase from accumulating when an external block-device probe (Talos block-controller, udev, multipathd) wins a race against the post-mkfs demotion. Fail-fast behavior preserved for any other secondary failure.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic retry logic for device secondary state transitions after filesystem creation. System now gracefully handles scenarios where devices are temporarily held open by other processes.

* **Documentation**
  * Added documentation for the new device state transition patch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->