### PR TITLE
fix(linstor): plunger demotes idle-Primary DRBD resources

### DIFF
--- a/packages/system/linstor/hack/plunger/plunger-satellite.sh
+++ b/packages/system/linstor/hack/plunger/plunger-satellite.sh
@@ -20,6 +20,34 @@ drbd_status_json() {
   drbdsetup status --json 2>/dev/null || true
 }
 
+# Detect DRBD resources stuck in Primary on this node with no consumer.
+# Auto-promote can promote a resource to Primary (e.g. during mkfs.ext4
+# at provisioning time), but auto-demote sometimes fails to fire on
+# close. The resource then stays Primary on a node that has no
+# consumer and blocks NodePublishVolume on the actual target node with
+# "failed to set source device readwrite". Upstream tracker:
+#   https://github.com/piraeusdatastore/piraeus-operator/issues/942
+#
+# `open == false` on every device of the resource guarantees nobody is
+# using it, so `drbdadm secondary` is safe — at worst it's a no-op
+# that auto-promote will redo when a real consumer arrives.
+drbd_fix_idle_primary() {
+  local json
+  json="$(drbd_status_json)"
+  [ -n "$json" ] || return 0
+
+  printf '%s' "$json" | jq -r '
+    .[]?
+    | select(.role == "Primary")
+    | select(all(.devices[]?; .open == false))
+    | .name
+  ' | while IFS= read -r res; do
+    [ -n "$res" ] || continue
+    log "Idle Primary detected: res=$res open:no -> drbdadm secondary"
+    drbdadm secondary "$res" || log "WARN: secondary failed for $res"
+  done
+}
+
 # Detect DRBD resources where resync is stuck:
 # - at least one local device is Inconsistent
 # - there is an active SyncTarget peer
@@ -153,6 +181,9 @@ while true; do
     drbdadm down "${secondary}" || echo "Command failed"
     drbdadm up "${secondary}" || echo "Command failed"
   ); done
+
+  # Detect and demote idle Primary resources stuck after auto-promote
+  drbd_fix_idle_primary || true
 
   # Detect and fix stalled DRBD resync by switching SyncTarget peer
   drbd_fix_stalled_sync || true


### PR DESCRIPTION
## What this PR does

Adds a per-satellite plunger handler that detects DRBD resources
stuck in `Primary` on the local node with no consumer and demotes
them to `Secondary`.

### Background

DRBD auto-promotes a resource to `Primary` during the provisioning
path (`mkfs.ext4` against a freshly created replica, for example),
but auto-demote sometimes fails to fire on close. The resource then
stays `Primary` on a node that has no consumer pod, and CSI on the
legitimate target node fails `NodePublishVolume` with:

```
failed to set source device readwrite: exit status 1
```

The only recovery is an explicit `drbdadm secondary` on the stuck
node — there is no upstream automation for it.

This was hit deterministically in Cozystack e2e CI on freshly
provisioned PVCs without any pod migration or node failure. Upstream
tracker: piraeusdatastore/piraeus-operator#942 (and the related
piraeusdatastore/linstor-csi#172).

### Implementation

In `plunger-satellite.sh` (already running as a privileged sidecar
on every linstor-satellite pod) add `drbd_fix_idle_primary`:

```jq
.[]?
| select(.role == "Primary")
| select(all(.devices[]?; .open == false))
| .name
```

For every match, run `drbdadm secondary <res>`.

### Why this is safe

- `open == false` on **every** device of the resource means no reader
  or writer holds the block device — the demote cannot interrupt I/O.
- Both detection and action are local to the satellite, no peer
  coordination needed.
- If a real consumer is about to arrive, DRBD auto-promote will redo
  the promotion when CSI opens the device — so even a misfire is a
  no-op.
- The jq filter was validated against a live multi-node cluster
  (3 nodes, 22 legitimate Primaries, 0 false positives — every
  legitimate Primary has at least one `open: true` volume).

### Release note

```release-note
fix(linstor): plunger now demotes DRBD resources stuck in Primary
without a consumer, fixing transient `failed to set source device
readwrite` mount errors during PVC provisioning.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced DRBD resource management with automatic remediation for idle Primary resources. The system now detects resources lacking active device connections and safely demotes them to Secondary state during routine maintenance cycles. Robust error handling preserves existing recovery procedures while improving overall system stability and preventing potential resource conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->