### PR TITLE
test(tests): pre-pull timing-sensitive platform images before install

### DIFF
--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -7,6 +7,30 @@
   fi
 }
 
+@test "Pre-pull platform images" {
+  # Cluster-member workloads (OVN raft, LINSTOR) fail if replicas start at
+  # different times due to image-pull stagger across nodes. Pre-pull these
+  # images to every node so all replicas start with images already cached.
+  #
+  # Source images directly from the rendered charts so version bumps stay in
+  # sync automatically. yq walks every PodSpec-shaped object and emits the
+  # images of each container — this scopes the result to images the kubelet
+  # actually pulls (skips configmap fields and CRD examples that happen to
+  # contain an `image:` key). Add a chart here when a new peer-sensitive
+  # workload is found.
+  # Capture each render into a variable first: bats does not enable
+  # `pipefail`, so a `helm template` failure inside a brace-grouped pipe
+  # would be silently masked by yq's exit code, the script would receive
+  # empty stdin, and the test would pass while pre-pull was skipped.
+  # Assigning to a variable lets `set -e` trigger on a render failure.
+  kubeovn_manifests=$(helm template packages/system/kubeovn)
+  linstor_manifests=$(helm template packages/system/linstor)
+  printf '%s\n%s\n' "$kubeovn_manifests" "$linstor_manifests" | yq -N '
+      (..|select(has("containers"))|.containers[]|.image),
+      (..|select(has("initContainers"))|.initContainers[]|.image)
+    ' | hack/e2e-prepull-images.sh
+}
+
 @test "Install Cozystack" {
   # Install cozy-installer chart (operator installs CRDs on startup via --install-crds)
   helm upgrade installer packages/core/installer \

--- a/hack/e2e-prepull-images.sh
+++ b/hack/e2e-prepull-images.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Pre-pull images to all cluster nodes.
+#
+# Reads image references from stdin, one per line. Empty lines and lines
+# starting with '#' are ignored.
+#
+# Some workloads (OVN raft, LINSTOR) are sensitive to peer-readiness at
+# startup: if nodes pull the image at different speeds, one replica boots
+# before its peers are reachable, exhausts its raft connection retries, and
+# the HelmRelease install times out. Pre-pulling eliminates the pull stagger
+# so all replicas start within milliseconds of each other.
+#
+# Implementation: a DaemonSet with one regular container per image (parallel
+# pulls — total time = max of any one image rather than sum). kubectl rollout
+# status blocks until all pods are Ready (= all containers running = all
+# images cached on every node), then we delete the DaemonSet.
+
+set -euo pipefail
+
+cleanup() {
+  kubectl delete daemonset e2e-image-prepuller -n kube-system --ignore-not-found
+}
+trap cleanup EXIT
+
+mapfile -t images < <(grep -Ev '^[[:space:]]*(#|$)' | sort -u)
+
+if [[ ${#images[@]} -eq 0 ]]; then
+  echo "e2e-prepull-images: no images on stdin, nothing to do" >&2
+  exit 0
+fi
+
+echo "Pre-pulling ${#images[@]} image(s):"
+printf '  %s\n' "${images[@]}"
+
+containers=""
+i=0
+for image in "${images[@]}"; do
+  containers+="
+      - name: pull-${i}
+        image: ${image}
+        command: [\"sleep\", \"infinity\"]
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 1m
+            memory: 1Mi"
+  i=$((i + 1))
+done
+
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: e2e-image-prepuller
+  namespace: kube-system
+  labels:
+    app: e2e-image-prepuller
+spec:
+  selector:
+    matchLabels:
+      app: e2e-image-prepuller
+  template:
+    metadata:
+      labels:
+        app: e2e-image-prepuller
+    spec:
+      # hostNetwork bypasses the CNI: this script runs BEFORE Cozystack
+      # installs kube-ovn, so the cluster has no working CNI yet and a normal
+      # pod would stay ContainerCreating with NetworkPluginNotReady, never
+      # reaching image-pull. With hostNetwork the pod sandbox is created on
+      # the host's namespace and the kubelet pulls images right away.
+      # Same pattern the cozystack-operator pod uses for the same reason.
+      hostNetwork: true
+      # No need for an SA token — this pod just sleeps while images pull.
+      automountServiceAccountToken: false
+      tolerations:
+      # Reach every node including control-plane and nodes still coming up.
+      - operator: Exists
+      containers:${containers}
+EOF
+
+echo "Waiting for e2e-image-prepuller DaemonSet to become ready..."
+kubectl rollout status daemonset/e2e-image-prepuller -n kube-system --timeout=10m
+
+echo "Image pre-pull complete."


### PR DESCRIPTION
## What this PR does

Some workloads (kube-ovn raft, LINSTOR controller / piraeus-server) fail when replicas start at materially different times due to image-pull stagger across nodes. Adds a DaemonSet-based pre-pull step that runs before `helm install`, ensuring every node has the images cached so replicas start within milliseconds of each other.

`hack/e2e-prepull-images.sh` accepts image refs on stdin and creates one container per image so pulls run in parallel — total time = max(any single image) rather than sum. The bats test sources image refs directly from the rendered platform charts via `yq`, walking only PodSpec-shaped objects, so version bumps stay in sync without a hardcoded list.

Surfaced from #2500.

### Release note

```
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test that pre-pulls platform container images before the installation workflow to improve install reliability.

* **Chores**
  * Added an automated pre-pull utility that reads image lists, deduplicates and sorts them, deploys a short-lived pre-puller across nodes, waits for completion, then cleans up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->