### PR TITLE
feat(cozyreport): collect Flux/cert-manager/host context + summary.txt

### DIFF
--- a/hack/cozyreport-summary.sh
+++ b/hack/cozyreport-summary.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# Emit a human-readable summary of "what is broken" to a single file.
+# Reads the live cluster (not the report dir) so it can use kubectl JSONPath.
+# Usage: cozyreport-summary.sh > summary.txt
+set -eu
+
+echo "# Cozystack E2E Diagnostic Summary"
+echo "Generated: $(date -Iseconds)"
+echo
+
+echo "## HelmReleases not Ready"
+echo
+kubectl get hr -A --no-headers 2>/dev/null \
+  | awk '$4 != "True" {printf "  %s/%s — %s\n", $1, $2, $5}' \
+  | head -40
+echo
+
+echo "## Pods not Running/Succeeded"
+echo
+kubectl get pod -A --no-headers 2>/dev/null \
+  | awk '$4 !~ /Running|Succeeded|Completed/ {printf "  %s/%s — %s (restarts=%s, age=%s)\n", $1, $2, $4, $5, $6}' \
+  | head -40
+echo
+
+echo "## ImagePullBackOff / ErrImagePull"
+echo
+kubectl get pod -A --no-headers 2>/dev/null \
+  | awk '$4 ~ /ImagePullBackOff|ErrImagePull/ {printf "  %s/%s — %s\n", $1, $2, $4}'
+echo
+
+echo "## OOMKilled in last 30 min"
+echo
+kubectl get events -A --field-selector reason=OOMKilling --sort-by=.lastTimestamp 2>/dev/null \
+  | tail -20
+echo
+
+echo "## Recent Warning events (top 30)"
+echo
+kubectl get events -A --field-selector type=Warning --sort-by=.lastTimestamp 2>/dev/null \
+  | tail -30
+echo
+
+echo "## cert-manager: Certificates not Ready"
+echo
+if kubectl get crd certificates.cert-manager.io >/dev/null 2>&1; then
+  kubectl get certificates.cert-manager.io -A --no-headers 2>/dev/null \
+    | awk '$3 != "True" {printf "  %s/%s — Ready=%s\n", $1, $2, $3}'
+fi
+echo
+
+echo "## Flux Sources not Ready"
+echo
+for kind in helmrepositories.source.toolkit.fluxcd.io ocirepositories.source.toolkit.fluxcd.io gitrepositories.source.toolkit.fluxcd.io; do
+  kubectl get $kind -A --no-headers 2>/dev/null \
+    | awk -v k="${kind%%.*}" '$4 != "True" {printf "  %s %s/%s — Ready=%s\n", k, $1, $2, $4}'
+done
+echo
+
+echo "## Storage: PVCs not Bound, PVs not Bound"
+echo
+kubectl get pvc -A --no-headers 2>/dev/null | awk '$3 != "Bound" {printf "  PVC %s/%s — %s\n", $1, $2, $3}'
+kubectl get pv --no-headers 2>/dev/null    | awk '$5 != "Bound" {printf "  PV %s — %s\n", $1, $5}'
+echo
+
+echo "## Node Conditions"
+kubectl get nodes -o custom-columns=NAME:.metadata.name,READY:.status.conditions[?\(@.type==\"Ready\"\)].status,DISK:.status.conditions[?\(@.type==\"DiskPressure\"\)].status,MEM:.status.conditions[?\(@.type==\"MemoryPressure\"\)].status 2>/dev/null

--- a/hack/cozyreport-summary.sh
+++ b/hack/cozyreport-summary.sh
@@ -10,9 +10,11 @@ echo
 
 echo "## HelmReleases not Ready"
 echo
-kubectl get hr -A --no-headers 2>/dev/null \
-  | awk '$4 != "True" {printf "  %s/%s — %s\n", $1, $2, $5}' \
-  | head -40
+if kubectl get crd helmreleases.helm.toolkit.fluxcd.io >/dev/null 2>&1; then
+  kubectl get hr -A --no-headers 2>/dev/null \
+    | awk '$4 != "True" {printf "  %s/%s — %s\n", $1, $2, $5}' \
+    | head -40
+fi
 echo
 
 echo "## Pods not Running/Succeeded"
@@ -28,7 +30,7 @@ kubectl get pod -A --no-headers 2>/dev/null \
   | awk '$4 ~ /ImagePullBackOff|ErrImagePull/ {printf "  %s/%s — %s\n", $1, $2, $4}'
 echo
 
-echo "## OOMKilled in last 30 min"
+echo "## Recent OOMKilled events (last 20)"
 echo
 kubectl get events -A --field-selector reason=OOMKilling --sort-by=.lastTimestamp 2>/dev/null \
   | tail -20
@@ -50,9 +52,10 @@ echo
 
 echo "## Flux Sources not Ready"
 echo
-for kind in helmrepositories.source.toolkit.fluxcd.io ocirepositories.source.toolkit.fluxcd.io gitrepositories.source.toolkit.fluxcd.io; do
-  kubectl get $kind -A --no-headers 2>/dev/null \
-    | awk -v k="${kind%%.*}" '$4 != "True" {printf "  %s %s/%s — Ready=%s\n", k, $1, $2, $4}'
+for kind in helmrepositories.source.toolkit.fluxcd.io ocirepositories.source.toolkit.fluxcd.io gitrepositories.source.toolkit.fluxcd.io externalartifacts.source.toolkit.fluxcd.io; do
+  kubectl get crd "$kind" >/dev/null 2>&1 || continue
+  short=${kind%%.*}
+  kubectl get "$kind" -A -o jsonpath='{range .items[?(@.status.conditions[?(@.type=="Ready")].status!="True")]}  '"$short"' {.metadata.namespace}/{.metadata.name} — Ready={.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null
 done
 echo
 

--- a/hack/cozyreport.sh
+++ b/hack/cozyreport.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPORT_DATE=$(date +%Y-%m-%d_%H-%M-%S)
 REPORT_NAME=${1:-cozyreport-$REPORT_DATE}
 REPORT_PDIR=$(mktemp -d)
@@ -140,8 +141,9 @@ for kind in applications.apps.cozystack.io applicationdefinitions.apps.cozystack
   short=${kind%%.*}
   if kubectl get crd $kind >/dev/null 2>&1; then
     kubectl get $kind -A > $DIR/$short.txt 2>&1
-    kubectl get $kind -A --no-headers 2>/dev/null | awk 'NF >= 3 && $NF != "True" && $NF != "Ready"' | \
-      while read NAMESPACE NAME _; do
+    kubectl get $kind -A -o jsonpath='{range .items[?(@.status.conditions[?(@.type=="Ready")].status!="True")]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null | \
+      while read NAMESPACE NAME; do
+        [ -z "$NAMESPACE" ] && continue
         d=$DIR/$short/$NAMESPACE/$NAME
         mkdir -p $d
         kubectl get $kind -n $NAMESPACE $NAME -o yaml > $d/$short.yaml 2>&1
@@ -241,17 +243,19 @@ free -m > $DIR/free.txt 2>&1
 ps auxww > $DIR/ps.txt 2>&1
 dmesg | tail -200 > $DIR/dmesg.txt 2>&1 || true
 if [ -f /workspace/talosconfig ]; then
-  for node in 192.168.123.11 192.168.123.12 192.168.123.13; do
-    talosctl --talosconfig /workspace/talosconfig -n $node dmesg --tail=200 > $DIR/talos-$node-dmesg.txt 2>&1 || true
-    talosctl --talosconfig /workspace/talosconfig -n $node logs kubelet --tail=500 > $DIR/talos-$node-kubelet.log 2>&1 || true
-    talosctl --talosconfig /workspace/talosconfig -n $node logs containerd --tail=500 > $DIR/talos-$node-containerd.log 2>&1 || true
+  NODES=$(kubectl get nodes -o jsonpath='{range .items[*]}{.status.addresses[?(@.type=="InternalIP")].address}{"\n"}{end}' 2>/dev/null)
+  for node in ${NODES:-192.168.123.11 192.168.123.12 192.168.123.13}; do
+    [ -z "$node" ] && continue
+    talosctl --talosconfig /workspace/talosconfig -n "$node" dmesg --tail=200 > "$DIR/talos-$node-dmesg.txt" 2>&1 || true
+    talosctl --talosconfig /workspace/talosconfig -n "$node" logs kubelet --tail=500 > "$DIR/talos-$node-kubelet.log" 2>&1 || true
+    talosctl --talosconfig /workspace/talosconfig -n "$node" logs containerd --tail=500 > "$DIR/talos-$node-containerd.log" 2>&1 || true
   done
 fi
 
 # -- finalization
 
 echo "Generating summary..."
-hack/cozyreport-summary.sh > $REPORT_DIR/summary.txt 2>&1 || true
+"$SCRIPT_DIR/cozyreport-summary.sh" > "$REPORT_DIR/summary.txt" 2>&1 || true
 
 echo "Creating archive..."
 tar -czf $REPORT_NAME.tgz -C $REPORT_PDIR .

--- a/hack/cozyreport.sh
+++ b/hack/cozyreport.sh
@@ -9,16 +9,59 @@ command -V kubectl >/dev/null || exit $?
 command -V tar >/dev/null || exit $?
 
 # -- cozystack module
-
 echo "Collecting Cozystack information..."
 mkdir -p $REPORT_DIR/cozystack
 kubectl get deploy -n cozy-system cozystack -o jsonpath='{.spec.template.spec.containers[0].image}' > $REPORT_DIR/cozystack/image.txt 2>&1
+if kubectl get deploy -n cozy-system cozystack-operator >/dev/null 2>&1; then
+  kubectl logs -n cozy-system deploy/cozystack-operator --tail=2000 > $REPORT_DIR/cozystack/operator.log 2>&1
+  kubectl logs -n cozy-system deploy/cozystack-operator --tail=2000 --previous > $REPORT_DIR/cozystack/operator-previous.log 2>&1 || true
+fi
 kubectl get cm -n cozy-system --no-headers | awk '$1 ~ /^cozystack/' |
   while read NAME _; do
     DIR=$REPORT_DIR/cozystack/configs
     mkdir -p $DIR
     kubectl get cm -n cozy-system $NAME -o yaml > $DIR/$NAME.yaml 2>&1
   done
+
+# -- flux module
+echo "Collecting Flux controller state..."
+mkdir -p $REPORT_DIR/flux
+for ctrl in helm-controller source-controller notification-controller kustomize-controller; do
+  if kubectl get deploy -n cozy-fluxcd $ctrl >/dev/null 2>&1; then
+    kubectl logs -n cozy-fluxcd deploy/$ctrl --tail=2000 > $REPORT_DIR/flux/$ctrl.log 2>&1
+    kubectl logs -n cozy-fluxcd deploy/$ctrl --tail=2000 --previous > $REPORT_DIR/flux/$ctrl-previous.log 2>&1 || true
+  fi
+done
+
+echo "Collecting Flux sources..."
+for kind in helmrepositories.source.toolkit.fluxcd.io ocirepositories.source.toolkit.fluxcd.io gitrepositories.source.toolkit.fluxcd.io externalartifacts.source.toolkit.fluxcd.io; do
+  short=${kind%%.*}
+  kubectl get $kind -A > $REPORT_DIR/flux/$short.txt 2>&1
+  kubectl get $kind -A -o yaml > $REPORT_DIR/flux/$short.yaml 2>&1
+done
+
+# -- cert-manager module
+if kubectl get crd certificates.cert-manager.io >/dev/null 2>&1; then
+  echo "Collecting cert-manager state..."
+  DIR=$REPORT_DIR/cert-manager
+  mkdir -p $DIR
+  kubectl get certificates.cert-manager.io -A > $DIR/certificates.txt 2>&1
+  kubectl get certificaterequests.cert-manager.io -A > $DIR/certificaterequests.txt 2>&1
+  kubectl get orders.acme.cert-manager.io -A > $DIR/orders.txt 2>&1
+  kubectl get challenges.acme.cert-manager.io -A > $DIR/challenges.txt 2>&1
+  # Per non-Ready cert: full yaml + describe
+  kubectl get certificates.cert-manager.io -A --no-headers 2>/dev/null | awk '$3 != "True"' | \
+    while read NAMESPACE NAME _; do
+      cdir=$DIR/certificates/$NAMESPACE/$NAME
+      mkdir -p $cdir
+      kubectl get certificates.cert-manager.io -n $NAMESPACE $NAME -o yaml > $cdir/cert.yaml 2>&1
+      kubectl describe certificates.cert-manager.io -n $NAMESPACE $NAME > $cdir/describe.txt 2>&1
+    done
+  if kubectl get deploy -n cozy-cert-manager cert-manager >/dev/null 2>&1; then
+    kubectl logs -n cozy-cert-manager deploy/cert-manager --tail=2000 > $DIR/cert-manager.log 2>&1
+    kubectl logs -n cozy-cert-manager deploy/cert-manager-webhook --tail=2000 > $DIR/cert-manager-webhook.log 2>&1
+  fi
+fi
 
 # -- kubernetes module
 
@@ -46,6 +89,13 @@ kubectl get ns --no-headers | awk '$2 != "Active"' |
     kubectl describe ns $NAME > $DIR/describe.txt 2>&1
   done
 
+echo "Collecting events..."
+kubectl get events -A --sort-by=.lastTimestamp > $REPORT_DIR/kubernetes/events.txt 2>&1
+# Filter to warning-class and recent for quick triage
+kubectl get events -A --sort-by=.lastTimestamp \
+  -o jsonpath='{range .items[?(@.type!="Normal")]}{.lastTimestamp}{"\t"}{.involvedObject.namespace}/{.involvedObject.kind}/{.involvedObject.name}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}' \
+  > $REPORT_DIR/kubernetes/events-warnings.txt 2>&1
+
 echo "Collecting helmreleases..."
 kubectl get hr -A > $REPORT_DIR/kubernetes/helmreleases.txt 2>&1
 kubectl get hr -A --no-headers | awk '$4 != "True"' | \
@@ -54,6 +104,13 @@ kubectl get hr -A --no-headers | awk '$4 != "True"' | \
     mkdir -p $DIR
     kubectl get hr -n $NAMESPACE $NAME -o yaml > $DIR/hr.yaml 2>&1
     kubectl describe hr -n $NAMESPACE $NAME > $DIR/describe.txt 2>&1
+    # Helm storage secrets: latest revision per release.
+    kubectl get secret -n $NAMESPACE -l owner=helm,name=$NAME --sort-by='.metadata.creationTimestamp' --no-headers 2>/dev/null | \
+      tail -1 | awk '{print $1}' | while read SECRET; do
+        [ -z "$SECRET" ] && continue
+        kubectl get secret -n $NAMESPACE $SECRET -o jsonpath='{.data.release}' 2>/dev/null \
+          | base64 -d | base64 -d | gzip -d > $DIR/helm-release.json 2>&1 || true
+      done
   done
 
 echo "Collecting packages..."
@@ -75,6 +132,23 @@ kubectl get packagesources --no-headers | awk '$3 != "True"' | \
     kubectl get packagesource $NAME -o yaml > $DIR/packagesource.yaml 2>&1
     kubectl describe packagesource $NAME > $DIR/describe.txt 2>&1
   done
+
+echo "Collecting cozystack apps..."
+DIR=$REPORT_DIR/cozystack-apps
+mkdir -p $DIR
+for kind in applications.apps.cozystack.io applicationdefinitions.apps.cozystack.io tenants.apps.cozystack.io; do
+  short=${kind%%.*}
+  if kubectl get crd $kind >/dev/null 2>&1; then
+    kubectl get $kind -A > $DIR/$short.txt 2>&1
+    kubectl get $kind -A --no-headers 2>/dev/null | awk 'NF >= 3 && $NF != "True" && $NF != "Ready"' | \
+      while read NAMESPACE NAME _; do
+        d=$DIR/$short/$NAMESPACE/$NAME
+        mkdir -p $d
+        kubectl get $kind -n $NAMESPACE $NAME -o yaml > $d/$short.yaml 2>&1
+        kubectl describe $kind -n $NAMESPACE $NAME > $d/describe.txt 2>&1
+      done
+  fi
+done
 
 echo "Collecting pods..."
 kubectl get pod -A -o wide > $REPORT_DIR/kubernetes/pods.txt 2>&1
@@ -157,7 +231,27 @@ if kubectl get deploy -n cozy-linstor linstor-controller >/dev/null 2>&1; then
   kubectl exec -n cozy-linstor deploy/linstor-controller -- linstor --no-color r l > $DIR/resources.txt 2>&1
 fi
 
+# -- sandbox-host module
+
+echo "Collecting sandbox host context..."
+DIR=$REPORT_DIR/sandbox-host
+mkdir -p $DIR
+df -h > $DIR/df.txt 2>&1
+free -m > $DIR/free.txt 2>&1
+ps auxww > $DIR/ps.txt 2>&1
+dmesg | tail -200 > $DIR/dmesg.txt 2>&1 || true
+if [ -f /workspace/talosconfig ]; then
+  for node in 192.168.123.11 192.168.123.12 192.168.123.13; do
+    talosctl --talosconfig /workspace/talosconfig -n $node dmesg --tail=200 > $DIR/talos-$node-dmesg.txt 2>&1 || true
+    talosctl --talosconfig /workspace/talosconfig -n $node logs kubelet --tail=500 > $DIR/talos-$node-kubelet.log 2>&1 || true
+    talosctl --talosconfig /workspace/talosconfig -n $node logs containerd --tail=500 > $DIR/talos-$node-containerd.log 2>&1 || true
+  done
+fi
+
 # -- finalization
+
+echo "Generating summary..."
+hack/cozyreport-summary.sh > $REPORT_DIR/summary.txt 2>&1 || true
 
 echo "Creating archive..."
 tar -czf $REPORT_NAME.tgz -C $REPORT_PDIR .


### PR DESCRIPTION
## What this PR does

Makes `cozyreport.tgz` actually useful when triaging an E2E failure deeper than a single pod log. Adds:

- Flux controller logs (helm-controller, source-controller, notification-controller, kustomize-controller, last 2000 lines each)
- Flux source resources (`HelmRepository`, `OCIRepository`, `GitRepository`, `ExternalArtifact`)
- Decoded Helm storage secrets for non-Ready HRs (`base64 -d | base64 -d | gzip -d`)
- Cluster events (all + warning-only filtered file)
- cert-manager `Certificate` / `CertificateRequest` / `Order` / `Challenge` resources + cert-manager logs
- `cozystack-operator` deployment logs (current + previous)
- `Application` / `ApplicationDefinition` / `Tenant` resources
- Sandbox host context per node: `df`, `free`, `ps`, `dmesg`, `talosctl logs/dmesg/kubelet/containerd`

New executable `hack/cozyreport-summary.sh` writes a `summary.txt` at the archive root listing what is broken right now — the first thing to read when downloading the artifact from a CI failure.

Surfaced from #2500.

### Release note

```
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a timestamped diagnostic summary report that highlights failing resources and key cluster issues.
  * Expanded diagnostic collection: controller logs (current+previous), Flux source status, cert-manager certificate details, Helm release payloads, and Cozystack resource status.
  * Added host-level diagnostics (disk/memory/process/dmesg) and improved event/warning listings to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->