### PR TITLE
fix(harbor): mark credentials Secret with user-secret label

### DIFF
--- a/packages/apps/harbor/templates/harbor.yaml
+++ b/packages/apps/harbor/templates/harbor.yaml
@@ -27,6 +27,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-credentials
+  labels:
+    apps.cozystack.io/user-secret: "true"
 stringData:
   admin-password: {{ $adminPassword | quote }}
   redis-password: {{ $redisPassword | quote }}

--- a/packages/system/harbor-rd/cozyrds/harbor.yaml
+++ b/packages/system/harbor-rd/cozyrds/harbor.yaml
@@ -33,6 +33,8 @@ spec:
     include:
       - resourceNames:
           - "{{ .name }}-credentials"
+      - matchLabels:
+          apps.cozystack.io/user-secret: "true"
   services:
     exclude: []
     include:


### PR DESCRIPTION
## What this PR does

- Stamps the Helm-managed `{{ .Release.Name }}-credentials` Secret with `apps.cozystack.io/user-secret: "true"`.
- Adds a `matchLabels` rule to `secrets.include` in the Harbor `ApplicationDefinition`, alongside the existing `resourceNames` entry.

The lineage webhook decides whether a Secret is tenant-visible by matching its name against the `secrets.include[].resourceNames` template in the corresponding `ApplicationDefinition`. For Harbor the template `{{ .name }}-credentials` renders to `{name}-credentials` and does not account for the `release.prefix: "harbor-"` set in the same definition, while the Helm chart actually creates `harbor-{name}-credentials`. The names never match, so the Secret ends up labelled `internal.cozystack.io/tenantresource=false` and never appears in the TenantSecrets API.

This change follows the existing `apps.cozystack.io/user-secret: "true"` pattern already used by Bucket (`packages/system/bucket/templates/user-credentials.yaml`) and RabbitMQ (`packages/apps/rabbitmq/templates/rabbitmq.yaml`). The webhook then matches via labels and is independent of how Helm names the Secret.

### Screenshots

Not applicable — no UI changes in this PR.

### Release note

```release-note
fix(harbor): expose Harbor credentials Secret to tenant-aware clients by marking it with the `apps.cozystack.io/user-secret` label, mirroring the pattern already used by Bucket and RabbitMQ.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Harbor configuration to support label-based secret discovery alongside existing name-based selection, improving secret management reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->