### PR TITLE
fix(ci): stop backport workflow from cascading on its own PRs

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -17,6 +17,7 @@ jobs:
   prepare:
     if: |
       github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
       (
         contains(github.event.pull_request.labels.*.name, 'backport') ||
         contains(github.event.pull_request.labels.*.name, 'backport-previous') ||
@@ -90,6 +91,7 @@ jobs:
     needs: prepare
     if: |
       github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
       (needs.prepare.outputs.backport_current == 'true' || needs.prepare.outputs.backport_previous == 'true')
     runs-on: [self-hosted]
     strategy:

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -134,7 +134,6 @@ jobs:
             const cleanTitle = backportMatch ? backportMatch[2] : title;
             if (backportMatch) {
               toAdd.add('area/release');
-              toAdd.add('backport');
             }
 
             // 2. Try Conventional Commits form: type(scope)?(!)?: description


### PR DESCRIPTION
## What this PR does

Fix the cascade where merging a backport PR (e.g. #2579) spawns another backport (e.g. #2581 `[Backport release-1.2] [Backport release-1.3] …`).

Two compounding issues:

1. `pr-labeler.yaml` auto-added the `backport` label to any PR whose title started with `[Backport release-X.Y]` — exactly the prefix `korthout/backport-action` puts on every backport PR. Introduced in `c8ed1c65` (CNCF/k8s label conventions). Fixed by dropping that `toAdd.add('backport')` line.
2. `dosubot[bot]` independently re-applies `backport-previous` to backport PRs based on similarity to the parent PR; it cannot be controlled from this repo. Fixed by gating both jobs in `backport.yaml` on `pull_request.base.ref == 'main'`, so backport PRs (which target `release-X.Y`) cannot trigger the workflow regardless of labels.

Verified pre-fix behaviour by inspecting the label-event timeline of #2580 (dosubot adds `backport-previous` 47s after PR open) and the diff of `c8ed1c65` adding `pr-labeler.yaml`.

### Release note

```release-note
fix(ci): backport automation no longer creates duplicate backport PRs when a backport PR is merged.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced backport automation workflow with additional safety checks to ensure operations only process pull requests targeting the main branch.
  * Simplified pull request labeling workflow to streamline label assignment logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->