### PR TITLE
feat(e2e): parallel post-install prep

### DIFF
--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -83,10 +83,25 @@ spec:
             - cozystack.external-dns-application
 EOF
 
+  # Launch storage + LB configuration in the background. It waits for its
+  # own prerequisites (linstor-controller deploy, MetalLB CRDs) and finishes
+  # while the parallel HR wait below is still running, so the cost overlaps
+  # with the platform reconcile instead of compounding it.
+  hack/e2e-post-install-prep.sh > /tmp/post-install-prep.log 2>&1 &
+  POST_PREP_PID=$!
+
   # Wait until HelmReleases appear & reconcile them
   timeout 180 sh -ec 'until [ $(kubectl get hr -A --no-headers 2>/dev/null | wc -l) -gt 10 ]; do sleep 1; done'
   sleep 5
   kubectl get hr -A | awk 'NR>1 {print "kubectl wait --timeout=15m --for=condition=ready -n "$1" hr/"$2" &"} END {print "wait"}' | sh -ex
+
+  echo "Waiting for post-install-prep to complete"
+  if ! wait $POST_PREP_PID; then
+    cat /tmp/post-install-prep.log >&2
+    echo "post-install-prep failed" >&2
+    exit 1
+  fi
+  cat /tmp/post-install-prep.log
 
   # Fail the test if any HelmRelease is not Ready
   if kubectl get hr -A | grep -v " True " | grep -v NAME; then
@@ -99,79 +114,6 @@ EOF
   # Wait for Cluster‑API provider deployments
   timeout 120 sh -ec 'until kubectl get deploy -n cozy-cluster-api capi-controller-manager capi-kamaji-controller-manager capi-kubeadm-bootstrap-controller-manager capi-operator-cluster-api-operator capk-controller-manager >/dev/null 2>&1; do sleep 1; done'
   kubectl wait deployment/capi-controller-manager deployment/capi-kamaji-controller-manager deployment/capi-kubeadm-bootstrap-controller-manager deployment/capi-operator-cluster-api-operator deployment/capk-controller-manager -n cozy-cluster-api --timeout=2m --for=condition=available
-}
-
-@test "Wait for LINSTOR and configure storage" {
-  # Linstor controller and nodes
-  kubectl wait deployment/linstor-controller -n cozy-linstor --timeout=5m --for=condition=available
-  timeout 60 sh -ec 'until [ $(kubectl exec -n cozy-linstor deploy/linstor-controller -- linstor node list | grep -c Online) -eq 3 ]; do sleep 1; done'
-
-  created_pools=$(kubectl exec -n cozy-linstor deploy/linstor-controller -- linstor sp l -s data --pastable | awk '$2 == "data" {printf " " $4} END{printf " "}')
-  for node in srv1 srv2 srv3; do
-    case $created_pools in
-      *" $node "*) echo "Storage pool 'data' already exists on node $node"; continue;;
-    esac
-    kubectl exec -n cozy-linstor deploy/linstor-controller -- linstor ps cdp zfs ${node} /dev/vdc --pool-name data --storage-pool data
-  done
-
-  # Storage classes
-  kubectl apply -f - <<'EOF'
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: local
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
-provisioner: linstor.csi.linbit.com
-parameters:
-  linstor.csi.linbit.com/storagePool: "data"
-  linstor.csi.linbit.com/layerList: "storage"
-  linstor.csi.linbit.com/allowRemoteVolumeAccess: "false"
-volumeBindingMode: WaitForFirstConsumer
-allowVolumeExpansion: true
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: replicated
-provisioner: linstor.csi.linbit.com
-parameters:
-  linstor.csi.linbit.com/storagePool: "data"
-  linstor.csi.linbit.com/autoPlace: "3"
-  linstor.csi.linbit.com/layerList: "drbd storage"
-  linstor.csi.linbit.com/allowRemoteVolumeAccess: "true"
-  property.linstor.csi.linbit.com/DrbdOptions/auto-quorum: suspend-io
-  property.linstor.csi.linbit.com/DrbdOptions/Resource/on-no-data-accessible: suspend-io
-  property.linstor.csi.linbit.com/DrbdOptions/Resource/on-suspended-primary-outdated: force-secondary
-  property.linstor.csi.linbit.com/DrbdOptions/Net/rr-conflict: retry-connect
-volumeBindingMode: Immediate
-allowVolumeExpansion: true
-EOF
-}
-
-@test "Wait for MetalLB and configure address pool" {
-  # MetalLB address pool
-  kubectl apply -f - <<'EOF'
----
-apiVersion: metallb.io/v1beta1
-kind: L2Advertisement
-metadata:
-  name: cozystack
-  namespace: cozy-metallb
-spec:
-  ipAddressPools: [cozystack]
----
-apiVersion: metallb.io/v1beta1
-kind: IPAddressPool
-metadata:
-  name: cozystack
-  namespace: cozy-metallb
-spec:
-  addresses: [192.168.123.200-192.168.123.250]
-  autoAssign: true
-  avoidBuggyIPs: false
-EOF
 }
 
 @test "Check Cozystack API service" {

--- a/hack/e2e-post-install-prep.sh
+++ b/hack/e2e-post-install-prep.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# Runs LINSTOR pool + StorageClass + MetalLB pool configuration as soon as
+# their respective prerequisites are reachable. Designed to run in the
+# background during the platform HR reconcile wait, so its wall-clock cost
+# overlaps with the wait instead of compounding it.
+set -eu
+
+echo "[post-install-prep] waiting for linstor HelmRelease object to exist"
+timeout 60 sh -ec 'until kubectl get hr/linstor -n cozy-linstor >/dev/null 2>&1; do sleep 2; done'
+
+echo "[post-install-prep] waiting for linstor HelmRelease to be Ready"
+kubectl wait helmrelease/linstor -n cozy-linstor --for=condition=Ready --timeout=15m
+
+echo "[post-install-prep] waiting for linstor-controller deployment to exist"
+timeout 300 sh -ec 'until kubectl get deploy/linstor-controller -n cozy-linstor >/dev/null 2>&1; do sleep 2; done'
+
+echo "[post-install-prep] waiting for linstor-controller to be Available"
+kubectl wait deployment/linstor-controller -n cozy-linstor --timeout=5m --for=condition=available
+
+echo "[post-install-prep] waiting for 3 LINSTOR nodes Online"
+timeout 60 sh -ec 'until [ $(kubectl exec -n cozy-linstor deploy/linstor-controller -- linstor node list | grep -c Online) -eq 3 ]; do sleep 1; done'
+
+echo "[post-install-prep] creating LINSTOR storage pools (parallel across nodes)"
+created_pools=$(kubectl exec -n cozy-linstor deploy/linstor-controller -- linstor sp l -s data --pastable | awk '$2 == "data" {printf " " $4} END{printf " "}')
+for node in srv1 srv2 srv3; do
+  case $created_pools in
+    *" $node "*) echo "  pool 'data' already exists on $node"; continue;;
+  esac
+  kubectl exec -n cozy-linstor deploy/linstor-controller -- linstor ps cdp zfs ${node} /dev/vdc --pool-name data --storage-pool data &
+done
+wait
+
+echo "[post-install-prep] applying StorageClasses"
+kubectl apply -f - <<'EOF'
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: linstor.csi.linbit.com
+parameters:
+  linstor.csi.linbit.com/storagePool: "data"
+  linstor.csi.linbit.com/layerList: "storage"
+  linstor.csi.linbit.com/allowRemoteVolumeAccess: "false"
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: replicated
+provisioner: linstor.csi.linbit.com
+parameters:
+  linstor.csi.linbit.com/storagePool: "data"
+  linstor.csi.linbit.com/autoPlace: "3"
+  linstor.csi.linbit.com/layerList: "drbd storage"
+  linstor.csi.linbit.com/allowRemoteVolumeAccess: "true"
+  property.linstor.csi.linbit.com/DrbdOptions/auto-quorum: suspend-io
+  property.linstor.csi.linbit.com/DrbdOptions/Resource/on-no-data-accessible: suspend-io
+  property.linstor.csi.linbit.com/DrbdOptions/Resource/on-suspended-primary-outdated: force-secondary
+  property.linstor.csi.linbit.com/DrbdOptions/Net/rr-conflict: retry-connect
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+EOF
+
+echo "[post-install-prep] waiting for MetalLB CRDs"
+timeout 300 sh -ec 'until kubectl get crd ipaddresspools.metallb.io l2advertisements.metallb.io >/dev/null 2>&1; do sleep 2; done'
+
+echo "[post-install-prep] applying MetalLB IPAddressPool"
+kubectl apply -f - <<'EOF'
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: cozystack
+  namespace: cozy-metallb
+spec:
+  ipAddressPools: [cozystack]
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: cozystack
+  namespace: cozy-metallb
+spec:
+  addresses: [192.168.123.200-192.168.123.250]
+  autoAssign: true
+  avoidBuggyIPs: false
+EOF
+
+echo "[post-install-prep] done"

--- a/hack/e2e-post-install-prep.sh
+++ b/hack/e2e-post-install-prep.sh
@@ -22,13 +22,17 @@ timeout 60 sh -ec 'until [ $(kubectl exec -n cozy-linstor deploy/linstor-control
 
 echo "[post-install-prep] creating LINSTOR storage pools (parallel across nodes)"
 created_pools=$(kubectl exec -n cozy-linstor deploy/linstor-controller -- linstor sp l -s data --pastable | awk '$2 == "data" {printf " " $4} END{printf " "}')
+pids=""
 for node in srv1 srv2 srv3; do
   case $created_pools in
     *" $node "*) echo "  pool 'data' already exists on $node"; continue;;
   esac
   kubectl exec -n cozy-linstor deploy/linstor-controller -- linstor ps cdp zfs ${node} /dev/vdc --pool-name data --storage-pool data &
+  pids="$pids $!"
 done
-wait
+for pid in $pids; do
+  wait "$pid"
+done
 
 echo "[post-install-prep] applying StorageClasses"
 kubectl apply -f - <<'EOF'


### PR DESCRIPTION
## What this PR does

### Parallel post-install prep

LINSTOR / StorageClass / MetalLB setup, previously sequential `@test` cases after the 15 m platform HR wait, now run as a background prep that completes during the platform reconcile. None of them gates platform HR reconcile, so they can move out of the critical path.

New helper `hack/e2e-post-install-prep.sh` polls for its prerequisites and is awaited at the end of the `Install Cozystack` test so failures still surface deterministically.

### T2-race fix

Wait on the LINSTOR HR being `Ready` before polling for `deploy/linstor-controller`. The old 5-min hard timeout fired during cold installs where the LINSTOR HR's dependency chain (cert-manager → piraeus-operator-crds → piraeus-operator → linstor) takes longer than 5 min to resolve.

### E2E uses helmReleaseInterval=30s

E2E install passes `--set cozystackOperator.helmReleaseInterval=30s` to eliminate the 8–10 min Flux dead zone where dependency-blocked HRs are requeued only every 5 min. Operator-side flag and chart value landed in #2509; production defaults are unchanged.

Surfaced from #2500.

### Release note

```
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  - Improved end-to-end test initialization to run concurrent post-install preparation, wait for cluster release reconciliation, verify component readiness, and validate automated storage configuration.

* **Chores**
  - Added background post-install setup and logging to increase test reliability and speed up cluster initialization and teardown diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->