### PR TITLE
fix(kafka): create LoadBalancer service when external flag is enabled

### DIFF
--- a/packages/apps/kafka/templates/dashboard-resourcemap.yaml
+++ b/packages/apps/kafka/templates/dashboard-resourcemap.yaml
@@ -9,6 +9,9 @@ rules:
   - services
   resourceNames:
   - {{ .Release.Name }}-kafka-bootstrap
+  {{- if .Values.external }}
+  - {{ .Release.Name }}-kafka-external-bootstrap
+  {{- end }}
   verbs: ["get", "list", "watch"]
 - apiGroups:
   - ""

--- a/packages/apps/kafka/templates/kafka.yaml
+++ b/packages/apps/kafka/templates/kafka.yaml
@@ -18,14 +18,12 @@ spec:
         port: 9093
         type: internal
         tls: true
+      {{- if .Values.external }}
       - name: external
         port: 9094
-        {{- if .Values.external }}
         type: loadbalancer
-        {{- else }}
-        type: internal
-        {{- end }}
         tls: false
+      {{- end }}
     config:
       {{- if eq (int .Values.kafka.replicas) 1 }}
       offsets.topic.replication.factor: 1

--- a/packages/apps/kafka/tests/dashboard-resourcemap_test.yaml
+++ b/packages/apps/kafka/tests/dashboard-resourcemap_test.yaml
@@ -1,0 +1,124 @@
+suite: dashboard resourcemap tests
+
+templates:
+  - templates/dashboard-resourcemap.yaml
+
+tests:
+  # Always renders Role and RoleBinding
+  - it: renders Role and RoleBinding
+    release:
+      name: test-kafka
+      namespace: tenant-test
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: Role
+        documentIndex: 0
+      - isKind:
+          of: RoleBinding
+        documentIndex: 1
+
+  # Role naming
+  - it: uses correct Role name
+    release:
+      name: my-kafka
+      namespace: tenant-test
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-kafka-dashboard-resources
+        documentIndex: 0
+
+  # RoleBinding naming
+  - it: uses correct RoleBinding name
+    release:
+      name: my-kafka
+      namespace: tenant-test
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-kafka-dashboard-resources
+        documentIndex: 1
+
+  # Internal bootstrap service always in RBAC
+  - it: grants access to internal bootstrap service
+    release:
+      name: test-kafka
+      namespace: tenant-test
+    asserts:
+      - contains:
+          path: rules[0].resourceNames
+          content: test-kafka-kafka-bootstrap
+        documentIndex: 0
+
+  # External bootstrap service absent when external is false
+  - it: does not grant access to external bootstrap service when external is false
+    release:
+      name: test-kafka
+      namespace: tenant-test
+    set:
+      external: false
+    asserts:
+      - notContains:
+          path: rules[0].resourceNames
+          content: test-kafka-kafka-external-bootstrap
+        documentIndex: 0
+
+  # External bootstrap service present when external is true
+  - it: grants access to external bootstrap service when external is true
+    release:
+      name: test-kafka
+      namespace: tenant-test
+    set:
+      external: true
+    asserts:
+      - contains:
+          path: rules[0].resourceNames
+          content: test-kafka-kafka-external-bootstrap
+        documentIndex: 0
+
+  # Role grants access to CA secret
+  - it: grants access to clients CA secret
+    release:
+      name: test-kafka
+      namespace: tenant-test
+    asserts:
+      - contains:
+          path: rules[1].resourceNames
+          content: test-kafka-clients-ca
+        documentIndex: 0
+
+  # Role grants access to workloadmonitors
+  - it: grants access to WorkloadMonitor
+    release:
+      name: test-kafka
+      namespace: tenant-test
+    asserts:
+      - contains:
+          path: rules[2].resourceNames
+          content: test-kafka
+        documentIndex: 0
+      - equal:
+          path: rules[2].apiGroups[0]
+          value: cozystack.io
+        documentIndex: 0
+
+  # RoleBinding references correct Role
+  - it: RoleBinding references correct Role
+    release:
+      name: test-kafka
+      namespace: tenant-test
+    asserts:
+      - equal:
+          path: roleRef.kind
+          value: Role
+        documentIndex: 1
+      - equal:
+          path: roleRef.name
+          value: test-kafka-dashboard-resources
+        documentIndex: 1
+      - equal:
+          path: roleRef.apiGroup
+          value: rbac.authorization.k8s.io
+        documentIndex: 1

--- a/packages/apps/kafka/tests/kafka_test.yaml
+++ b/packages/apps/kafka/tests/kafka_test.yaml
@@ -1,0 +1,114 @@
+suite: Kafka CR tests
+
+templates:
+  - templates/kafka.yaml
+
+tests:
+  ###################
+  # Basic rendering #
+  ###################
+
+  - it: renders Kafka CR
+    release:
+      name: test-kafka
+      namespace: tenant-test
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Kafka
+
+  - it: sets correct CR name
+    release:
+      name: my-kafka
+      namespace: tenant-test
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-kafka
+
+  #####################
+  # Internal listeners #
+  #####################
+
+  - it: always creates plain internal listener
+    release:
+      name: test-kafka
+      namespace: tenant-test
+    asserts:
+      - contains:
+          path: spec.kafka.listeners
+          content:
+            name: plain
+            port: 9092
+            type: internal
+            tls: false
+
+  - it: always creates tls internal listener
+    release:
+      name: test-kafka
+      namespace: tenant-test
+    asserts:
+      - contains:
+          path: spec.kafka.listeners
+          content:
+            name: tls
+            port: 9093
+            type: internal
+            tls: true
+
+  #####################
+  # External listener  #
+  #####################
+
+  - it: does not create external listener when external is false
+    release:
+      name: test-kafka
+      namespace: tenant-test
+    set:
+      external: false
+    asserts:
+      - notContains:
+          path: spec.kafka.listeners
+          content:
+            name: external
+            port: 9094
+            type: loadbalancer
+            tls: false
+
+  - it: creates external loadbalancer listener when external is true
+    release:
+      name: test-kafka
+      namespace: tenant-test
+    set:
+      external: true
+    asserts:
+      - contains:
+          path: spec.kafka.listeners
+          content:
+            name: external
+            port: 9094
+            type: loadbalancer
+            tls: false
+
+  - it: has exactly 2 listeners when external is false
+    release:
+      name: test-kafka
+      namespace: tenant-test
+    set:
+      external: false
+    asserts:
+      - lengthEqual:
+          path: spec.kafka.listeners
+          count: 2
+
+  - it: has exactly 3 listeners when external is true
+    release:
+      name: test-kafka
+      namespace: tenant-test
+    set:
+      external: true
+    asserts:
+      - lengthEqual:
+          path: spec.kafka.listeners
+          count: 3


### PR DESCRIPTION
## What this PR does

When `external: true` is set in the Kafka chart, Strimzi creates a
LoadBalancer service named `<release>-kafka-external-bootstrap` for
external client access. However, two issues prevented this from working
correctly:

1. **Unconditional listener definition**: the `external` listener was
   always present in the Kafka CR (as `type: internal` when disabled),
   instead of being omitted entirely when `external: false`.

2. **Missing dashboard RBAC**: the dashboard role only granted access
   to `<release>-kafka-bootstrap` (internal ClusterIP). The
   Strimzi-managed external bootstrap service was not included, making
   it invisible to tenant users even when it was created.

**Changes:**
- Make the external listener conditional — added only when `external: true`
- Add `<release>-kafka-external-bootstrap` to dashboard RBAC rules
  when `external: true`
- Add helm-unittest tests covering listener and RBAC behavior for both
  `external: true` and `external: false`

### Screenshots

N/A — no UI changes.

### Release note

```release-note
fix(kafka): external listener is now correctly created as a LoadBalancer and exposed in the tenant dashboard when `external: true` is set
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External Kafka listener and external bootstrap service in dashboard resource mapping are now conditionally enabled based on configuration settings.

* **Tests**
  * Added comprehensive test suites validating Kafka configuration rendering and dashboard resource mapping across internal and external deployment variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->