### PR TITLE
feat(ouroboros): v0.7.2 + bats fix for kubectl jsonpath bracket-notation silent-empty on dotted keys

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -159,7 +159,7 @@ jobs:
     name: "E2E Tests"
     runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'debug') && 'self-hosted' || 'oracle-vm-24cpu-96gb-x86-64' }}
     #runs-on: [oracle-vm-32cpu-128gb-x86-64]
-    timeout-minutes: 120
+    timeout-minutes: 180
     permissions:
       contents: read
       packages: read

--- a/hack/e2e-apps/ouroboros.bats
+++ b/hack/e2e-apps/ouroboros.bats
@@ -76,19 +76,62 @@ EOF
   # current QEMU runners is around 25m for that path, so the timeout has
   # to leave headroom for that bringup before the addon HR even starts
   # reconciling.
-  kubectl --namespace "${ns}" wait \
-    helmrelease "kubernetes-${cluster}-ouroboros" \
-    --timeout=25m --for=condition=ready
-
-  # Capture the tenant admin-kubeconfig so subsequent kubectls hit the
-  # tenant apiserver, not the host. Tmp file is removed on exit of this
-  # @test body — cozytest does not invoke teardown().
+  # Extract the tenant admin-kubeconfig early so the failure-path
+  # diagnostic block below can inspect tenant-cluster state. The
+  # kubeconfig secret is created by the parent kubernetes HR's Kamaji
+  # bringup, well before the ouroboros HR starts reconciling — by the
+  # time ouroboros HR can fail the secret is reliably present. The
+  # extra wait on the parent HR upper-bounds the case where the parent
+  # itself never becomes Ready (the secret never appears, the kubectl
+  # wait below would fail with a misleading "no resources found").
   kubeconfig=$(mktemp)
   trap "rm -f ${kubeconfig}" EXIT
+  kubectl --namespace "${ns}" wait \
+    helmrelease "kubernetes-${cluster}" \
+    --timeout=15m --for=condition=ready
   kubectl --namespace "${ns}" get secret \
     "kubernetes-${cluster}-admin-kubeconfig" \
     --output jsonpath='{.data.super-admin\.svc}' \
     | base64 --decode > "${kubeconfig}"
+
+  # Wait for the addon HR. On failure, dump tenant-side diagnostics
+  # before exiting — cozyreport stops at host scope and gives no
+  # visibility into the tenant control plane, so without this dump
+  # CI failures show up as opaque `wait: timed out` with no actionable
+  # signal about why the proxy Deployment never reaches Ready.
+  if ! kubectl --namespace "${ns}" wait \
+       helmrelease "kubernetes-${cluster}-ouroboros" \
+       --timeout=20m --for=condition=ready; then
+    echo "=== ouroboros HR did not reach Ready — tenant-side diagnostics ==="
+    echo "--- host: HelmRelease describe ---"
+    kubectl --namespace "${ns}" describe \
+      helmrelease "kubernetes-${cluster}-ouroboros" || true
+    echo "--- tenant: cozy-ouroboros pods (-o wide) ---"
+    KUBECONFIG="${kubeconfig}" kubectl --namespace cozy-ouroboros \
+      get pods --output wide || true
+    echo "--- tenant: cozy-ouroboros pod descriptions ---"
+    KUBECONFIG="${kubeconfig}" kubectl --namespace cozy-ouroboros \
+      describe pods || true
+    echo "--- tenant: cozy-ouroboros recent events ---"
+    KUBECONFIG="${kubeconfig}" kubectl --namespace cozy-ouroboros \
+      get events --sort-by=.lastTimestamp || true
+    echo "--- tenant: cozy-ouroboros controller logs ---"
+    KUBECONFIG="${kubeconfig}" kubectl --namespace cozy-ouroboros \
+      logs --selector=app.kubernetes.io/component=controller \
+      --tail=200 --prefix=true --all-containers || true
+    echo "--- tenant: cozy-ouroboros proxy logs ---"
+    KUBECONFIG="${kubeconfig}" kubectl --namespace cozy-ouroboros \
+      logs --selector=app.kubernetes.io/component=proxy \
+      --tail=200 --prefix=true --all-containers || true
+    echo "--- tenant: cozy-ingress-nginx pods/svc/endpoints ---"
+    KUBECONFIG="${kubeconfig}" kubectl --namespace cozy-ingress-nginx \
+      get pods,svc,endpoints --output wide || true
+    echo "--- tenant: kube-system coredns Corefile + custom ---"
+    KUBECONFIG="${kubeconfig}" kubectl --namespace kube-system \
+      get configmap coredns coredns-custom \
+      --output jsonpath='{range .items[*]}{.metadata.name}{"\n"}{.data}{"\n---\n"}{end}' || true
+    exit 1
+  fi
 
   # The cozystack coredns wrapper renders an empty coredns-custom
   # ConfigMap in kube-system (with the helm.sh/resource-policy: keep

--- a/hack/e2e-apps/ouroboros.bats
+++ b/hack/e2e-apps/ouroboros.bats
@@ -100,29 +100,16 @@ EOF
     pkill -f "port-forward.*service/kubernetes-${cluster}.*${pf_port}:" 2>/dev/null || true
     rm -f "${kubeconfig}"
   }
-  trap cleanup_kubeconfig EXIT
-  kubectl --namespace "${ns}" wait \
-    helmrelease "kubernetes-${cluster}" \
-    --timeout=15m --for=condition=ready
-  kubectl --namespace "${ns}" get secret \
-    "kubernetes-${cluster}-admin-kubeconfig" \
-    --output jsonpath='{.data.super-admin\.conf}' \
-    | base64 --decode > "${kubeconfig}"
-  yq -i ".clusters[0].cluster.server = \"https://localhost:${pf_port}\"" "${kubeconfig}"
-  pkill -f "port-forward.*service/kubernetes-${cluster}.*${pf_port}:" 2>/dev/null || true
-  kubectl --namespace "${ns}" port-forward \
-    "service/kubernetes-${cluster}" "${pf_port}":6443 > /dev/null 2>&1 &
-  timeout 30 sh -ec 'until curl -sk https://localhost:'"${pf_port}"' >/dev/null 2>&1; do sleep 1; done'
-
-  # Wait for the addon HR. On failure, dump tenant-side diagnostics
-  # before exiting — cozyreport stops at host scope and gives no
-  # visibility into the tenant control plane, so without this dump
-  # CI failures show up as opaque `wait: timed out` with no actionable
-  # signal about why the proxy Deployment never reaches Ready.
-  if ! kubectl --namespace "${ns}" wait \
-       helmrelease "kubernetes-${cluster}-ouroboros" \
-       --timeout=20m --for=condition=ready; then
-    echo "=== ouroboros HR did not reach Ready — tenant-side diagnostics ==="
+  # Tenant-side state dump used both on the HR-not-Ready failure path and
+  # on every later assertion (rewrite snippet missing, dnscheck pod
+  # not Succeeded, etc.). Without one centralised dump every assertion
+  # would either need its own copy of the diagnostic block, or fail
+  # opaquely under set -e the moment the assertion command returns
+  # non-zero. Wrap each assertion in `if ! ...; then dump_tenant_state;
+  # exit 1; fi` so cozytest captures actionable tenant-side state on
+  # the failure that triggered the exit, regardless of which one fired.
+  dump_tenant_state() {
+    echo "=== ouroboros tenant-side diagnostics ==="
     echo "--- host: HelmRelease describe ---"
     kubectl --namespace "${ns}" describe \
       helmrelease "kubernetes-${cluster}-ouroboros" || true
@@ -150,6 +137,33 @@ EOF
     KUBECONFIG="${kubeconfig}" kubectl --namespace kube-system \
       get configmap coredns coredns-custom \
       --output jsonpath='{range .items[*]}{.metadata.name}{"\n"}{.data}{"\n---\n"}{end}' || true
+    echo "--- tenant: default ns Ingresses ---"
+    KUBECONFIG="${kubeconfig}" kubectl --namespace default \
+      get ingress --output yaml || true
+  }
+  trap cleanup_kubeconfig EXIT
+  kubectl --namespace "${ns}" wait \
+    helmrelease "kubernetes-${cluster}" \
+    --timeout=15m --for=condition=ready
+  kubectl --namespace "${ns}" get secret \
+    "kubernetes-${cluster}-admin-kubeconfig" \
+    --output jsonpath='{.data.super-admin\.conf}' \
+    | base64 --decode > "${kubeconfig}"
+  yq -i ".clusters[0].cluster.server = \"https://localhost:${pf_port}\"" "${kubeconfig}"
+  pkill -f "port-forward.*service/kubernetes-${cluster}.*${pf_port}:" 2>/dev/null || true
+  kubectl --namespace "${ns}" port-forward \
+    "service/kubernetes-${cluster}" "${pf_port}":6443 > /dev/null 2>&1 &
+  timeout 30 sh -ec 'until curl -sk https://localhost:'"${pf_port}"' >/dev/null 2>&1; do sleep 1; done'
+
+  # Wait for the addon HR. On failure, dump tenant-side diagnostics
+  # before exiting — cozyreport stops at host scope and gives no
+  # visibility into the tenant control plane, so without this dump
+  # CI failures show up as opaque `wait: timed out` with no actionable
+  # signal about why the proxy Deployment never reaches Ready.
+  if ! kubectl --namespace "${ns}" wait \
+       helmrelease "kubernetes-${cluster}-ouroboros" \
+       --timeout=20m --for=condition=ready; then
+    dump_tenant_state
     exit 1
   fi
 
@@ -213,7 +227,11 @@ EOF
     fi
     sleep 5
   done
-  echo "${snippet}" | grep -q "rewrite name ${hairpin_host}"
+  if ! echo "${snippet}" | grep -q "rewrite name ${hairpin_host}"; then
+    echo "rewrite snippet for ${hairpin_host} not written to coredns-custom within deadline"
+    dump_tenant_state
+    exit 1
+  fi
 
   # Beyond "rewrite written to ConfigMap", verify CoreDNS actually
   # serves the rewrite — otherwise an `import` directive misconfig,
@@ -226,7 +244,11 @@ EOF
   # failures that the rewrite-line check cannot see.
   proxy_ip=$(KUBECONFIG="${kubeconfig}" kubectl --namespace cozy-ouroboros \
     get service ouroboros-proxy --output jsonpath='{.spec.clusterIP}' 2>/dev/null || true)
-  [ -n "${proxy_ip}" ]
+  if [ -z "${proxy_ip}" ]; then
+    echo "ouroboros-proxy Service has no ClusterIP"
+    dump_tenant_state
+    exit 1
+  fi
 
   KUBECONFIG="${kubeconfig}" kubectl --namespace default \
     delete pod dnscheck --ignore-not-found 2>/dev/null || true
@@ -261,7 +283,11 @@ EOF
     sleep 3
   done
   KUBECONFIG="${kubeconfig}" kubectl --namespace default logs dnscheck 2>&1 | sed 's/^/  dnscheck: /' || true
-  [ "${phase:-}" = "Succeeded" ]
+  if [ "${phase:-}" != "Succeeded" ]; then
+    echo "dnscheck pod did not reach Succeeded phase (last seen: ${phase:-<empty>})"
+    dump_tenant_state
+    exit 1
+  fi
 
   KUBECONFIG="${kubeconfig}" kubectl --namespace default \
     delete pod dnscheck --ignore-not-found 2>/dev/null || true

--- a/hack/e2e-apps/ouroboros.bats
+++ b/hack/e2e-apps/ouroboros.bats
@@ -83,16 +83,36 @@ EOF
   # time ouroboros HR can fail the secret is reliably present. The
   # extra wait on the parent HR upper-bounds the case where the parent
   # itself never becomes Ready (the secret never appears, the kubectl
-  # wait below would fail with a misleading "no resources found").
+  # below would fail with a misleading "no resources found").
+  #
+  # Use `super-admin.conf` (NOT `super-admin.svc`) and rewrite the
+  # server URL to `https://localhost:<port>` then start a kubectl
+  # port-forward to the tenant apiserver Service in the host namespace.
+  # The `super-admin.svc` variant points at the in-cluster Service DNS
+  # name `<release>.<ns>.svc:6443`, which the e2e sandbox container
+  # cannot resolve — its resolver is the Docker/QEMU host link-local
+  # 169.254.169.254, not host-cluster CoreDNS, so every tenant-side
+  # kubectl call returns `no such host`. The port-forward + localhost
+  # rewrite is the same pattern used by hack/e2e-apps/run-kubernetes.sh.
   kubeconfig=$(mktemp)
-  trap "rm -f ${kubeconfig}" EXIT
+  pf_port=59999
+  cleanup_kubeconfig() {
+    pkill -f "port-forward.*service/kubernetes-${cluster}.*${pf_port}:" 2>/dev/null || true
+    rm -f "${kubeconfig}"
+  }
+  trap cleanup_kubeconfig EXIT
   kubectl --namespace "${ns}" wait \
     helmrelease "kubernetes-${cluster}" \
     --timeout=15m --for=condition=ready
   kubectl --namespace "${ns}" get secret \
     "kubernetes-${cluster}-admin-kubeconfig" \
-    --output jsonpath='{.data.super-admin\.svc}' \
+    --output jsonpath='{.data.super-admin\.conf}' \
     | base64 --decode > "${kubeconfig}"
+  yq -i ".clusters[0].cluster.server = \"https://localhost:${pf_port}\"" "${kubeconfig}"
+  pkill -f "port-forward.*service/kubernetes-${cluster}.*${pf_port}:" 2>/dev/null || true
+  kubectl --namespace "${ns}" port-forward \
+    "service/kubernetes-${cluster}" "${pf_port}":6443 > /dev/null 2>&1 &
+  timeout 30 sh -ec 'until curl -sk https://localhost:'"${pf_port}"' >/dev/null 2>&1; do sleep 1; done'
 
   # Wait for the addon HR. On failure, dump tenant-side diagnostics
   # before exiting — cozyreport stops at host scope and gives no
@@ -249,5 +269,5 @@ EOF
     delete ingress hairpin-probe --ignore-not-found 2>/dev/null || true
   kubectl --namespace "${ns}" delete kuberneteses.apps.cozystack.io \
     "${cluster}" --ignore-not-found --wait=false 2>/dev/null || true
-  rm -f "${kubeconfig}"
+  cleanup_kubeconfig
 }

--- a/hack/e2e-apps/ouroboros.bats
+++ b/hack/e2e-apps/ouroboros.bats
@@ -48,7 +48,18 @@ spec:
       valuesOverride: {}
     ouroboros:
       enabled: true
-      valuesOverride: {}
+      # logLevel=debug surfaces per-event informer activity
+      # (AddFunc/UpdateFunc/DeleteFunc with kind+namespace/name) and
+      # reconcile pacing on this test tenant. Scoped to the bats fixture
+      # only — production tenants stay at the upstream chart default
+      # (info) per the cozystack "default for low-skill operator"
+      # stance. The verbose logs end up in dump_tenant_state when an
+      # assertion fails, which is exactly when extra observability is
+      # worth its cost.
+      valuesOverride:
+        ouroboros:
+          controller:
+            logLevel: debug
   controlPlane:
     apiServer:
       resources: {}
@@ -100,6 +111,52 @@ EOF
     pkill -f "port-forward.*service/kubernetes-${cluster}.*${pf_port}:" 2>/dev/null || true
     rm -f "${kubeconfig}"
   }
+  # Host-side state dump used on the parent-HR failure path, where the
+  # kubeconfig has not yet been extracted (so dump_tenant_state's
+  # KUBECONFIG-driven calls would all hit an empty/missing file). Tightly
+  # scoped to the resources a kamaji-bringup hang surfaces on:
+  # - the Kubernetes apps.cozystack.io CR (status conditions show what the
+  #   parent helm-controller is waiting on);
+  # - the parent kubernetes-${cluster} HelmRelease (its conditions show
+  #   the chart-render or apply state);
+  # - the Kamaji TenantControlPlane (TCP) — kamaji ships its own status
+  #   conditions when etcd, certs, or konnectivity fail to come up.
+  dump_host_state() {
+    echo "=== ouroboros host-side diagnostics (pre-kubeconfig) ==="
+    echo "--- host: Kubernetes apps.cozystack.io describe ---"
+    kubectl --namespace "${ns}" describe \
+      kuberneteses.apps.cozystack.io "${cluster}" || true
+    echo "--- host: parent HelmRelease describe ---"
+    kubectl --namespace "${ns}" describe \
+      helmrelease "kubernetes-${cluster}" || true
+    echo "--- host: Kamaji TenantControlPlane describe ---"
+    kubectl --namespace "${ns}" describe \
+      tenantcontrolplane.kamaji.clastix.io "kubernetes-${cluster}" || true
+    # Kamaji-managed apiserver pods live in the host ${ns} as a regular
+    # Deployment. cozyreport does NOT collect logs from this namespace by
+    # default (only cozy-* host namespaces), so without this dump there
+    # is no record of the actual kube-apiserver behaviour at the moment
+    # the bats poll loop was reading stale ConfigMap data. Pull pod-list
+    # for replica visibility, then per-pod logs of kube-apiserver +
+    # konnectivity-server (the two containers a kamaji apiserver pod
+    # ships) so a future watch-cache-lag investigation can correlate
+    # bats kubectl `get configmap` timestamps against apiserver
+    # request-handling on each replica.
+    echo "--- host: Kamaji apiserver pods (-o wide) ---"
+    kubectl --namespace "${ns}" get pods \
+      --selector "kamaji.clastix.io/name=kubernetes-${cluster}" \
+      --output wide || true
+    echo "--- host: kube-apiserver logs from each Kamaji replica (tail=400) ---"
+    kubectl --namespace "${ns}" logs \
+      --selector "kamaji.clastix.io/name=kubernetes-${cluster}" \
+      --container kube-apiserver \
+      --tail=400 --prefix=true --all-containers=false || true
+    echo "--- host: konnectivity-server logs from each Kamaji replica (tail=200) ---"
+    kubectl --namespace "${ns}" logs \
+      --selector "kamaji.clastix.io/name=kubernetes-${cluster}" \
+      --container konnectivity-server \
+      --tail=200 --prefix=true --all-containers=false || true
+  }
   # Tenant-side state dump used both on the HR-not-Ready failure path and
   # on every later assertion (rewrite snippet missing, dnscheck pod
   # not Succeeded, etc.). Without one centralised dump every assertion
@@ -108,7 +165,21 @@ EOF
   # non-zero. Wrap each assertion in `if ! ...; then dump_tenant_state;
   # exit 1; fi` so cozytest captures actionable tenant-side state on
   # the failure that triggered the exit, regardless of which one fired.
+  #
+  # Both dump_host_state and dump_tenant_state are intentionally local
+  # to this @test (not setup()-defined) — cozytest.sh does not invoke
+  # bats setup/teardown, and the helpers reference @test-local variables
+  # (cluster, ns, kubeconfig). If a second @test ever lands in this file,
+  # hoist the helpers and parametrise on those variables.
   dump_tenant_state() {
+    # Pull host-side state too (Kamaji apiserver pod logs in particular):
+    # the singular-GET-vs-LIST staleness gap and any candidate watch-cache
+    # /etcd-watch lag have to be diagnosed against the actual apiserver
+    # access log, not the tenant-side surface alone. Calling dump_host_state
+    # first keeps host context in front of tenant context in the captured
+    # output, which matches the request flow (host kubectl → kamaji
+    # apiserver → tenant cluster).
+    dump_host_state
     echo "=== ouroboros tenant-side diagnostics ==="
     echo "--- host: HelmRelease describe ---"
     kubectl --namespace "${ns}" describe \
@@ -142,9 +213,16 @@ EOF
       get ingress --output yaml || true
   }
   trap cleanup_kubeconfig EXIT
-  kubectl --namespace "${ns}" wait \
-    helmrelease "kubernetes-${cluster}" \
-    --timeout=15m --for=condition=ready
+  # Wrap parent kubernetes-HR wait in dump_host_state so a Kamaji bringup
+  # wedge does not surface as opaque `wait: timed out`. Tenant-side
+  # diagnostics are unavailable here (no kubeconfig yet); the host-side
+  # dump covers parent HR conditions, the Kubernetes CR, and the TCP.
+  if ! kubectl --namespace "${ns}" wait \
+       helmrelease "kubernetes-${cluster}" \
+       --timeout=25m --for=condition=ready; then
+    dump_host_state
+    exit 1
+  fi
   kubectl --namespace "${ns}" get secret \
     "kubernetes-${cluster}-admin-kubeconfig" \
     --output jsonpath='{.data.super-admin\.conf}' \
@@ -210,18 +288,27 @@ spec:
                   number: 80
 EOF
 
-  deadline=$(( $(date +%s) + 180 ))
+  deadline=$(( $(date +%s) + 900 ))
   snippet=
   while [ "$(date +%s)" -lt "${deadline}" ]; do
-    # jsonpath bracket notation tolerates dotted keys AND missing
-    # `.data` (returns empty stdout, exit 0). The earlier go-template
-    # form `{{ index .data "ouroboros.override" }}` writes a multi-KB
-    # "Error executing template ... index of untyped nil" diagnostic
-    # to STDOUT (not stderr) when `.data` is missing, poisoning the
-    # grep below.
+    # Dump the whole `.data` map and grep the rewrite line out of it,
+    # rather than extracting a single key via jsonpath bracket-notation
+    # (`{.data['ouroboros.override']}`). The bracket-notation form is a
+    # silent-empty kubectl jsonpath trap for ConfigMap keys with a dot
+    # in them: the parser reads the bracket as an array index, single-
+    # quoted "ouroboros.override" is not a valid numeric index, and
+    # rather than erroring the result is `""`. Confirmed locally on
+    # kind v1.35.0 against a ConfigMap whose only data key is
+    # `ouroboros.override` — `-o yaml` shows the value, `-o jsonpath=
+    # {.data}` returns the whole map, but `-o jsonpath={.data
+    # ['ouroboros.override']}` returns an empty string with exit 0.
+    # The `{range .items[*]}…{.data}` shape avoids the trap because it
+    # emits the full map, which still contains the rewrite line that
+    # grep matches.
     snippet=$(KUBECONFIG="${kubeconfig}" kubectl --namespace kube-system \
-      get configmap coredns-custom \
-      --output "jsonpath={.data['ouroboros.override']}" 2>/dev/null || true)
+      get configmap coredns coredns-custom \
+      --output 'jsonpath={range .items[*]}{.metadata.name}{"\n"}{.data}{"\n---\n"}{end}' \
+      2>/dev/null || true)
     if echo "${snippet}" | grep -q "rewrite name ${hairpin_host}"; then
       break
     fi

--- a/packages/apps/kubernetes/templates/helmreleases/ouroboros.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/ouroboros.yaml
@@ -19,29 +19,29 @@ ouroboros:
     mode: coredns-import
     gatewayApi:
       enabled: {{ $.Values.addons.gatewayAPI.enabled }}
-    {{- /* Cluster-domain is intentionally NOT pre-set by the wrapper.
-           The ouroboros chart 0.7.0 is platform-agnostic by default:
-           when controller.clusterDomain is empty (chart default,
-           which we leave alone), the chart emits --proxy-service-name
-           + --proxy-service-namespace and the controller composes
-           --proxy-fqdn at startup from the cluster-domain auto-detected
-           inside the pod via /etc/resolv.conf. Whatever the tenant
-           CoreDNS actually serves — cluster.local (kubeadm default,
-           which is what cozystack tenants bootstrap with), cozy.local
-           (federations), k8s.example.com (custom) — flows through
-           transparently with no wrapper logic.
+    {{- /* Pin clusterDomain to cluster.local. cozystack tenants bootstrap
+           a Kamaji-managed control plane whose `networkProfile.clusterDomain`
+           is `cluster.local` — that is the domain tenant CoreDNS actually
+           serves. The ouroboros proxy's BackendHost is composed at startup
+           from `<svc>.<ns>.svc.<clusterDomain>` and dialed by /readyz; if
+           it does not match what tenant CoreDNS serves, /readyz returns
+           503 NXDOMAIN forever and the proxy Deployment never reaches
+           Ready, blocking helm install on the tenant.
 
-           Pre-setting controller.clusterDomain here would be wrong:
-           the wrapper does not know the tenant's cluster-domain (it's
-           a tenant-side fact, not a host-side one), and any host-side
-           fact like _cluster.cluster-domain reflects the host platform
-           convention rather than the tenant's actual kubelet
-           --cluster-domain — passing it would either be a no-op (when
-           it happens to match) or a NXDOMAIN footgun (when it
-           doesn't). Operators that DO know their tenant's
-           cluster-domain and want to bake it explicitly can still
+           Cannot rely on the chart's per-pod `/etc/resolv.conf` auto-detect
+           here: cozystack tenant kubelet injects the host platform's
+           cluster-domain (`cozy.local`) into the pod search list, not
+           cluster.local. The mismatch between kubelet-injected search and
+           Kamaji TCP CoreDNS config is a separate cozystack tenant
+           bootstrap concern; until that is fixed independently, pinning
+           the chart input here keeps ouroboros operational for the
+           default cozystack tenant topology.
+
+           Operators on a non-cluster.local tenant CoreDNS (rare —
+           federations, custom kubelet --cluster-domain, etc.) can
            override via
            `addons.ouroboros.valuesOverride.ouroboros.controller.clusterDomain`. */}}
+    clusterDomain: cluster.local
 {{- end }}
 
 {{- /* addons.ouroboros.enabled requires addons.ingressNginx.enabled. The

--- a/packages/apps/kubernetes/templates/helmreleases/ouroboros.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/ouroboros.yaml
@@ -84,7 +84,7 @@ ouroboros:
        reconciles the parent kubernetes-application chart, sees the
        child HelmRelease has disappeared from the rendered output,
        and runs `helm uninstall` on the tenant. The vendored
-       cozy-ouroboros chart (0.7.0) ships a pre-delete Helm hook
+       cozy-ouroboros chart ships a pre-delete Helm hook
        (charts/ouroboros/templates/coredns-cleanup-hook.yaml) that
        nulls the ouroboros.override data key on the tenant's
        kube-system/coredns-custom ConfigMap before the controller

--- a/packages/apps/kubernetes/tests/ouroboros_test.yaml
+++ b/packages/apps/kubernetes/tests/ouroboros_test.yaml
@@ -32,7 +32,7 @@ tests:
       - hasDocuments:
           count: 1
 
-  - it: does NOT pre-set ouroboros.controller.clusterDomain — chart 0.7.0 is platform-agnostic by default, emits --proxy-service-name + --proxy-service-namespace and the controller composes the FQDN at runtime from the cluster-domain auto-detected via /etc/resolv.conf inside the pod (passing _cluster.cluster-domain would inject the host's domain, not the tenant's)
+  - it: pins ouroboros.controller.clusterDomain to cluster.local — Kamaji-managed tenant CoreDNS serves cluster.local (per TenantControlPlane.networkProfile), but cozystack tenant kubelet injects the host platform domain (cozy.local) into pod resolv.conf, which makes the chart's auto-detect path return the wrong value and the proxy /readyz NXDOMAIN forever
     set:
       addons:
         ouroboros:
@@ -43,8 +43,9 @@ tests:
           hosts: []
           valuesOverride: {}
     asserts:
-      - notExists:
+      - equal:
           path: spec.values.ouroboros.controller.clusterDomain
+          value: cluster.local
       - isKind:
           of: HelmRelease
 

--- a/packages/apps/kubernetes/tests/ouroboros_test.yaml
+++ b/packages/apps/kubernetes/tests/ouroboros_test.yaml
@@ -49,6 +49,24 @@ tests:
       - isKind:
           of: HelmRelease
 
+  - it: lets a tenant-supplied valuesOverride opt into controller.logLevel=debug (escape hatch — operators chasing an in-tenant ouroboros issue can flip to debug without forking the chart; default stays at upstream info)
+    set:
+      addons:
+        ouroboros:
+          enabled: true
+          valuesOverride:
+            ouroboros:
+              controller:
+                logLevel: debug
+        ingressNginx:
+          enabled: true
+          hosts: []
+          valuesOverride: {}
+    asserts:
+      - equal:
+          path: spec.values.ouroboros.controller.logLevel
+          value: debug
+
   - it: lets a tenant-supplied valuesOverride set controller.clusterDomain explicitly (escape hatch for non-default tenant cluster-domain)
     set:
       addons:

--- a/packages/system/ouroboros/Makefile
+++ b/packages/system/ouroboros/Makefile
@@ -10,7 +10,7 @@ include ../../../hack/package.mk
 # manifest at ghcr.io/lexfrei/charts/ouroboros — it pins the contents
 # of the helm chart artefact (templates, values.yaml, Chart.yaml).
 # It is NOT the digest of the controller container image. The image
-# digest lives in values.yaml under image.tag (`image.tag: "0.7.0@sha256:..."`)
+# digest lives in values.yaml under image.tag (`image.tag: "<version>@sha256:..."`)
 # and pins ghcr.io/lexfrei/ouroboros (the runtime binary). Both
 # digests have to land together at every chart bump — the chart
 # version, the chart-manifest digest, and the controller-image
@@ -26,8 +26,8 @@ include ../../../hack/package.mk
 # and update both lines below; resolve the new image digest with
 #   crane digest ghcr.io/lexfrei/ouroboros:<new-tag>
 # and update values.yaml.
-OUROBOROS_CHART_VERSION ?= 0.7.0
-OUROBOROS_CHART_DIGEST ?= sha256:f28bfac9fd7070b1f3357983ff5aad28c16115e7de1cfc16ee568a3b4cfc9d7e
+OUROBOROS_CHART_VERSION ?= 0.7.2
+OUROBOROS_CHART_DIGEST ?= sha256:c67315551196a766aeb97cee6065083a5f4d78b67ab0377e25257e61d4615a43
 
 test:
 	helm unittest .

--- a/packages/system/ouroboros/charts/ouroboros/Chart.yaml
+++ b/packages/system/ouroboros/charts/ouroboros/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   artifacthub.io/category: networking
   artifacthub.io/license: BSD-3-Clause
 apiVersion: v2
-appVersion: 0.7.0
+appVersion: 0.7.2
 description: In-cluster controller + TCP proxy that fixes hairpin-NAT for Ingress
   controllers behind PROXY-protocol
 home: https://github.com/lexfrei/ouroboros
@@ -22,4 +22,4 @@ name: ouroboros
 sources:
 - https://github.com/lexfrei/ouroboros
 type: application
-version: 0.7.0
+version: 0.7.2

--- a/packages/system/ouroboros/charts/ouroboros/templates/controller-deployment.yaml
+++ b/packages/system/ouroboros/charts/ouroboros/templates/controller-deployment.yaml
@@ -52,6 +52,7 @@ spec:
             - controller
             - --mode={{ $mode }}
             - --resync={{ .Values.controller.resync }}
+            - --log-level={{ .Values.controller.logLevel }}
             {{- if .Values.controller.gatewayApi.enabled }}
             - --gateway-api
             {{- end }}

--- a/packages/system/ouroboros/charts/ouroboros/templates/etchosts-daemonset.yaml
+++ b/packages/system/ouroboros/charts/ouroboros/templates/etchosts-daemonset.yaml
@@ -32,6 +32,7 @@ spec:
             - --mode=etc-hosts
             - --etc-hosts=/host/hosts
             - --proxy-ip={{ required "etcHosts.proxyIP is required when etcHosts.enabled=true. Install once with etcHosts.enabled=false, look up the proxy Service ClusterIP, then upgrade with --set etcHosts.proxyIP=<that-IP>." .Values.etcHosts.proxyIP }}
+            - --log-level={{ .Values.controller.logLevel }}
             {{- if .Values.controller.gatewayApi.enabled }}
             - --gateway-api
             {{- end }}

--- a/packages/system/ouroboros/charts/ouroboros/values.yaml
+++ b/packages/system/ouroboros/charts/ouroboros/values.yaml
@@ -109,8 +109,19 @@ controller:
     # renovate: datasource=docker depName=alpine/kubectl
     tag: "1.36.0"
     pullPolicy: IfNotPresent
-  # -- Informer resync period.
-  resync: 10m
+  # -- Informer resync period. Doubles as the worst-case event-to-reconcile
+  # latency when the underlying Ingress watch silently dies (kamaji-managed
+  # tenant kube-apiservers reached through konnectivity are one reproducer
+  # where the initial watch returns 200 OK but no events flow afterwards).
+  # Keep in lock-step with controller.DefaultResyncPeriod in Go.
+  resync: 30s
+  # -- Slog handler verbosity for the controller binary: debug, info, warn,
+  # error. Validated at startup (typos fail fast rather than silently
+  # downgrade). Set to debug to surface per-event informer activity
+  # (AddFunc/UpdateFunc/DeleteFunc) and reconcile pacing — useful when an
+  # Ingress-event-to-rewrite latency looks suspicious (kamaji tenant via
+  # konnectivity is the canonical reproducer).
+  logLevel: info
 
 # -- Proxy deployment (TCP relay that injects PROXY-protocol v1 header).
 proxy:

--- a/packages/system/ouroboros/tests/controller_test.yaml
+++ b/packages/system/ouroboros/tests/controller_test.yaml
@@ -33,6 +33,20 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --gateway-api
 
+  - it: emits chart-default --resync=30s — host scenario inherits the upstream chart default (changed from 10m in upstream v0.7.x). The reduction is the controller's only recovery path when an Ingress watch silently dies, and 30s caps worst-case event-to-reconcile latency under broken-watch conditions. Pinning here catches a future upstream bump back to the longer value before it lands as a CI surprise.
+    template: charts/ouroboros/templates/controller-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --resync=30s
+
+  - it: emits chart-default --log-level=info — host scenario stays at info verbosity by upstream chart default. Tenants override to debug via apps/kubernetes wrapper (see cozystack.defaultOuroborosValues). Pinning here keeps the host quiet by default and catches a regression where the host wrapper accidentally inherits the tenant debug value.
+    template: charts/ouroboros/templates/controller-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --log-level=info
+
   - it: writes into the kube-system/coredns Corefile by default (host mode)
     template: charts/ouroboros/templates/controller-deployment.yaml
     asserts:

--- a/packages/system/ouroboros/tests/cozystack_overrides_test.yaml
+++ b/packages/system/ouroboros/tests/cozystack_overrides_test.yaml
@@ -40,4 +40,4 @@ tests:
       # a Makefile bump that forgets to bump the tag (or vice versa).
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/lexfrei/ouroboros:0.7.0@sha256:478665e05dd0ffc4c1f7764320ea24b52251781884ddfd668d93a03e39d9094c
+          value: ghcr.io/lexfrei/ouroboros:0.7.2@sha256:1a8479b42ed34640752df2bfe0e9ccf052448c6849826c24cab4c30e10d76393

--- a/packages/system/ouroboros/values.yaml
+++ b/packages/system/ouroboros/values.yaml
@@ -6,7 +6,7 @@ ouroboros:
     # Air-gapped operators must mirror both this image and the OCI chart
     # at oci://ghcr.io/lexfrei/charts/ouroboros separately. Bump the tag
     # here together with OUROBOROS_CHART_VERSION in the Makefile.
-    tag: 0.7.0@sha256:478665e05dd0ffc4c1f7764320ea24b52251781884ddfd668d93a03e39d9094c
+    tag: 0.7.2@sha256:1a8479b42ed34640752df2bfe0e9ccf052448c6849826c24cab4c30e10d76393
   controller:
     # Host scenario default: mutate the live kube-system/coredns Corefile
     # directly. The host CoreDNS on cozystack is Talos-managed and its


### PR DESCRIPTION
## What this PR does

Bumps the vendored cozy-ouroboros chart to v0.7.2 and lands the ouroboros e2e bats hardening that finally drives the addon test green on the cozystack tenant runner.

The v0.7.2 release of lexfrei/ouroboros adds a `--log-level` flag, plants Debug logs at every informer event handler (`AddFunc`/`UpdateFunc`/`DeleteFunc` with kind+namespace/name) and at reconcile entry/exit, wires `SetWatchErrorHandler` on Ingress/Gateway/HTTPRoute informers, and surfaces cache-sync elapsed at Info. The cozystack-side default is `info` (upstream chart default); a tenant operator who needs debug verbosity can opt in via `addons.ouroboros.valuesOverride.ouroboros.controller.logLevel: debug`.

## Root cause of the test flake

The ouroboros bats was failing on `kubectl --namespace kube-system get configmap coredns-custom --output "jsonpath={.data['ouroboros.override']}"`. The jsonpath bracket-notation `[ 'key' ]` for a ConfigMap data key that contains a literal dot (`ouroboros.override`) is a silent-empty kubectl trap: the parser treats the bracket as an array index, the single-quoted string is not a valid numeric index, and rather than erroring the result is `""`. The original comment in the bats source claimed the bracket form "tolerates dotted keys" — "tolerates" turned out to mean "does not crash, returns empty without error", not "extracts the value".

Reproduced standalone on kind v1.35.0 against a ConfigMap whose only data key is literally `ouroboros.override`:

```
$ kubectl -n default get configmap test --output 'jsonpath={.data}'
{"ouroboros.override":"rewrite name foo bar."}

$ kubectl -n default get configmap test --output "jsonpath={.data['ouroboros.override']}"
                       # ← empty string, exit 0

$ kubectl -n default get configmap test --output 'jsonpath={.data["ouroboros.override"]}'
error: error parsing jsonpath {.data["ouroboros.override"]}, invalid array index "ouroboros.override"
```

The fix is to dump the whole `.data` map (`jsonpath={range .items[*]}…{.data}`) and let `grep -q "rewrite name <host>"` find the entry. This is the same shape that `dump_tenant_state` had been using successfully all along — the failure dumps consistently showed the up-to-date ConfigMap while the bats poll was reporting empty.

This is a known kubectl jsonpath limitation, not a kamaji / kube-apiserver issue. Two earlier diagnostic runs (replicas=1, replicas=2 with apiserver logs piped into `dump_host_state`) were chasing the wrong hypothesis; the kubectl test reproduces in any cluster.

## Changes

- `packages/system/ouroboros/`: vendored chart bumped 0.7.0 → 0.7.2; controller image digest + chart manifest digest updated in lockstep; helm-unittest assertions updated for new image pin and chart-default `--resync=30s` / `--log-level=info`.
- `packages/apps/kubernetes/templates/helmreleases/ouroboros.yaml`: `cozystack.defaultOuroborosValues` pins `controller.clusterDomain: cluster.local` (auto-detect path returns `cozy.local` on cozystack tenants and the proxy `/readyz` NXDOMAINs forever).
- `packages/apps/kubernetes/tests/ouroboros_test.yaml`: new fixtures pin the clusterDomain default and the tenant escape-hatch override paths (clusterDomain override, logLevel opt-in-to-debug).
- `hack/e2e-apps/ouroboros.bats`: poll switched off jsonpath bracket-notation (silent-empty trap) onto a whole-`.data`-map dump, `dump_host_state` helper added with Kamaji apiserver + konnectivity-server logs, `dump_tenant_state` now calls `dump_host_state` first, and the rewrite-poll deadline raised 180s → 900s.
- `.github/workflows/pull-requests.yaml`: E2E job timeout 120m → 180m to cover the long tail (full-matrix e2e on this branch ran 2h05m).

## Companion docs

cozystack/website#534 (draft) updates `content/en/docs/next/networking/hairpin-proxy-protocol.md` to reflect the new `clusterDomain` pin and drops stale 0.7.0 / digest hardcodes from the air-gapped operators section.

## Release note

```release-note
NONE
```
