### PR TITLE
feat(talos): bump Talos to v1.13.0

### DIFF
--- a/packages/core/talos/images/talos/profiles/initramfs.yaml
+++ b/packages/core/talos/images/talos/profiles/initramfs.yaml
@@ -3,24 +3,24 @@
 arch: amd64
 platform: metal
 secureboot: false
-version: v1.12.7
+version: v1.13.0
 input:
   kernel:
     path: /usr/install/amd64/vmlinuz
   initramfs:
     path: /usr/install/amd64/initramfs.xz
   baseInstaller:
-    imageRef: "ghcr.io/siderolabs/installer:v1.12.7"
+    imageRef: "ghcr.io/siderolabs/installer:v1.13.0"
   systemExtensions:
     - imageRef: ghcr.io/siderolabs/amd-ucode:20260410@sha256:d5a0256846700ebb4fd2dba0107cfd944f6689d9bf96f47ab9dc35ef1e225179
-    - imageRef: ghcr.io/siderolabs/amdgpu:20260410-v1.12.7@sha256:56f15250504024879b7088902c18682332ad90ba1572473e62524f4e79e85684
+    - imageRef: ghcr.io/siderolabs/amdgpu:20260410-v1.13.0@sha256:48f121b8b6575b6c38e2dd459cbb022f6ef3e8aea6209255a14654d28aea8b8c
     - imageRef: ghcr.io/siderolabs/bnx2-bnx2x:20260410@sha256:5a481b38c305d2292e7b6e06750ec704ac1229602c75cf80535ff3561f0b29c3
     - imageRef: ghcr.io/siderolabs/intel-ice-firmware:20260410@sha256:ef1cbec222fb2d2ae0db9c025e4b9b6b875d965d49ebb71d7ad9f0713133c299
-    - imageRef: ghcr.io/siderolabs/i915:20260410-v1.12.7@sha256:d7b5fe4ee60a3afbb4e858b49956d9559c1f7a38d42e1df63e847189b149c6da
+    - imageRef: ghcr.io/siderolabs/i915:20260410-v1.13.0@sha256:fa10ab5a7ab8e412ef8ead8d244cf1ba37c13c60ceb0150044e4682ff29b25af
     - imageRef: ghcr.io/siderolabs/intel-ucode:20260227@sha256:6112f6426a7081727545f7c33dcf2a89ff672494847b180380b4c58f3544a7b2
     - imageRef: ghcr.io/siderolabs/qlogic-firmware:20260410@sha256:83593864ae91b16e9962258b5f0bd777d4c81846ece206bb84e9c37be023715c
-    - imageRef: ghcr.io/siderolabs/drbd:9.2.16-v1.12.7@sha256:be407c20d509a1a445310636b0508008a8e5cd8e1532fbd11e5d131ae2fe9dca
-    - imageRef: ghcr.io/siderolabs/zfs:2.4.1-v1.12.7@sha256:1d98138c6422e52b850da99a68e918b721b4358eed8c4daa1c9059222175127c
+    - imageRef: ghcr.io/siderolabs/drbd:9.3.1-v1.13.0@sha256:414c94ab6c73c6f20b4dbfce53383fd9ea7bc485d76ceaee5eb6360d2bddcc40
+    - imageRef: ghcr.io/siderolabs/zfs:2.4.1-v1.13.0@sha256:301ae643b38d8b377c051ec0e52b9b03ea49bdc90ca7c49e0da83444a92c5619
 output:
   kind: initramfs
   imageOptions: {}

--- a/packages/core/talos/images/talos/profiles/installer.yaml
+++ b/packages/core/talos/images/talos/profiles/installer.yaml
@@ -3,24 +3,24 @@
 arch: amd64
 platform: metal
 secureboot: false
-version: v1.12.7
+version: v1.13.0
 input:
   kernel:
     path: /usr/install/amd64/vmlinuz
   initramfs:
     path: /usr/install/amd64/initramfs.xz
   baseInstaller:
-    imageRef: "ghcr.io/siderolabs/installer:v1.12.7"
+    imageRef: "ghcr.io/siderolabs/installer:v1.13.0"
   systemExtensions:
     - imageRef: ghcr.io/siderolabs/amd-ucode:20260410@sha256:d5a0256846700ebb4fd2dba0107cfd944f6689d9bf96f47ab9dc35ef1e225179
-    - imageRef: ghcr.io/siderolabs/amdgpu:20260410-v1.12.7@sha256:56f15250504024879b7088902c18682332ad90ba1572473e62524f4e79e85684
+    - imageRef: ghcr.io/siderolabs/amdgpu:20260410-v1.13.0@sha256:48f121b8b6575b6c38e2dd459cbb022f6ef3e8aea6209255a14654d28aea8b8c
     - imageRef: ghcr.io/siderolabs/bnx2-bnx2x:20260410@sha256:5a481b38c305d2292e7b6e06750ec704ac1229602c75cf80535ff3561f0b29c3
     - imageRef: ghcr.io/siderolabs/intel-ice-firmware:20260410@sha256:ef1cbec222fb2d2ae0db9c025e4b9b6b875d965d49ebb71d7ad9f0713133c299
-    - imageRef: ghcr.io/siderolabs/i915:20260410-v1.12.7@sha256:d7b5fe4ee60a3afbb4e858b49956d9559c1f7a38d42e1df63e847189b149c6da
+    - imageRef: ghcr.io/siderolabs/i915:20260410-v1.13.0@sha256:fa10ab5a7ab8e412ef8ead8d244cf1ba37c13c60ceb0150044e4682ff29b25af
     - imageRef: ghcr.io/siderolabs/intel-ucode:20260227@sha256:6112f6426a7081727545f7c33dcf2a89ff672494847b180380b4c58f3544a7b2
     - imageRef: ghcr.io/siderolabs/qlogic-firmware:20260410@sha256:83593864ae91b16e9962258b5f0bd777d4c81846ece206bb84e9c37be023715c
-    - imageRef: ghcr.io/siderolabs/drbd:9.2.16-v1.12.7@sha256:be407c20d509a1a445310636b0508008a8e5cd8e1532fbd11e5d131ae2fe9dca
-    - imageRef: ghcr.io/siderolabs/zfs:2.4.1-v1.12.7@sha256:1d98138c6422e52b850da99a68e918b721b4358eed8c4daa1c9059222175127c
+    - imageRef: ghcr.io/siderolabs/drbd:9.3.1-v1.13.0@sha256:414c94ab6c73c6f20b4dbfce53383fd9ea7bc485d76ceaee5eb6360d2bddcc40
+    - imageRef: ghcr.io/siderolabs/zfs:2.4.1-v1.13.0@sha256:301ae643b38d8b377c051ec0e52b9b03ea49bdc90ca7c49e0da83444a92c5619
 output:
   kind: installer
   imageOptions: {}

--- a/packages/core/talos/images/talos/profiles/iso.yaml
+++ b/packages/core/talos/images/talos/profiles/iso.yaml
@@ -3,24 +3,24 @@
 arch: amd64
 platform: metal
 secureboot: false
-version: v1.12.7
+version: v1.13.0
 input:
   kernel:
     path: /usr/install/amd64/vmlinuz
   initramfs:
     path: /usr/install/amd64/initramfs.xz
   baseInstaller:
-    imageRef: "ghcr.io/siderolabs/installer:v1.12.7"
+    imageRef: "ghcr.io/siderolabs/installer:v1.13.0"
   systemExtensions:
     - imageRef: ghcr.io/siderolabs/amd-ucode:20260410@sha256:d5a0256846700ebb4fd2dba0107cfd944f6689d9bf96f47ab9dc35ef1e225179
-    - imageRef: ghcr.io/siderolabs/amdgpu:20260410-v1.12.7@sha256:56f15250504024879b7088902c18682332ad90ba1572473e62524f4e79e85684
+    - imageRef: ghcr.io/siderolabs/amdgpu:20260410-v1.13.0@sha256:48f121b8b6575b6c38e2dd459cbb022f6ef3e8aea6209255a14654d28aea8b8c
     - imageRef: ghcr.io/siderolabs/bnx2-bnx2x:20260410@sha256:5a481b38c305d2292e7b6e06750ec704ac1229602c75cf80535ff3561f0b29c3
     - imageRef: ghcr.io/siderolabs/intel-ice-firmware:20260410@sha256:ef1cbec222fb2d2ae0db9c025e4b9b6b875d965d49ebb71d7ad9f0713133c299
-    - imageRef: ghcr.io/siderolabs/i915:20260410-v1.12.7@sha256:d7b5fe4ee60a3afbb4e858b49956d9559c1f7a38d42e1df63e847189b149c6da
+    - imageRef: ghcr.io/siderolabs/i915:20260410-v1.13.0@sha256:fa10ab5a7ab8e412ef8ead8d244cf1ba37c13c60ceb0150044e4682ff29b25af
     - imageRef: ghcr.io/siderolabs/intel-ucode:20260227@sha256:6112f6426a7081727545f7c33dcf2a89ff672494847b180380b4c58f3544a7b2
     - imageRef: ghcr.io/siderolabs/qlogic-firmware:20260410@sha256:83593864ae91b16e9962258b5f0bd777d4c81846ece206bb84e9c37be023715c
-    - imageRef: ghcr.io/siderolabs/drbd:9.2.16-v1.12.7@sha256:be407c20d509a1a445310636b0508008a8e5cd8e1532fbd11e5d131ae2fe9dca
-    - imageRef: ghcr.io/siderolabs/zfs:2.4.1-v1.12.7@sha256:1d98138c6422e52b850da99a68e918b721b4358eed8c4daa1c9059222175127c
+    - imageRef: ghcr.io/siderolabs/drbd:9.3.1-v1.13.0@sha256:414c94ab6c73c6f20b4dbfce53383fd9ea7bc485d76ceaee5eb6360d2bddcc40
+    - imageRef: ghcr.io/siderolabs/zfs:2.4.1-v1.13.0@sha256:301ae643b38d8b377c051ec0e52b9b03ea49bdc90ca7c49e0da83444a92c5619
 output:
   kind: iso
   imageOptions: {}

--- a/packages/core/talos/images/talos/profiles/kernel.yaml
+++ b/packages/core/talos/images/talos/profiles/kernel.yaml
@@ -3,24 +3,24 @@
 arch: amd64
 platform: metal
 secureboot: false
-version: v1.12.7
+version: v1.13.0
 input:
   kernel:
     path: /usr/install/amd64/vmlinuz
   initramfs:
     path: /usr/install/amd64/initramfs.xz
   baseInstaller:
-    imageRef: "ghcr.io/siderolabs/installer:v1.12.7"
+    imageRef: "ghcr.io/siderolabs/installer:v1.13.0"
   systemExtensions:
     - imageRef: ghcr.io/siderolabs/amd-ucode:20260410@sha256:d5a0256846700ebb4fd2dba0107cfd944f6689d9bf96f47ab9dc35ef1e225179
-    - imageRef: ghcr.io/siderolabs/amdgpu:20260410-v1.12.7@sha256:56f15250504024879b7088902c18682332ad90ba1572473e62524f4e79e85684
+    - imageRef: ghcr.io/siderolabs/amdgpu:20260410-v1.13.0@sha256:48f121b8b6575b6c38e2dd459cbb022f6ef3e8aea6209255a14654d28aea8b8c
     - imageRef: ghcr.io/siderolabs/bnx2-bnx2x:20260410@sha256:5a481b38c305d2292e7b6e06750ec704ac1229602c75cf80535ff3561f0b29c3
     - imageRef: ghcr.io/siderolabs/intel-ice-firmware:20260410@sha256:ef1cbec222fb2d2ae0db9c025e4b9b6b875d965d49ebb71d7ad9f0713133c299
-    - imageRef: ghcr.io/siderolabs/i915:20260410-v1.12.7@sha256:d7b5fe4ee60a3afbb4e858b49956d9559c1f7a38d42e1df63e847189b149c6da
+    - imageRef: ghcr.io/siderolabs/i915:20260410-v1.13.0@sha256:fa10ab5a7ab8e412ef8ead8d244cf1ba37c13c60ceb0150044e4682ff29b25af
     - imageRef: ghcr.io/siderolabs/intel-ucode:20260227@sha256:6112f6426a7081727545f7c33dcf2a89ff672494847b180380b4c58f3544a7b2
     - imageRef: ghcr.io/siderolabs/qlogic-firmware:20260410@sha256:83593864ae91b16e9962258b5f0bd777d4c81846ece206bb84e9c37be023715c
-    - imageRef: ghcr.io/siderolabs/drbd:9.2.16-v1.12.7@sha256:be407c20d509a1a445310636b0508008a8e5cd8e1532fbd11e5d131ae2fe9dca
-    - imageRef: ghcr.io/siderolabs/zfs:2.4.1-v1.12.7@sha256:1d98138c6422e52b850da99a68e918b721b4358eed8c4daa1c9059222175127c
+    - imageRef: ghcr.io/siderolabs/drbd:9.3.1-v1.13.0@sha256:414c94ab6c73c6f20b4dbfce53383fd9ea7bc485d76ceaee5eb6360d2bddcc40
+    - imageRef: ghcr.io/siderolabs/zfs:2.4.1-v1.13.0@sha256:301ae643b38d8b377c051ec0e52b9b03ea49bdc90ca7c49e0da83444a92c5619
 output:
   kind: kernel
   imageOptions: {}

--- a/packages/core/talos/images/talos/profiles/metal.yaml
+++ b/packages/core/talos/images/talos/profiles/metal.yaml
@@ -3,24 +3,24 @@
 arch: amd64
 platform: metal
 secureboot: false
-version: v1.12.7
+version: v1.13.0
 input:
   kernel:
     path: /usr/install/amd64/vmlinuz
   initramfs:
     path: /usr/install/amd64/initramfs.xz
   baseInstaller:
-    imageRef: "ghcr.io/siderolabs/installer:v1.12.7"
+    imageRef: "ghcr.io/siderolabs/installer:v1.13.0"
   systemExtensions:
     - imageRef: ghcr.io/siderolabs/amd-ucode:20260410@sha256:d5a0256846700ebb4fd2dba0107cfd944f6689d9bf96f47ab9dc35ef1e225179
-    - imageRef: ghcr.io/siderolabs/amdgpu:20260410-v1.12.7@sha256:56f15250504024879b7088902c18682332ad90ba1572473e62524f4e79e85684
+    - imageRef: ghcr.io/siderolabs/amdgpu:20260410-v1.13.0@sha256:48f121b8b6575b6c38e2dd459cbb022f6ef3e8aea6209255a14654d28aea8b8c
     - imageRef: ghcr.io/siderolabs/bnx2-bnx2x:20260410@sha256:5a481b38c305d2292e7b6e06750ec704ac1229602c75cf80535ff3561f0b29c3
     - imageRef: ghcr.io/siderolabs/intel-ice-firmware:20260410@sha256:ef1cbec222fb2d2ae0db9c025e4b9b6b875d965d49ebb71d7ad9f0713133c299
-    - imageRef: ghcr.io/siderolabs/i915:20260410-v1.12.7@sha256:d7b5fe4ee60a3afbb4e858b49956d9559c1f7a38d42e1df63e847189b149c6da
+    - imageRef: ghcr.io/siderolabs/i915:20260410-v1.13.0@sha256:fa10ab5a7ab8e412ef8ead8d244cf1ba37c13c60ceb0150044e4682ff29b25af
     - imageRef: ghcr.io/siderolabs/intel-ucode:20260227@sha256:6112f6426a7081727545f7c33dcf2a89ff672494847b180380b4c58f3544a7b2
     - imageRef: ghcr.io/siderolabs/qlogic-firmware:20260410@sha256:83593864ae91b16e9962258b5f0bd777d4c81846ece206bb84e9c37be023715c
-    - imageRef: ghcr.io/siderolabs/drbd:9.2.16-v1.12.7@sha256:be407c20d509a1a445310636b0508008a8e5cd8e1532fbd11e5d131ae2fe9dca
-    - imageRef: ghcr.io/siderolabs/zfs:2.4.1-v1.12.7@sha256:1d98138c6422e52b850da99a68e918b721b4358eed8c4daa1c9059222175127c
+    - imageRef: ghcr.io/siderolabs/drbd:9.3.1-v1.13.0@sha256:414c94ab6c73c6f20b4dbfce53383fd9ea7bc485d76ceaee5eb6360d2bddcc40
+    - imageRef: ghcr.io/siderolabs/zfs:2.4.1-v1.13.0@sha256:301ae643b38d8b377c051ec0e52b9b03ea49bdc90ca7c49e0da83444a92c5619
 output:
   kind: image
   imageOptions: { diskSize: 1306525696, diskFormat: raw }

--- a/packages/core/talos/images/talos/profiles/nocloud.yaml
+++ b/packages/core/talos/images/talos/profiles/nocloud.yaml
@@ -3,24 +3,24 @@
 arch: amd64
 platform: nocloud
 secureboot: false
-version: v1.12.7
+version: v1.13.0
 input:
   kernel:
     path: /usr/install/amd64/vmlinuz
   initramfs:
     path: /usr/install/amd64/initramfs.xz
   baseInstaller:
-    imageRef: "ghcr.io/siderolabs/installer:v1.12.7"
+    imageRef: "ghcr.io/siderolabs/installer:v1.13.0"
   systemExtensions:
     - imageRef: ghcr.io/siderolabs/amd-ucode:20260410@sha256:d5a0256846700ebb4fd2dba0107cfd944f6689d9bf96f47ab9dc35ef1e225179
-    - imageRef: ghcr.io/siderolabs/amdgpu:20260410-v1.12.7@sha256:56f15250504024879b7088902c18682332ad90ba1572473e62524f4e79e85684
+    - imageRef: ghcr.io/siderolabs/amdgpu:20260410-v1.13.0@sha256:48f121b8b6575b6c38e2dd459cbb022f6ef3e8aea6209255a14654d28aea8b8c
     - imageRef: ghcr.io/siderolabs/bnx2-bnx2x:20260410@sha256:5a481b38c305d2292e7b6e06750ec704ac1229602c75cf80535ff3561f0b29c3
     - imageRef: ghcr.io/siderolabs/intel-ice-firmware:20260410@sha256:ef1cbec222fb2d2ae0db9c025e4b9b6b875d965d49ebb71d7ad9f0713133c299
-    - imageRef: ghcr.io/siderolabs/i915:20260410-v1.12.7@sha256:d7b5fe4ee60a3afbb4e858b49956d9559c1f7a38d42e1df63e847189b149c6da
+    - imageRef: ghcr.io/siderolabs/i915:20260410-v1.13.0@sha256:fa10ab5a7ab8e412ef8ead8d244cf1ba37c13c60ceb0150044e4682ff29b25af
     - imageRef: ghcr.io/siderolabs/intel-ucode:20260227@sha256:6112f6426a7081727545f7c33dcf2a89ff672494847b180380b4c58f3544a7b2
     - imageRef: ghcr.io/siderolabs/qlogic-firmware:20260410@sha256:83593864ae91b16e9962258b5f0bd777d4c81846ece206bb84e9c37be023715c
-    - imageRef: ghcr.io/siderolabs/drbd:9.2.16-v1.12.7@sha256:be407c20d509a1a445310636b0508008a8e5cd8e1532fbd11e5d131ae2fe9dca
-    - imageRef: ghcr.io/siderolabs/zfs:2.4.1-v1.12.7@sha256:1d98138c6422e52b850da99a68e918b721b4358eed8c4daa1c9059222175127c
+    - imageRef: ghcr.io/siderolabs/drbd:9.3.1-v1.13.0@sha256:414c94ab6c73c6f20b4dbfce53383fd9ea7bc485d76ceaee5eb6360d2bddcc40
+    - imageRef: ghcr.io/siderolabs/zfs:2.4.1-v1.13.0@sha256:301ae643b38d8b377c051ec0e52b9b03ea49bdc90ca7c49e0da83444a92c5619
 output:
   kind: image
   imageOptions: { diskSize: 1306525696, diskFormat: raw }


### PR DESCRIPTION
## What this PR does

Bumps Talos Linux from v1.12.7 to v1.13.0. The v1.13 release line also contains the kernel fix for CVE-2026-31431 ("Copy Fail").

Refreshes the bundled system extension digests (amdgpu, i915, drbd, zfs) to their 1.13.0-aligned builds.

Generated via `make update` in `packages/core/talos`.

Stacked on top of #2545. Targets `fix/talos-1.12.7` so the diff shown here is just the v1.12.7 → v1.13.0 delta.

References:
- https://copy.fail/
- https://www.siderolabs.com/blog/exploit-fail-cve-2026-31431-copy-fail-barely-scratches-talos-linux

### Release note

```release-note
feat(talos): bump Talos Linux to v1.13.0
```