### PR TITLE
fix(harbor,bucket): guard COSI BucketInfo render against half-initialised state

### DIFF
--- a/packages/system/bucket/Makefile
+++ b/packages/system/bucket/Makefile
@@ -5,6 +5,9 @@ export NAME=s3manager-system
 include ../../../hack/common-envs.mk
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 update:
 	@echo Nothing to update
 

--- a/packages/system/bucket/templates/deployment.yaml
+++ b/packages/system/bucket/templates/deployment.yaml
@@ -1,8 +1,15 @@
+{{- /*
+On a fresh install the COSI BucketAccess driver creates the
+credentials Secret before populating `data.BucketInfo`, so guard
+the inner index against the half-initialised state — otherwise the
+template fails with `index of untyped nil` and the HelmRelease is
+marked failed until the next reconcile.
+*/ -}}
 {{- $endpoint := printf "s3.%s" .Values._namespace.host }}
 {{- range $name, $user := .Values.users }}
   {{- $secretName := printf "%s-%s" $.Values.bucketName $name }}
   {{- $existingSecret := lookup "v1" "Secret" $.Release.Namespace $secretName }}
-  {{- if $existingSecret }}
+  {{- if and $existingSecret (hasKey ($existingSecret.data | default dict) "BucketInfo") }}
     {{- $bucketInfo := fromJson (b64dec (index $existingSecret.data "BucketInfo")) }}
     {{- $endpoint = trimPrefix "https://" (index $bucketInfo.spec.secretS3 "endpoint") }}
   {{- end }}

--- a/packages/system/bucket/templates/user-credentials.yaml
+++ b/packages/system/bucket/templates/user-credentials.yaml
@@ -1,7 +1,13 @@
+{{- /*
+Same COSI race as deployment.yaml: BucketAccess creates the source
+Secret before populating data.BucketInfo. Skip the credentials
+Secret render until BucketInfo is present; the HelmRelease retries
+each reconcile interval.
+*/ -}}
 {{- range $name, $user := .Values.users }}
 {{- $secretName := printf "%s-%s" $.Values.bucketName $name }}
 {{- $existingSecret := lookup "v1" "Secret" $.Release.Namespace $secretName }}
-{{- if $existingSecret }}
+{{- if and $existingSecret (hasKey ($existingSecret.data | default dict) "BucketInfo") }}
 {{- $bucketInfo := fromJson (b64dec (index $existingSecret.data "BucketInfo")) }}
 ---
 apiVersion: v1

--- a/packages/system/bucket/tests/cosi_race_test.yaml
+++ b/packages/system/bucket/tests/cosi_race_test.yaml
@@ -1,0 +1,63 @@
+suite: COSI bootstrap race guards
+
+release:
+  name: bucket
+  namespace: tenant-root
+
+# Coverage scope: helm-unittest's `lookup` always returns nil (no
+# cluster). The outer `if $existingSecret` guard already existed
+# before this PR, so removing only the new inner
+# `hasKey ($existingSecret.data | default dict) "BucketInfo"` check
+# leaves these cases passing — the inner guard handles a real-cluster
+# race state (Secret exists, `data.BucketInfo` not yet populated by
+# the COSI BucketAccess driver) that cannot be mocked under
+# helm-unittest. Cluster-level coverage of that branch lives in the
+# bucket e2e flow.
+#
+# What this suite pins: the templates render without error and emit
+# zero credentials documents while the source Secret is absent or
+# while no users are declared. The deployment falls back to the
+# computed `s3.<host>` endpoint when no source Secret is reachable.
+# These guard the OUTER branch, the values-shape contract, and the
+# default-endpoint fallback against accidental refactor regressions.
+#
+# Shared values (_namespace, _cluster) are populated below because
+# the chart includes ingress.yaml that references them; helm-unittest
+# renders every template even when the assertions target one file.
+set:
+  bucketName: cozystack
+  _namespace:
+    host: example.com
+    ingress: ""
+  _cluster:
+    cluster-domain: cozy.local
+
+tests:
+  - it: user-credentials emits no Secret when source is absent
+    template: templates/user-credentials.yaml
+    set:
+      users:
+        alice:
+          accessPolicy: readwrite
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: user-credentials emits nothing when no users are declared
+    template: templates/user-credentials.yaml
+    set:
+      users: {}
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: deployment falls back to default endpoint when source is absent
+    template: templates/deployment.yaml
+    set:
+      users:
+        alice:
+          accessPolicy: readwrite
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name=="ENDPOINT")].value
+          value: s3.example.com

--- a/packages/system/harbor/Makefile
+++ b/packages/system/harbor/Makefile
@@ -3,6 +3,9 @@ export NAMESPACE=cozy-system
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 update:
 	rm -rf charts
 	helm repo add harbor https://helm.goharbor.io

--- a/packages/system/harbor/templates/bucket-secret.yaml
+++ b/packages/system/harbor/templates/bucket-secret.yaml
@@ -1,5 +1,16 @@
+{{- /*
+On a fresh install the COSI BucketAccess driver has not yet
+populated `<bucket.secretName>.data.BucketInfo` by the time this
+chart first renders. Without a guard the template fails with
+  index of untyped nil
+which marks the HelmRelease as failed until the next reconcile.
+Render the dependent Secret only once BucketInfo is present; the
+HelmRelease retries every reconcile interval, so the registry-s3
+Secret materialises as soon as the bucket is provisioned.
+*/ -}}
 {{- if .Values.bucket.secretName }}
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace .Values.bucket.secretName }}
+{{- if and $existingSecret (hasKey ($existingSecret.data | default dict) "BucketInfo") }}
 {{- $bucketInfo := fromJson (b64dec (index $existingSecret.data "BucketInfo")) }}
 {{- $accessKeyID := index $bucketInfo.spec.secretS3 "accessKeyID" }}
 {{- $accessSecretKey := index $bucketInfo.spec.secretS3 "accessSecretKey" }}
@@ -17,4 +28,5 @@ stringData:
   REGISTRY_STORAGE_S3_REGIONENDPOINT: {{ $endpoint | quote }}
   REGISTRY_STORAGE_S3_BUCKET: {{ $bucketName | quote }}
   REGISTRY_STORAGE_S3_REGION: "us-east-1"
+{{- end }}
 {{- end }}

--- a/packages/system/harbor/tests/bucket_secret_test.yaml
+++ b/packages/system/harbor/tests/bucket_secret_test.yaml
@@ -22,6 +22,11 @@ tests:
       - hasDocuments:
           count: 0
 
+  # If the guard is removed, this case fails with a render error
+  # (`index of untyped nil`) rather than a doc-count mismatch — the
+  # whole template aborts before any document is produced. Either
+  # signal flags the regression; helm-unittest surfaces the render
+  # error inline above the suite summary.
   - it: no Secret rendered (and no template error) when source secret is absent
     template: templates/bucket-secret.yaml
     set:

--- a/packages/system/harbor/tests/bucket_secret_test.yaml
+++ b/packages/system/harbor/tests/bucket_secret_test.yaml
@@ -4,12 +4,20 @@ release:
   name: harbor
   namespace: tenant-root
 
-# Helm `lookup` returns nil under helm-unittest (no cluster), so this
-# suite covers exactly the failure modes the bucket-secret template
-# has to absorb on a fresh install: the COSI BucketAccess driver has
-# not yet populated `<release>-registry-bucket.data.BucketInfo`.
-# The template must skip the dependent registry-s3 Secret rather
-# than fail with `index of untyped nil`.
+# Coverage scope: helm-unittest's `lookup` always returns nil (no
+# cluster), so the cases below pin the OUTER guard — the
+# `if .Values.bucket.secretName` short-circuit and the `$existingSecret`
+# truthy check. Both ride the same code path: empty values OR nil
+# lookup → no document.
+#
+# The INNER guard (`hasKey ($existingSecret.data | default dict) "BucketInfo"`)
+# handles a real-cluster race where the COSI BucketAccess driver has
+# created the Secret but not yet populated `data.BucketInfo`. That
+# state cannot be mocked under helm-unittest; cluster-level coverage
+# lives in `hack/e2e-apps/harbor.bats`, which exercises the full
+# COSI -> bucket-secret -> harbor pod startup chain. If a future
+# refactor drops just the inner guard, this suite will still pass —
+# the e2e is the regression line for that branch.
 tests:
   - it: no Secret rendered when bucket.secretName is empty
     template: templates/bucket-secret.yaml
@@ -22,11 +30,12 @@ tests:
       - hasDocuments:
           count: 0
 
-  # If the guard is removed, this case fails with a render error
-  # (`index of untyped nil`) rather than a doc-count mismatch — the
-  # whole template aborts before any document is produced. Either
-  # signal flags the regression; helm-unittest surfaces the render
-  # error inline above the suite summary.
+  # If the OUTER guard is removed (so lookup nil flows straight into
+  # `index $existingSecret.data ...`), this case fails with a render
+  # error rather than a doc-count mismatch — helm-unittest surfaces
+  # the render error inline above the suite summary, which is enough
+  # signal for the next reader. The inner hasKey guard isn't pinned
+  # here (see suite header).
   - it: no Secret rendered (and no template error) when source secret is absent
     template: templates/bucket-secret.yaml
     set:

--- a/packages/system/harbor/tests/bucket_secret_test.yaml
+++ b/packages/system/harbor/tests/bucket_secret_test.yaml
@@ -1,0 +1,34 @@
+suite: bucket-secret guards
+
+release:
+  name: harbor
+  namespace: tenant-root
+
+# Helm `lookup` returns nil under helm-unittest (no cluster), so this
+# suite covers exactly the failure modes the bucket-secret template
+# has to absorb on a fresh install: the COSI BucketAccess driver has
+# not yet populated `<release>-registry-bucket.data.BucketInfo`.
+# The template must skip the dependent registry-s3 Secret rather
+# than fail with `index of untyped nil`.
+tests:
+  - it: no Secret rendered when bucket.secretName is empty
+    template: templates/bucket-secret.yaml
+    set:
+      harbor:
+        fullnameOverride: harbor
+      bucket:
+        secretName: ""
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: no Secret rendered (and no template error) when source secret is absent
+    template: templates/bucket-secret.yaml
+    set:
+      harbor:
+        fullnameOverride: harbor
+      bucket:
+        secretName: harbor-registry-bucket
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
<!-- Conventional Commit type/scope already in title: fix(harbor,bucket) -->

## What this PR does

On a fresh install the COSI BucketAccess driver creates the credentials Secret first and populates `data.BucketInfo` in a follow-up update. The `cozy-harbor` and `cozy-bucket` charts both index `BucketInfo` directly during template rendering, so during the bootstrap window helm fails with

```
error calling index: index of untyped nil
```

and the HelmRelease is marked failed until the next reconcile interval (5m default). Symptom is reproducible with `helm template` against an empty cluster.

This PR wraps both the `cozy-harbor` `bucket-secret.yaml` template and the two `cozy-bucket` templates (`deployment.yaml`, `user-credentials.yaml`) in a single uniform guard:

```gotemplate
{{- if and $existingSecret (hasKey ($existingSecret.data | default dict) "BucketInfo") }}
```

`| default dict` covers a Secret object with `data: null` (which the API can return for a freshly created empty Secret). Once `BucketInfo` is populated, behaviour is identical — only the failure mode changes: render-error becomes "skip and let the HelmRelease retry on the next interval".

`fix(harbor)` also references the originating commit `e7ffc217` (Feb 2026) that introduced the unguarded shape.

### Test coverage

Two new helm-unittest suites (`packages/system/harbor/tests/bucket_secret_test.yaml`, `packages/system/bucket/tests/cosi_race_test.yaml`) plus `test:` Makefile targets that wire them into `hack/helm-unit-tests.sh` auto-discovery. 5/5 tests pass locally.

Honest scope note: helm-unittest's `lookup` always returns nil (no cluster), so the new tests pin the OUTER guard branch only. The INNER `hasKey BucketInfo` guard handles a real-cluster race state (Secret exists, key not yet populated) that cannot be mocked under helm-unittest. Cluster-level coverage of that branch lives in the existing `hack/e2e-apps/{harbor,bucket}.bats` suites — both already exercise the full BucketClaim → BucketAccess → secret rename → app pod startup chain. Each test file's header documents this scope explicitly so a future reader does not assume coverage that does not exist.

### Release note

```release-note
fix(harbor,bucket): wrap COSI `BucketInfo` index calls with a `hasKey` guard so first-install rendering does not fail with `index of untyped nil` while the BucketAccess driver is still populating the credentials Secret. The HelmRelease retries each reconcile interval and the dependent Secret materialises once the bucket is provisioned.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race condition where deployment and registry configuration templates could fail if referenced Secrets weren't fully populated during system initialization.
  * Added conditional safeguards to gracefully handle missing or incomplete Secret data during template rendering operations, preventing initialization failures.

* **Tests**
  * Added comprehensive test suites to verify proper handling of initialization timing edge cases and expected fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->